### PR TITLE
fix(elastic): make the driver reachable, and stop losing keys it created

### DIFF
--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/openbao/openbao/sdk/v2/physical/inmem"
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/credential/types"
 	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stretchr/testify/assert"
@@ -2709,4 +2710,90 @@ func TestCredentialConfigStore_RotationScheduleFollowsUpdates(t *testing.T) {
 		require.NoError(t, store.UpdateSpec(ctx, spec))
 		assert.Nil(t, specEntry(), "a spec with no rotation period must not stay enrolled")
 	})
+}
+
+// TestCredentialConfigStore_ValidateSpec_UpstreamMintingSources covers the
+// sources that create their credential at the upstream rather than holding one:
+// elastic, grafana and honeycomb. Their factories infer the api_key credential
+// type, and nothing else accepts their source type, so a gap in that type's
+// source allowlist made every spec written against them impossible to create —
+// the documented flow for all three failed at write time with no other route to
+// reach the driver.
+//
+// The driver registry is left nil so the create-time test mint is skipped: what
+// is under test is the validation chain, which needs no cluster.
+func TestCredentialConfigStore_ValidateSpec_UpstreamMintingSources(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+
+	store.core.credentialTypeRegistry = credential.NewTypeRegistry()
+	require.NoError(t, types.RegisterBuiltinTypes(store.core.credentialTypeRegistry))
+	store.core.credentialDriverRegistry = nil
+
+	for _, sourceType := range []string{
+		credential.SourceTypeElastic,
+		credential.SourceTypeGrafana,
+		credential.SourceTypeHoneycomb,
+	} {
+		t.Run(sourceType, func(t *testing.T) {
+			source := &credential.CredSource{Name: sourceType + "-src", Type: sourceType}
+			require.NoError(t, store.CreateSource(ctx, source))
+
+			spec := &credential.CredSpec{
+				Name:   sourceType + "-spec",
+				Type:   credential.TypeAPIKey,
+				Source: source.Name,
+				MinTTL: 5 * time.Minute,
+				MaxTTL: 1 * time.Hour,
+				Config: map[string]string{},
+			}
+			require.NoError(t, store.CreateSpec(ctx, spec),
+				"a spec against a %s source must be creatable", sourceType)
+		})
+	}
+}
+
+// An elastic spec naming the key to create must be accepted. key_name is also a
+// credential field on an apikey source, and the adjunct check rejects credential
+// fields on a source that cannot carry them — so without an exemption this
+// documented mint parameter is refused, and the error tells the operator to
+// switch to an apikey source, which would not mint anything at all.
+func TestCredentialConfigStore_ValidateSpec_ElasticKeyNameIsAMintParameter(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+
+	store.core.credentialTypeRegistry = credential.NewTypeRegistry()
+	require.NoError(t, types.RegisterBuiltinTypes(store.core.credentialTypeRegistry))
+	store.core.credentialDriverRegistry = nil
+
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "es-src", Type: credential.SourceTypeElastic,
+	}))
+
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name:   "es-scoped",
+		Type:   credential.TypeAPIKey,
+		Source: "es-src",
+		MinTTL: 5 * time.Minute,
+		MaxTTL: 1 * time.Hour,
+		Config: map[string]string{
+			"key_name":         "ingest-writer",
+			"expiration":       "24h",
+			"role_descriptors": `{"reader":{"indices":[{"names":["logs-*"],"privileges":["read"]}]}}`,
+		},
+	}))
+
+	// The same key on an apikey source is a credential field, and is still held
+	// to the declaration rule.
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "ak-src", Type: credential.SourceTypeAPIKey,
+	}))
+	err := store.CreateSpec(ctx, &credential.CredSpec{
+		Name:   "ak-spec",
+		Type:   credential.TypeAPIKey,
+		Source: "ak-src",
+		MinTTL: 5 * time.Minute,
+		MaxTTL: 1 * time.Hour,
+		Config: map[string]string{"api_key": "sk-test", "key_name": "prod"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential_fields")
 }

--- a/credential/carriage.go
+++ b/credential/carriage.go
@@ -61,12 +61,38 @@ func UncarriedAdjunctFields(credType interface{}, specConfig, sourceConfig map[s
 		}
 	}
 
+	mintParams := mintParameterFields[sourceType]
+
 	for _, field := range carrier.KnownAdjunctFields() {
-		if specConfig[field] != "" && !declared[field] {
-			fields = append(fields, field)
+		if specConfig[field] == "" || declared[field] {
+			continue
 		}
+		// The same name means different things to different sources, so whether it
+		// describes the credential is not a property of the name alone. Skipping
+		// here rather than trimming the type's list keeps the helpful error for
+		// every source that does treat it as a credential field.
+		if _, isMintParam := mintParams[field]; isMintParam {
+			continue
+		}
+		fields = append(fields, field)
 	}
 	return fields, carriable
+}
+
+// mintParameterFields names, per source type, the spec-config keys that a
+// credential type lists as adjuncts but that this source spends on the mint
+// instead — so they are neither carried nor missing, and rejecting a spec for
+// setting one would refuse a documented parameter.
+//
+// It is deliberately keyed on the source type rather than added to
+// reservedSpecConfigKeys, because these names are not globally reserved. An
+// apikey spec's key_name really is a credential field: an operator names it in
+// credential_fields and a provider reads it. An elastic spec's key_name is the
+// name the cluster will give the key it creates, and never reaches the
+// credential at all. Reserving it globally would delete the check for the source
+// that needs it.
+var mintParameterFields = map[string]map[string]struct{}{
+	SourceTypeElastic: {"key_name": {}},
 }
 
 // reservedSpecConfigKeys are spec-config keys that address the mint itself —

--- a/credential/carriage_test.go
+++ b/credential/carriage_test.go
@@ -290,6 +290,32 @@ func TestUncarriedAdjunctFields(t *testing.T) {
 	assert.True(t, carriable)
 }
 
+// key_name is a credential field on an apikey source and the name of the key an
+// elastic source is about to create. Reporting the elastic one as uncarried
+// refuses a documented mint parameter, and tells the operator to move to an
+// apikey source to fix it.
+func TestUncarriedAdjunctFields_MintParametersAreNotCredentialFields(t *testing.T) {
+	carrier := stubAdjunctCarrier{fields: []string{"key_name", "organization_id"}}
+
+	fields, _ := UncarriedAdjunctFields(carrier,
+		map[string]string{"key_name": "ingest-writer"},
+		map[string]string{}, SourceTypeElastic)
+	assert.Empty(t, fields, "key_name is what the elastic driver names the key it creates")
+
+	// The exemption is scoped to the source that spends it on the mint, and to
+	// that name alone.
+	fields, _ = UncarriedAdjunctFields(carrier,
+		map[string]string{"key_name": "prod", "organization_id": "org"},
+		map[string]string{}, SourceTypeElastic)
+	assert.Equal(t, []string{"organization_id"}, fields)
+
+	fields, _ = UncarriedAdjunctFields(carrier,
+		map[string]string{"key_name": "prod"},
+		map[string]string{}, SourceTypeAPIKey)
+	assert.Equal(t, []string{"key_name"}, fields,
+		"on an apikey source key_name really is a credential field")
+}
+
 type stubAdjunctCarrier struct{ fields []string }
 
 func (s stubAdjunctCarrier) KnownAdjunctFields() []string { return s.fields }

--- a/credential/drivers/elastic_driver.go
+++ b/credential/drivers/elastic_driver.go
@@ -25,6 +25,12 @@ const DefaultElasticActivationDelay = 10 * time.Second
 // elasticMaxResponseBodySize limits response body reads to prevent OOM
 const elasticMaxResponseBodySize = 1 << 20 // 1MB
 
+// elasticSweepPageSize bounds the orphan sweep's result set. The sweep runs
+// against one cluster principal's rotation keys, where a handful is already a
+// symptom; the cap is here so a pathological cluster cannot answer with more
+// than elasticMaxResponseBodySize and turn the read itself into the failure.
+const elasticSweepPageSize = 100
+
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*ElasticDriver)(nil)
 var _ credential.Rotatable = (*ElasticDriver)(nil)
@@ -44,13 +50,40 @@ type ElasticDriver struct {
 	// HTTP client for Elasticsearch API calls
 	httpClient *http.Client
 
-	// authMu protects sourceAPIKeyID and credSource.Config writes during rotation.
-	authMu sync.Mutex
+	// configMu guards every read of credSource.Config as well as the discovered
+	// fields below, because rotation replaces the whole config map while requests
+	// are in flight on this shared driver.
+	//
+	// Methods holding it must call the ...With variants, which take the snapshot
+	// as an argument: the lock is not reentrant, and both rotation stages issue
+	// HTTP requests while holding it.
+	configMu sync.RWMutex
 
-	// sourceAPIKeyID is the ID portion of the source API key (decoded from base64).
-	// Used for cleanup during rotation.
-	// Protected by authMu.
+	// sourceAPIKeyID is the ID portion of the source API key, and sourceUsername
+	// the cluster principal that key authenticates as. The id is what rotation
+	// cleans up; the username is what bounds the orphan sweep. Both are
+	// discovered at Create and refreshed on commit.
+	// Protected by configMu.
 	sourceAPIKeyID string
+	sourceUsername string
+}
+
+// elasticAuth is the credential one request authenticates with, snapshotted out
+// of the config so a request in flight is unaffected by a rotation committing
+// underneath it.
+type elasticAuth struct {
+	baseURL string
+	encoded string
+}
+
+// elasticIdentity is what the cluster says about the key it just authenticated.
+type elasticIdentity struct {
+	Username string `json:"username"`
+	Enabled  bool   `json:"enabled"`
+	APIKey   struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"api_key"`
 }
 
 // ElasticDriverFactory creates ElasticDriver instances
@@ -71,8 +104,15 @@ func (f *ElasticDriverFactory) ValidateConfig(config map[string]string) error {
 				if !strings.HasPrefix(v, "https://") && !(strings.HasPrefix(v, "http://") && skipTLS) {
 					return fmt.Errorf("elastic_url must use https scheme, got: %s", v)
 				}
-				if _, err := url.Parse(v); err != nil {
+				parsed, err := url.Parse(v)
+				if err != nil {
 					return fmt.Errorf("elastic_url is not a valid URL: %w", err)
+				}
+				// Past the scheme prefix, Parse accepts almost anything — "https://"
+				// alone parses cleanly — so without this the validator passes a value
+				// every request will then fail on.
+				if parsed.Host == "" {
+					return fmt.Errorf("elastic_url must include a host, got: %s", v)
 				}
 				return nil
 			}).
@@ -139,24 +179,47 @@ func (f *ElasticDriverFactory) Create(config map[string]string, log *logger.Gate
 	}
 	driver.httpClient = httpClient
 
+	encoded := credential.GetString(config, "api_key", "")
+
 	// Extract API key ID from pre-encoded value if not explicitly provided
+	decodedID, decodeErr := decodeElasticAPIKeyID(encoded)
 	apiKeyID := credential.GetString(config, "api_key_id", "")
 	if apiKeyID == "" {
-		var err error
-		apiKeyID, err = decodeElasticAPIKeyID(credential.GetString(config, "api_key", ""))
-		if err != nil {
-			return nil, fmt.Errorf("failed to extract API key ID from encoded api_key: %w", err)
+		if decodeErr != nil {
+			return nil, fmt.Errorf("failed to extract API key ID from encoded api_key: %w", decodeErr)
 		}
+		apiKeyID = decodedID
+	} else if decodeErr == nil && apiKeyID != decodedID {
+		// An id set by hand wins over the decoded one, and nothing downstream
+		// re-derives it — so a typo here is spent on rotation cleanup, which
+		// invalidates whatever key that id names. Catch the disagreement while
+		// both values are still in hand.
+		return nil, fmt.Errorf("api_key_id %q does not match the id encoded in api_key (%q); omit api_key_id to use the encoded one",
+			truncateID(apiKeyID, 8), truncateID(decodedID, 8))
 	}
-	driver.sourceAPIKeyID = apiKeyID
 
 	// Verify source credentials
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if err := driver.verifyAuthentication(ctx); err != nil {
+	// Snapshotting without the lock is safe here and only here: nothing else can
+	// reach this driver until Create returns it.
+	identity, err := driver.verifyAuthenticationWith(ctx, driver.authSnapshotLocked())
+	if err != nil {
 		return nil, fmt.Errorf("Elasticsearch authentication failed: %w", err)
 	}
+
+	// The cluster is the authority on which key just authenticated. Checking the
+	// configured id against it catches the case the decode cannot: an api_key_id
+	// that agrees with a stale api_key, both of them naming a key this source no
+	// longer authenticates as.
+	if identity.APIKey.ID != "" && apiKeyID != identity.APIKey.ID {
+		return nil, fmt.Errorf("configured api_key_id %q is not the key the cluster authenticated (%q)",
+			truncateID(apiKeyID, 8), truncateID(identity.APIKey.ID, 8))
+	}
+
+	driver.sourceAPIKeyID = apiKeyID
+	driver.sourceUsername = identity.Username
 
 	return driver, nil
 }
@@ -172,9 +235,12 @@ func (f *ElasticDriverFactory) Create(config map[string]string, log *logger.Gate
 //   - role_descriptors: JSON string of role descriptors (optional)
 //   - expiration: Key expiration duration, e.g. "30d" (optional)
 func (d *ElasticDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	d.configMu.RLock()
+	auth := d.authSnapshotLocked()
 	prefix := credential.GetString(d.credSource.Config, "key_name_prefix", "warden")
+	d.configMu.RUnlock()
+
 	keyName := credential.GetString(spec.Config, "key_name", fmt.Sprintf("%s-%s-%d", prefix, spec.Name, time.Now().Unix()))
-	expiration := credential.GetString(spec.Config, "expiration", "1h")
 
 	reqBody := map[string]interface{}{
 		"name": keyName,
@@ -193,16 +259,24 @@ func (d *ElasticDriver) MintCredential(ctx context.Context, spec *credential.Cre
 		reqBody["role_descriptors"] = roleDescriptors
 	}
 
-	if expiration != "" {
-		reqBody["expiration"] = expiration
+	// A key created without an expiration never expires, so an empty value is
+	// refused rather than passed through as absent. Spec validation rejects it at
+	// write time; this holds for a spec that predates that check.
+	expiration, present := spec.Config["expiration"]
+	if present && expiration == "" {
+		return nil, nil, 0, "", fmt.Errorf("spec sets an empty expiration; omit it to take the 1h default, or give a lifetime such as 24h")
 	}
+	if !present {
+		expiration = "1h"
+	}
+	reqBody["expiration"] = expiration
 
 	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("failed to marshal create API key request: %w", err)
 	}
 
-	respBody, _, err := d.doElasticRequest(ctx, http.MethodPost, "/_security/api_key", body)
+	respBody, _, err := d.doElasticRequestWith(ctx, auth, http.MethodPost, "/_security/api_key", body, defaultElasticRetryConfig())
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("failed to create Elasticsearch API key: %w", err)
 	}
@@ -226,6 +300,11 @@ func (d *ElasticDriver) MintCredential(ctx context.Context, spec *credential.Cre
 		"api_key": createResp.Encoded,
 	}
 
+	metadata := map[string]interface{}{
+		"key_id":   createResp.ID,
+		"key_name": createResp.Name,
+	}
+
 	// Compute TTL from expiration timestamp
 	var ttl time.Duration
 	if createResp.Expiration != nil {
@@ -246,7 +325,7 @@ func (d *ElasticDriver) MintCredential(ctx context.Context, spec *credential.Cre
 		)
 	}
 
-	return rawData, nil, ttl, leaseID, nil
+	return rawData, metadata, ttl, leaseID, nil
 }
 
 // Revoke invalidates an Elasticsearch API key via DELETE /_security/api_key.
@@ -257,19 +336,15 @@ func (d *ElasticDriver) Revoke(ctx context.Context, leaseID string) error {
 
 	// Extract key ID from "elastic:<id>" format
 	keyID := strings.TrimPrefix(leaseID, "elastic:")
-	if keyID == leaseID {
+	if keyID == leaseID || keyID == "" {
 		return fmt.Errorf("invalid lease ID format: %s", leaseID)
 	}
 
-	reqBody, err := json.Marshal(map[string]interface{}{
-		"ids": []string{keyID},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to marshal invalidate request: %w", err)
-	}
+	d.configMu.RLock()
+	auth := d.authSnapshotLocked()
+	d.configMu.RUnlock()
 
-	_, _, err = d.doElasticRequest(ctx, http.MethodDelete, "/_security/api_key", reqBody)
-	if err != nil {
+	if err := d.invalidateKeys(ctx, auth, []string{keyID}); err != nil {
 		return fmt.Errorf("failed to invalidate Elasticsearch API key %s: %w", truncateID(keyID, 8), err)
 	}
 
@@ -296,7 +371,11 @@ func (d *ElasticDriver) Cleanup(_ context.Context) error {
 // VerifySpec validates that the source credentials are functional by calling
 // the Elasticsearch authenticate endpoint.
 func (d *ElasticDriver) VerifySpec(ctx context.Context, _ *credential.CredSpec) error {
-	if err := d.verifyAuthentication(ctx); err != nil {
+	d.configMu.RLock()
+	auth := d.authSnapshotLocked()
+	d.configMu.RUnlock()
+
+	if _, err := d.verifyAuthenticationWith(ctx, auth); err != nil {
 		return fmt.Errorf("Elasticsearch spec verification failed: %w", err)
 	}
 	return nil
@@ -310,22 +389,34 @@ func (d *ElasticDriver) VerifySpec(ctx context.Context, _ *credential.CredSpec) 
 // Rotation requires the source API key to have the manage_api_key or
 // manage_own_api_key cluster privilege.
 func (d *ElasticDriver) SupportsRotation() bool {
-	d.authMu.Lock()
-	defer d.authMu.Unlock()
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
 	return d.sourceAPIKeyID != ""
 }
 
 // PrepareRotation creates a new API key using the current source credentials.
 // Returns activateAfter to allow time for cluster propagation.
 func (d *ElasticDriver) PrepareRotation(ctx context.Context) (map[string]string, map[string]string, time.Duration, error) {
-	d.authMu.Lock()
-	defer d.authMu.Unlock()
+	d.configMu.Lock()
+	defer d.configMu.Unlock()
 
 	if d.sourceAPIKeyID == "" {
 		return nil, nil, 0, fmt.Errorf("cannot rotate: source API key ID not discovered")
 	}
 
+	auth := d.authSnapshotLocked()
 	prefix := credential.GetString(d.credSource.Config, "key_name_prefix", "warden")
+	oldAPIKeyID := d.sourceAPIKeyID
+
+	// Reclaim keys earlier cycles lost before creating another. A rotation that
+	// is prepared and then abandoned — the persist fails, the commit fails, the
+	// node restarts before activation — leaves a key with this source's full
+	// privileges that nothing records and nothing will ever revoke.
+	//
+	// The sweep runs here, at the top of prepare, because that is the one moment
+	// when any staged key that exists is necessarily from an abandoned cycle:
+	// prepare is what creates the legitimate one, and it has not run yet.
+	d.sweepRotationOrphans(ctx, auth, oldAPIKeyID)
 
 	// Create new API key via the Security API
 	reqBody, err := json.Marshal(map[string]interface{}{
@@ -333,13 +424,18 @@ func (d *ElasticDriver) PrepareRotation(ctx context.Context) (map[string]string,
 		"metadata": map[string]interface{}{
 			"managed_by": "warden",
 			"purpose":    "source_rotation",
+			// Lineage, for the operator reading the key list in Kibana: this key
+			// exists to replace that one. The sweep does not match on it — a key is
+			// orphaned precisely when its cycle was abandoned, so its own stamp is
+			// never asked for again.
+			"replacing": oldAPIKeyID,
 		},
 	})
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("failed to marshal create API key request: %w", err)
 	}
 
-	respBody, _, err := d.doElasticRequest(ctx, http.MethodPost, "/_security/api_key", reqBody)
+	respBody, _, err := d.doElasticRequestWith(ctx, auth, http.MethodPost, "/_security/api_key", reqBody, elasticCreateRetryConfig())
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("failed to create new source API key: %w", err)
 	}
@@ -355,8 +451,6 @@ func (d *ElasticDriver) PrepareRotation(ctx context.Context) (map[string]string,
 	if createResp.Encoded == "" || createResp.ID == "" {
 		return nil, nil, 0, fmt.Errorf("create API key response missing encoded or id")
 	}
-
-	oldAPIKeyID := d.sourceAPIKeyID
 
 	// Build new config
 	newConfig := make(map[string]string)
@@ -384,25 +478,25 @@ func (d *ElasticDriver) PrepareRotation(ctx context.Context) (map[string]string,
 }
 
 // CommitRotation activates new credentials in the driver.
+//
+// There is no rollback. The manager persists newConfig before calling this
+// (see activateSource), so the stored config already names the new key; putting
+// the in-memory config back would leave this instance authenticating as a key
+// storage no longer records, and the next cycle would then mint a replacement
+// for it — a fresh untracked key every failed cycle. Failing forward keeps the
+// two in agreement, and a restart rebuilds the driver from what was stored.
 func (d *ElasticDriver) CommitRotation(ctx context.Context, newConfig map[string]string) error {
-	d.authMu.Lock()
-	defer d.authMu.Unlock()
+	d.configMu.Lock()
+	defer d.configMu.Unlock()
 
-	// Save old state for rollback
-	oldConfig := d.credSource.Config
-	oldAPIKeyID := d.sourceAPIKeyID
-
-	// Update config
 	d.credSource.Config = newConfig
 	d.sourceAPIKeyID = credential.GetString(newConfig, "api_key_id", "")
 
-	// Verify new credentials work
-	if err := d.verifyAuthentication(ctx); err != nil {
-		// Rollback
-		d.credSource.Config = oldConfig
-		d.sourceAPIKeyID = oldAPIKeyID
+	identity, err := d.verifyAuthenticationWith(ctx, d.authSnapshotLocked())
+	if err != nil {
 		return fmt.Errorf("failed to authenticate with new API key: %w", err)
 	}
+	d.sourceUsername = identity.Username
 
 	if d.logger != nil {
 		d.logger.Debug("committed source API key rotation",
@@ -420,15 +514,11 @@ func (d *ElasticDriver) CleanupRotation(ctx context.Context, cleanupConfig map[s
 		return nil
 	}
 
-	reqBody, err := json.Marshal(map[string]interface{}{
-		"ids": []string{oldAPIKeyID},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to marshal invalidate request: %w", err)
-	}
+	d.configMu.RLock()
+	auth := d.authSnapshotLocked()
+	d.configMu.RUnlock()
 
-	_, _, err = d.doElasticRequest(ctx, http.MethodDelete, "/_security/api_key", reqBody)
-	if err != nil {
+	if err := d.invalidateKeys(ctx, auth, []string{oldAPIKeyID}); err != nil {
 		return fmt.Errorf("failed to invalidate old API key: %w", err)
 	}
 
@@ -445,37 +535,222 @@ func (d *ElasticDriver) CleanupRotation(ctx context.Context, cleanupConfig map[s
 // Helpers
 // ============================================================================
 
-// verifyAuthentication calls GET /_security/_authenticate to verify the source
-// API key is valid.
-func (d *ElasticDriver) verifyAuthentication(ctx context.Context) error {
-	respBody, _, err := d.doElasticRequest(ctx, http.MethodGet, "/_security/_authenticate", nil)
+// warn logs a recoverable problem, if this driver has a logger at all. The
+// best-effort paths below — a sweep that could not list, an invalidation the
+// cluster had nothing to invalidate — report only this way, and a driver built
+// without a logger must not turn that report into a panic.
+func (d *ElasticDriver) warn(msg string, fields ...logger.TypedField) {
+	if d.logger != nil {
+		d.logger.Warn(msg, fields...)
+	}
+}
+
+// authSnapshotLocked copies out what a request needs to authenticate. Callers
+// hold configMu; the returned value is safe to use after releasing it.
+//
+// The trailing slash comes off here rather than being resolved once at Create,
+// so that the config stays the single source of truth for where the cluster is.
+// A URL cached at construction is a field that silently disagrees with the
+// config every time one is set without the other.
+func (d *ElasticDriver) authSnapshotLocked() elasticAuth {
+	return elasticAuth{
+		baseURL: strings.TrimRight(credential.GetString(d.credSource.Config, "elastic_url", ""), "/"),
+		encoded: credential.GetString(d.credSource.Config, "api_key", ""),
+	}
+}
+
+// verifyAuthenticationWith calls GET /_security/_authenticate and returns what
+// the cluster says about the key that authenticated.
+func (d *ElasticDriver) verifyAuthenticationWith(ctx context.Context, auth elasticAuth) (elasticIdentity, error) {
+	var identity elasticIdentity
+
+	respBody, _, err := d.doElasticRequestWith(ctx, auth, http.MethodGet, "/_security/_authenticate", nil, defaultElasticRetryConfig())
 	if err != nil {
-		return fmt.Errorf("authentication verification failed: %w", err)
+		return identity, fmt.Errorf("authentication verification failed: %w", err)
 	}
 
-	var authResp struct {
-		Username string `json:"username"`
-		Enabled  bool   `json:"enabled"`
-	}
-	if err := json.Unmarshal(respBody, &authResp); err != nil {
-		return fmt.Errorf("failed to decode authenticate response: %w", err)
+	if err := json.Unmarshal(respBody, &identity); err != nil {
+		return identity, fmt.Errorf("failed to decode authenticate response: %w", err)
 	}
 
-	if authResp.Username == "" {
-		return fmt.Errorf("authenticate response missing username")
+	if identity.Username == "" {
+		return identity, fmt.Errorf("authenticate response missing username")
+	}
+
+	// A disabled principal still answers _authenticate. Reading only the username
+	// would call such a source healthy at create and at every verification after
+	// it, while every mint it is asked for fails.
+	if !identity.Enabled {
+		return identity, fmt.Errorf("the authenticated principal %q is disabled", identity.Username)
+	}
+
+	return identity, nil
+}
+
+// sweepRotationOrphans invalidates rotation keys left behind by cycles that
+// never completed. Best-effort: a failure here must not stop the rotation that
+// is about to run, so it is logged rather than returned.
+//
+// Two things bound what it will touch. The query is scoped to the cluster
+// principal this source authenticates as, so it cannot reach the keys of
+// another source — or another deployment — sharing the cluster. And the key in
+// use is excluded by id, never by name or by stamp, so a key whose metadata is
+// missing or unexpected cannot be mistaken for a sweepable one.
+//
+// Two sources authenticating as the same principal would still sweep each
+// other. That configuration is already fatal without any sweep, since either
+// one's cleanup invalidates the key the other holds.
+func (d *ElasticDriver) sweepRotationOrphans(ctx context.Context, auth elasticAuth, liveKeyID string) {
+	if d.sourceUsername == "" || liveKeyID == "" {
+		return
+	}
+
+	query, err := json.Marshal(map[string]interface{}{
+		"size": elasticSweepPageSize,
+		"query": map[string]interface{}{
+			"bool": map[string]interface{}{
+				"filter": []map[string]interface{}{
+					{"term": map[string]interface{}{"username": d.sourceUsername}},
+					{"term": map[string]interface{}{"invalidated": false}},
+					{"term": map[string]interface{}{"metadata.managed_by": "warden"}},
+					{"term": map[string]interface{}{"metadata.purpose": "source_rotation"}},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return
+	}
+
+	respBody, _, err := d.doElasticRequestWith(ctx, auth, http.MethodPost, "/_security/_query/api_key", query, defaultElasticRetryConfig())
+	if err != nil {
+		d.warn("could not list rotation keys to reclaim orphans; continuing with the rotation",
+			logger.Err(err))
+		return
+	}
+
+	var queryResp struct {
+		APIKeys []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"api_keys"`
+	}
+	if err := json.Unmarshal(respBody, &queryResp); err != nil {
+		d.warn("could not decode the rotation key listing; continuing with the rotation",
+			logger.Err(err))
+		return
+	}
+
+	var orphans []string
+	for _, key := range queryResp.APIKeys {
+		if key.ID != "" && key.ID != liveKeyID {
+			orphans = append(orphans, key.ID)
+		}
+	}
+	if len(orphans) == 0 {
+		return
+	}
+
+	if err := d.invalidateKeys(ctx, auth, orphans); err != nil {
+		d.warn("could not reclaim abandoned rotation keys; they remain live at the cluster",
+			logger.Int("count", len(orphans)), logger.Err(err))
+		return
+	}
+
+	if d.logger != nil {
+		d.logger.Info("reclaimed abandoned rotation keys",
+			logger.Int("count", len(orphans)))
+	}
+}
+
+// elasticInvalidateResponse is the body DELETE /_security/api_key answers with.
+// The cluster reports per-key outcomes here and still returns 200, so the body
+// is the only place a refusal shows up.
+type elasticInvalidateResponse struct {
+	Invalidated           []string `json:"invalidated_api_keys"`
+	PreviouslyInvalidated []string `json:"previously_invalidated_api_keys"`
+	ErrorCount            int      `json:"error_count"`
+	ErrorDetails          []struct {
+		Type   string `json:"type"`
+		Reason string `json:"reason"`
+	} `json:"error_details"`
+}
+
+// invalidateKeys invalidates the given key ids and reads the outcome out of the
+// response body.
+//
+// A 200 is not success here. The cluster answers per key, so a refusal — a key
+// this principal may not manage, most often — arrives as error_count on an
+// otherwise ordinary response. Taking the status alone is what let a rotation
+// report a completed cleanup while the old source key stayed live.
+//
+// A key that is already gone is success, in both of the shapes that takes: the
+// cluster lists it as previously invalidated, or reports it as not found. That
+// tolerance matters more than it looks — cleanup failures are retried daily for
+// a week before being abandoned, so treating a key nobody can find as a failure
+// buys a week of retries for a request that can never succeed.
+func (d *ElasticDriver) invalidateKeys(ctx context.Context, auth elasticAuth, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	reqBody, err := json.Marshal(map[string]interface{}{"ids": ids})
+	if err != nil {
+		return fmt.Errorf("failed to marshal invalidate request: %w", err)
+	}
+
+	respBody, _, err := d.doElasticRequestWith(ctx, auth, http.MethodDelete, "/_security/api_key", reqBody, defaultElasticRetryConfig())
+	if err != nil {
+		return err
+	}
+
+	var resp elasticInvalidateResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return fmt.Errorf("failed to decode invalidate response: %w", err)
+	}
+
+	var refusals []string
+	for _, detail := range resp.ErrorDetails {
+		if strings.Contains(detail.Type, "resource_not_found") {
+			continue
+		}
+		refusals = append(refusals, fmt.Sprintf("%s: %s", detail.Type, detail.Reason))
+	}
+	if len(refusals) > 0 {
+		return fmt.Errorf("the cluster refused %d of %d invalidations: %s",
+			len(refusals), len(ids), strings.Join(refusals, "; "))
+	}
+
+	accounted := make(map[string]struct{}, len(resp.Invalidated)+len(resp.PreviouslyInvalidated))
+	for _, id := range resp.Invalidated {
+		accounted[id] = struct{}{}
+	}
+	for _, id := range resp.PreviouslyInvalidated {
+		accounted[id] = struct{}{}
+	}
+	for _, id := range ids {
+		if _, ok := accounted[id]; !ok {
+			// Neither invalidated nor refused: the cluster has no such key. Nothing
+			// is left live, so this is not a failure to retry — but it is worth
+			// saying, since the likeliest cause is an id that names nothing.
+			d.warn("Elasticsearch reported no outcome for an invalidated key; it does not exist at the cluster",
+				logger.String("key_id", truncateID(id, 8)))
+		}
 	}
 
 	return nil
 }
 
-// doElasticRequest executes an HTTP request to the Elasticsearch cluster using
-// the source API key for authentication.
-func (d *ElasticDriver) doElasticRequest(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
-	elasticURL := credential.GetString(d.credSource.Config, "elastic_url", "")
-	apiKey := credential.GetString(d.credSource.Config, "api_key", "")
-
+// doElasticRequestWith executes an HTTP request against the cluster with an
+// explicit credential.
+//
+// The credential is passed in rather than read from the config here, because
+// both rotation stages call this while holding configMu and the lock is not
+// reentrant — reading it here would deadlock them. Passing it also means a
+// request that started before a rotation finishes with the key it started with.
+func (d *ElasticDriver) doElasticRequestWith(ctx context.Context, auth elasticAuth, method, path string, body []byte, retry httputil.HTTPRetryConfig) ([]byte, int, error) {
 	headers := map[string]string{
-		"Authorization": "ApiKey " + apiKey,
+		"Authorization": "ApiKey " + auth.encoded,
 		"Accept":        "application/json",
 	}
 	if body != nil {
@@ -484,10 +759,10 @@ func (d *ElasticDriver) doElasticRequest(ctx context.Context, method, path strin
 
 	return httputil.ExecuteWithRetry(ctx, d.httpClient, httputil.HTTPRequest{
 		Method:  method,
-		URL:     elasticURL + path,
+		URL:     auth.baseURL + path,
 		Body:    body,
 		Headers: headers,
-	}, defaultElasticRetryConfig())
+	}, retry)
 }
 
 // defaultElasticRetryConfig returns the standard retry configuration for Elasticsearch API calls.
@@ -498,6 +773,26 @@ func defaultElasticRetryConfig() httputil.HTTPRetryConfig {
 		RetryableStatuses: []int{429, 500}, // 500 = wildcard for all 5xx (see httputil.ExecuteWithRetry)
 		BaseBackoff:       1 * time.Second,
 		JitterPercent:     20,
+	}
+}
+
+// elasticCreateRetryConfig is used for the rotation's key creation, which is not
+// idempotent and must not be retried.
+//
+// ExecuteWithRetry retries a transport error before it ever consults
+// RetryableStatuses, and a connection reset or a timeout reading the response —
+// the likeliest way to lose an acknowledgement for a request that arrived — is
+// exactly that. Retrying produced up to three live keys of which Warden learned
+// one, and a rotation key carries no expiration, so each was permanent.
+//
+// Failing a rate-limited create is the better trade: the manager retries the
+// whole cycle on its own schedule, and a deferred rotation costs less than a key
+// nobody can find. The per-spec mint keeps the retries, because the key it
+// strands carries an expiration and dies on its own.
+func elasticCreateRetryConfig() httputil.HTTPRetryConfig {
+	return httputil.HTTPRetryConfig{
+		MaxAttempts: 1,
+		MaxBodySize: elasticMaxResponseBodySize,
 	}
 }
 

--- a/credential/drivers/elastic_driver_test.go
+++ b/credential/drivers/elastic_driver_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -247,7 +248,109 @@ func newElasticMockServer(t *testing.T) *httptest.Server {
 		}
 	})
 
+	// Query API keys, which the rotation orphan sweep uses. The default cluster
+	// holds no orphans; tests that want some use newElasticSweepServer.
+	mux.HandleFunc("/_security/_query/api_key", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"api_keys": []interface{}{},
+			"total":    0,
+			"count":    0,
+		})
+	})
+
 	return httptest.NewServer(mux)
+}
+
+// elasticSweepServer is a cluster that holds rotation keys and records what the
+// sweep asked of it, so a test can assert both the scoping of the query and the
+// set of keys the sweep chose to invalidate.
+type elasticSweepServer struct {
+	*httptest.Server
+
+	// keys are the api keys the query endpoint reports, by id.
+	keys []string
+
+	lastQuery       map[string]interface{}
+	lastInvalidated []string
+}
+
+func newElasticSweepServer(t *testing.T, keys ...string) *elasticSweepServer {
+	t.Helper()
+
+	s := &elasticSweepServer{keys: keys}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/_security/_authenticate", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"username": "warden-service",
+			"enabled":  true,
+			"api_key":  map[string]interface{}{"id": "source-key-id"},
+		})
+	})
+
+	mux.HandleFunc("/_security/_query/api_key", func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&s.lastQuery)
+
+		found := make([]interface{}, 0, len(s.keys))
+		for _, id := range s.keys {
+			found = append(found, map[string]interface{}{"id": id, "name": "warden-source-rotated-1"})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{"api_keys": found})
+	})
+
+	mux.HandleFunc("/_security/api_key", func(w http.ResponseWriter, r *http.Request) {
+		var reqBody map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&reqBody)
+
+		switch r.Method {
+		case http.MethodDelete:
+			ids, _ := reqBody["ids"].([]interface{})
+			s.lastInvalidated = nil
+			for _, id := range ids {
+				if v, ok := id.(string); ok {
+					s.lastInvalidated = append(s.lastInvalidated, v)
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"invalidated_api_keys":            s.lastInvalidated,
+				"previously_invalidated_api_keys": []string{},
+				"error_count":                     0,
+			})
+		default:
+			name, _ := reqBody["name"].(string)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":      "new-key-id-123",
+				"name":    name,
+				"encoded": testEncodedAPIKey("new-key-id-123", "new-secret"),
+			})
+		}
+	})
+
+	s.Server = httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return s
+}
+
+// newElasticInvalidateServer answers every invalidate with a fixed body, so the
+// per-key outcomes the cluster reports under a 200 can be driven directly.
+func newElasticInvalidateServer(t *testing.T, body map[string]interface{}) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_security/api_key", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(body)
+	})
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
 }
 
 func newTestElasticDriver(t *testing.T, serverURL string) *ElasticDriver {
@@ -262,6 +365,7 @@ func newTestElasticDriver(t *testing.T, serverURL string) *ElasticDriver {
 		},
 		httpClient:     &http.Client{Timeout: 5 * time.Second},
 		sourceAPIKeyID: "source-key-id",
+		sourceUsername: "warden-service",
 	}
 }
 
@@ -582,13 +686,16 @@ func TestElasticDriver_CommitRotation(t *testing.T) {
 	assert.NotEqual(t, oldAPIKeyID, d.sourceAPIKeyID)
 }
 
-func TestElasticDriver_CommitRotation_RollbackOnFailure(t *testing.T) {
+// A failed commit must NOT put the old config back. The rotation manager
+// persists the new config before calling CommitRotation, so restoring the old
+// one here would leave this instance authenticating as a key storage no longer
+// records — and the next cycle would then mint a replacement for that key,
+// stranding a new one every time it failed.
+func TestElasticDriver_CommitRotation_KeepsNewConfigOnFailure(t *testing.T) {
 	srv := newElasticMockServer(t)
 	defer srv.Close()
 
 	d := newTestElasticDriver(t, srv.URL)
-	originalConfig := d.credSource.Config
-	originalKeyID := d.sourceAPIKeyID
 
 	// Provide an invalid key so authentication fails
 	newConfig := map[string]string{
@@ -601,9 +708,9 @@ func TestElasticDriver_CommitRotation_RollbackOnFailure(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to authenticate")
 
-	// Config should be rolled back
-	assert.Equal(t, originalConfig["api_key"], d.credSource.Config["api_key"])
-	assert.Equal(t, originalKeyID, d.sourceAPIKeyID)
+	assert.Equal(t, "invalid-key", d.credSource.Config["api_key"],
+		"driver must keep the config the manager already persisted")
+	assert.Equal(t, "bad-key-id", d.sourceAPIKeyID)
 }
 
 func TestElasticDriver_CleanupRotation(t *testing.T) {
@@ -683,17 +790,34 @@ func TestElasticDriverFactory_Create_WithExplicitKeyID(t *testing.T) {
 	defer srv.Close()
 
 	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
-
 	f := &ElasticDriverFactory{}
-	driver, err := f.Create(map[string]string{
-		"elastic_url": srv.URL,
-		"api_key":     testEncodedAPIKey("source-key-id", "source-secret"),
-		"api_key_id":  "explicit-id",
-	}, log)
-	require.NoError(t, err)
 
-	elasticDriver := driver.(*ElasticDriver)
-	assert.Equal(t, "explicit-id", elasticDriver.sourceAPIKeyID, "should use explicit api_key_id over decoded")
+	t.Run("agreeing with the encoded key", func(t *testing.T) {
+		driver, err := f.Create(map[string]string{
+			"elastic_url": srv.URL,
+			"api_key":     testEncodedAPIKey("source-key-id", "source-secret"),
+			"api_key_id":  "source-key-id",
+		}, log)
+		require.NoError(t, err)
+
+		elasticDriver := driver.(*ElasticDriver)
+		assert.Equal(t, "source-key-id", elasticDriver.sourceAPIKeyID)
+		assert.Equal(t, "warden-service", elasticDriver.sourceUsername,
+			"the sweep is scoped by this, so it must be discovered at create")
+	})
+
+	// Nothing downstream re-derives the id, and rotation cleanup spends it on a
+	// DELETE — so an id that names a different key than the one being
+	// authenticated with would invalidate whatever key it does name.
+	t.Run("disagreeing with the encoded key is refused", func(t *testing.T) {
+		_, err := f.Create(map[string]string{
+			"elastic_url": srv.URL,
+			"api_key":     testEncodedAPIKey("source-key-id", "source-secret"),
+			"api_key_id":  "explicit-id",
+		}, log)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match the id encoded in api_key")
+	})
 }
 
 func TestElasticDriverFactory_Create_InvalidKey(t *testing.T) {
@@ -845,4 +969,274 @@ func TestElasticDriver_ImplementsInterfaces(t *testing.T) {
 	var _ credential.SourceDriver = (*ElasticDriver)(nil)
 	var _ credential.Rotatable = (*ElasticDriver)(nil)
 	var _ credential.SpecVerifier = (*ElasticDriver)(nil)
+}
+
+// ============================================================================
+// Invalidation outcome tests
+//
+// Elasticsearch answers an invalidate request with 200 and reports the per-key
+// outcome in the body, so the status alone says nothing about whether anything
+// was actually invalidated.
+// ============================================================================
+
+func TestElasticDriver_Revoke_ReportsClusterRefusal(t *testing.T) {
+	srv := newElasticInvalidateServer(t, map[string]interface{}{
+		"invalidated_api_keys":            []string{},
+		"previously_invalidated_api_keys": []string{},
+		"error_count":                     1,
+		"error_details": []map[string]interface{}{
+			{"type": "security_exception", "reason": "unauthorized for user [warden-service]"},
+		},
+	})
+
+	d := newTestElasticDriver(t, srv.URL)
+
+	err := d.Revoke(context.TODO(), "elastic:some-key-id")
+	require.Error(t, err, "a refused invalidation must not read as success")
+	assert.Contains(t, err.Error(), "security_exception")
+	assert.Contains(t, err.Error(), "unauthorized")
+}
+
+func TestElasticDriver_CleanupRotation_ReportsClusterRefusal(t *testing.T) {
+	srv := newElasticInvalidateServer(t, map[string]interface{}{
+		"invalidated_api_keys":            []string{},
+		"previously_invalidated_api_keys": []string{},
+		"error_count":                     1,
+		"error_details": []map[string]interface{}{
+			{"type": "security_exception", "reason": "unauthorized"},
+		},
+	})
+
+	d := newTestElasticDriver(t, srv.URL)
+
+	// This is the case that matters most: a cleanup reported as done while the
+	// old source key is still live is a rotation that did not rotate.
+	err := d.CleanupRotation(context.TODO(), map[string]string{"api_key_id": "old-key-id"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to invalidate old API key")
+}
+
+func TestElasticDriver_Revoke_AcceptsAlreadyInvalidatedKey(t *testing.T) {
+	srv := newElasticInvalidateServer(t, map[string]interface{}{
+		"invalidated_api_keys":            []string{},
+		"previously_invalidated_api_keys": []string{"some-key-id"},
+		"error_count":                     0,
+	})
+
+	d := newTestElasticDriver(t, srv.URL)
+
+	require.NoError(t, d.Revoke(context.TODO(), "elastic:some-key-id"),
+		"a key that is already invalidated leaves nothing live, so this is success")
+}
+
+// A key that is gone entirely must not fail either. Cleanup failures are
+// retried daily for a week before being abandoned, so calling this a failure
+// buys a week of retries for a request that can never succeed.
+func TestElasticDriver_CleanupRotation_AcceptsMissingKey(t *testing.T) {
+	srv := newElasticInvalidateServer(t, map[string]interface{}{
+		"invalidated_api_keys":            []string{},
+		"previously_invalidated_api_keys": []string{},
+		"error_count":                     1,
+		"error_details": []map[string]interface{}{
+			{"type": "resource_not_found_exception", "reason": "no API key owned by requesting user found for id [old-key-id]"},
+		},
+	})
+
+	d := newTestElasticDriver(t, srv.URL)
+
+	require.NoError(t, d.CleanupRotation(context.TODO(), map[string]string{"api_key_id": "old-key-id"}))
+}
+
+func TestElasticDriver_Revoke_RejectsEmptyKeyID(t *testing.T) {
+	d := newTestElasticDriver(t, "https://unused.example.com")
+
+	// "elastic:" clears a naive TrimPrefix guard and would post {"ids":[""]}.
+	err := d.Revoke(context.TODO(), "elastic:")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid lease ID format")
+}
+
+// ============================================================================
+// Rotation orphan sweep
+// ============================================================================
+
+func TestElasticDriver_PrepareRotation_SweepsOrphansButNotTheLiveKey(t *testing.T) {
+	srv := newElasticSweepServer(t, "source-key-id", "abandoned-1", "abandoned-2")
+
+	d := newTestElasticDriver(t, srv.URL)
+
+	_, _, _, err := d.PrepareRotation(context.TODO())
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"abandoned-1", "abandoned-2"}, srv.lastInvalidated,
+		"every rotation key but the one in use should be reclaimed")
+	assert.NotContains(t, srv.lastInvalidated, "source-key-id",
+		"the key this source authenticates with must be excluded by id")
+}
+
+// The sweep issues an authenticated bulk DELETE, so what it is allowed to match
+// is the whole of its safety. A filter that is not bound to this source's own
+// cluster principal would reach the mid-rotation keys of every other elastic
+// source sharing the cluster.
+func TestElasticDriver_PrepareRotation_SweepIsScopedToThisPrincipal(t *testing.T) {
+	srv := newElasticSweepServer(t, "source-key-id")
+
+	d := newTestElasticDriver(t, srv.URL)
+
+	_, _, _, err := d.PrepareRotation(context.TODO())
+	require.NoError(t, err)
+
+	require.NotNil(t, srv.lastQuery, "the sweep must query before it deletes")
+	encoded, err := json.Marshal(srv.lastQuery)
+	require.NoError(t, err)
+	query := string(encoded)
+
+	assert.Contains(t, query, `"username":"warden-service"`)
+	assert.Contains(t, query, `"invalidated":false`)
+	assert.Contains(t, query, `"metadata.managed_by":"warden"`)
+	assert.Contains(t, query, `"metadata.purpose":"source_rotation"`)
+}
+
+// A cluster that cannot answer the listing must not block the rotation: the
+// sweep is a reclamation, not a precondition.
+func TestElasticDriver_PrepareRotation_SucceedsWhenSweepCannotList(t *testing.T) {
+	srv := newElasticMockServer(t) // has no orphans, and answers the query with none
+	defer srv.Close()
+
+	d := newTestElasticDriver(t, srv.URL)
+	d.sourceUsername = "" // as if the username were never discovered
+
+	newConfig, cleanupConfig, _, err := d.PrepareRotation(context.TODO())
+	require.NoError(t, err)
+	assert.Equal(t, "new-key-id-123", newConfig["api_key_id"])
+	assert.Equal(t, "source-key-id", cleanupConfig["api_key_id"])
+}
+
+// ============================================================================
+// Concurrency
+// ============================================================================
+
+// Mint reads the config while a commit replaces it. Run under -race, this is
+// what pins the snapshot: the config is a whole map that rotation swaps, and
+// reading it unsynchronised from the request path is a data race however benign
+// the values look.
+func TestElasticDriver_MintRacesCommitRotation(t *testing.T) {
+	srv := newElasticMockServer(t)
+	defer srv.Close()
+
+	d := newTestElasticDriver(t, srv.URL)
+
+	spec := &credential.CredSpec{Name: "race-spec", Config: map[string]string{}}
+
+	// Each goroutine loops: the unsynchronised read was a narrow window at the
+	// top of the mint, so a single pass each could pass on timing alone.
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				// The error is not the point; reaching the config safely is.
+				_, _, _, _, _ = d.MintCredential(context.TODO(), spec)
+			}
+		}()
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				_ = d.CommitRotation(context.TODO(), map[string]string{
+					"elastic_url": srv.URL,
+					"api_key":     testEncodedAPIKey(fmt.Sprintf("rotated-%d-%d", n, j), "secret"),
+					"api_key_id":  fmt.Sprintf("rotated-%d-%d", n, j),
+				})
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// ============================================================================
+// Authentication and URL handling
+// ============================================================================
+
+func TestElasticDriver_VerifyRejectsDisabledPrincipal(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_security/_authenticate", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"username": "warden-service",
+			"enabled":  false,
+			"api_key":  map[string]interface{}{"id": "source-key-id"},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	d := newTestElasticDriver(t, srv.URL)
+
+	err := d.VerifySpec(context.TODO(), &credential.CredSpec{Name: "s"})
+	require.Error(t, err, "a disabled principal answers _authenticate but cannot mint")
+	assert.Contains(t, err.Error(), "disabled")
+}
+
+func TestElasticDriver_TrailingSlashInURLIsTrimmed(t *testing.T) {
+	var paths []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"username": "warden-service",
+			"enabled":  true,
+			"api_key":  map[string]interface{}{"id": "source-key-id"},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	d := newTestElasticDriver(t, srv.URL+"/")
+
+	require.NoError(t, d.VerifySpec(context.TODO(), &credential.CredSpec{Name: "s"}))
+	require.Len(t, paths, 1)
+	assert.Equal(t, "/_security/_authenticate", paths[0],
+		"a configured trailing slash must not reach the cluster as a doubled separator")
+}
+
+// ============================================================================
+// Expiration
+// ============================================================================
+
+// A key created without an expiration never expires. The driver's 1h default
+// only applies when the field is absent, so a set-but-empty value would reach
+// the cluster as "no expiration" — a permanent key from a spec that looks like
+// it asked for a lifetime.
+func TestElasticDriver_MintCredential_RejectsEmptyExpiration(t *testing.T) {
+	srv := newElasticMockServer(t)
+	defer srv.Close()
+
+	d := newTestElasticDriver(t, srv.URL)
+
+	_, _, _, _, err := d.MintCredential(context.TODO(), &credential.CredSpec{
+		Name:   "test-spec",
+		Config: map[string]string{"expiration": ""},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty expiration")
+}
+
+func TestElasticDriver_MintCredential_ReturnsKeyMetadata(t *testing.T) {
+	srv := newElasticMockServer(t)
+	defer srv.Close()
+
+	d := newTestElasticDriver(t, srv.URL)
+
+	_, metadata, _, _, err := d.MintCredential(context.TODO(), &credential.CredSpec{
+		Name:   "test-spec",
+		Config: map[string]string{},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, metadata, "the audit record should name the key that was created")
+	assert.Equal(t, "new-key-id-123", metadata["key_id"])
 }

--- a/credential/types/api_key.go
+++ b/credential/types/api_key.go
@@ -1,7 +1,10 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/stephnangue/warden/credential"
 )
@@ -44,7 +47,21 @@ func NewAPIKeyCredType() *APIKeyCredType {
 					},
 				},
 			},
-			Revocable: false, // Static API keys are not revocable via lease
+			// Revocable where a lease exists. Parse gates this on a non-empty
+			// leaseID, so the sources that read a key out of a store — the apikey
+			// and local specs, the vault static_apikey read, the aws
+			// secrets_manager read — stay non-revocable: they hand back a key they
+			// did not create and return no lease, and revoking one would destroy a
+			// secret somebody else owns.
+			//
+			// The sources that CREATE a key upstream do return one, and every one
+			// of them implements a Revoke that invalidates it. Left false, that
+			// lease reached nothing: the expiration manager is only told about a
+			// credential the type calls revocable, so a key minted for a caller
+			// outlived the session it was minted for and sat at the upstream until
+			// its own expiry — which an elastic spec may set to 30d, and which a
+			// grafana service-account token does not have at all.
+			Revocable: true,
 		},
 	}
 }
@@ -85,6 +102,53 @@ func (t *APIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 		credential.StringField("application_key").
 			Describe("Second API key some providers require alongside api_key (optional; datadog)").
 			Example("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"),
+
+		// Mint parameters for the sources that create a key upstream rather than
+		// reading one out of a store. They shape the request the driver makes;
+		// none of them is part of the credential.
+		//
+		// Declared for the same reason as the adjuncts above: an undeclared
+		// spec-config key is masked on read, since the type has no basis for
+		// calling an unrecognised key public. Left undeclared, an operator reading
+		// back a spec would find the indices their key is scoped to displayed as a
+		// secret.
+		credential.StringField("expiration").
+			Describe("Key lifetime, as an Elasticsearch time value (elastic; default 1h)").
+			Example("24h"),
+
+		credential.StringField("role_descriptors").
+			Describe("JSON role descriptors scoping the key's privileges (elastic)").
+			Example(`{"reader":{"indices":[{"names":["logs-*"],"privileges":["read"]}]}}`),
+
+		credential.StringField("role").
+			OneOf("Viewer", "Editor", "Admin").
+			Describe("Service-account role (grafana)").
+			Example("Viewer"),
+
+		credential.StringField("name_prefix").
+			Describe("Prefix for the generated service-account name (grafana)").
+			Example("warden"),
+
+		credential.StringField("org_id").
+			Describe("Organization the service account is created in (grafana)").
+			Example("1"),
+
+		credential.StringField("key_type").
+			OneOf("ingest", "configuration").
+			Describe("Which kind of key to create (honeycomb)").
+			Example("ingest"),
+
+		credential.StringField("key_name_prefix").
+			Describe("Prefix for the generated key name (honeycomb)").
+			Example("warden"),
+
+		credential.StringField("environment_id").
+			Describe("Environment the key is created in (honeycomb)").
+			Example("hcaen_xxxxxxxxxxxx"),
+
+		credential.StringField("permissions").
+			Describe("JSON permissions for a configuration key (honeycomb)").
+			Example(`{"create_datasets":true}`),
 
 		// Store-backed sources (vault static_apikey, aws secrets_manager)
 		credential.StringField("mint_method").
@@ -155,12 +219,23 @@ func (t *APIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 // holds connection info (api_url). This allows multiple specs with different
 // API keys to share one source.
 func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType string) error {
-	// Step 1: Validate source type compatibility
+	// Step 1: Validate source type compatibility.
+	//
+	// Two families reach this type. One holds the key in the spec or reads it out
+	// of a store; the other creates a fresh key at the upstream on every mint, and
+	// so carries no key in the spec at all — which is why the required-api_key
+	// check below is not reached for them.
+	//
+	// The second family was missing here, and its absence made all three of those
+	// drivers unreachable: their factories infer this type, no other type accepts
+	// their source, and so every spec written against one was refused. There is no
+	// second path to reach them.
 	switch sourceType {
-	case credential.SourceTypeAPIKey, credential.SourceTypeLocal, credential.SourceTypeVault, credential.SourceTypeAWS:
+	case credential.SourceTypeAPIKey, credential.SourceTypeLocal, credential.SourceTypeVault, credential.SourceTypeAWS,
+		credential.SourceTypeElastic, credential.SourceTypeGrafana, credential.SourceTypeHoneycomb:
 		// Supported
 	default:
-		return fmt.Errorf("api_key credentials require an apikey, local, vault, or aws source, got: %s", sourceType)
+		return fmt.Errorf("api_key credentials require an apikey, local, vault, aws, elastic, grafana, or honeycomb source, got: %s", sourceType)
 	}
 
 	// Step 2: Validate config against schema
@@ -198,6 +273,28 @@ func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType str
 			return fmt.Errorf("'mint_method' must be 'secrets_manager' for an aws source, got: %s", config["mint_method"])
 		}
 		return validateAWSSecretsManagerSpecConfig(config)
+	case credential.SourceTypeElastic:
+		// The key is created at the cluster on every mint, so the spec carries
+		// none. What it carries is the shape of the key to create.
+		//
+		// An expiration is checked here rather than left to the cluster because a
+		// key minted without one never expires, and the driver's default is only
+		// applied when the field is absent: set-but-empty reaches the cluster as
+		// "no expiration". A spec that says expiration= reads as though it asked
+		// for something.
+		if raw, present := config["expiration"]; present {
+			if err := validateElasticTimeValue(raw); err != nil {
+				return fmt.Errorf("'expiration': %w", err)
+			}
+		}
+		if rd := config["role_descriptors"]; rd != "" {
+			if !json.Valid([]byte(rd)) {
+				return fmt.Errorf("'role_descriptors' is not valid JSON")
+			}
+		}
+	case credential.SourceTypeGrafana, credential.SourceTypeHoneycomb:
+		// As above: the key is created upstream per mint and the spec holds no
+		// key. Their mint parameters are validated by their own drivers.
 	default:
 		// apikey source: the api_key lives inline in the spec, unless it is sourced from
 		// another cred spec via credential chaining (secret_spec) — the two are mutually
@@ -213,6 +310,40 @@ func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType str
 	}
 
 	return nil
+}
+
+// elasticTimeUnits are the suffixes an Elasticsearch time value may carry,
+// longest first so "ms" is matched before "s" and "micros" before "s".
+var elasticTimeUnits = []string{"nanos", "micros", "ms", "d", "h", "m", "s"}
+
+// validateElasticTimeValue checks a duration written the way Elasticsearch
+// writes them: an integer and a unit, no sign, no fractional part.
+//
+// This deliberately does not use time.ParseDuration. The two notations overlap
+// enough to look interchangeable and disagree exactly where it costs: Go rejects
+// "30d", the single most likely value for a key lifetime and the one the driver
+// documentation uses, while accepting "1.5h" and "-1h", which the cluster does
+// not.
+func validateElasticTimeValue(v string) error {
+	if v == "" {
+		return fmt.Errorf("must not be empty; omit it to take the default, or give a lifetime such as 24h or 30d")
+	}
+	for _, unit := range elasticTimeUnits {
+		digits, ok := strings.CutSuffix(v, unit)
+		if !ok || digits == "" {
+			continue
+		}
+		n, err := strconv.Atoi(digits)
+		if err != nil {
+			break
+		}
+		if n <= 0 {
+			return fmt.Errorf("must be positive, got: %s", v)
+		}
+		return nil
+	}
+	return fmt.Errorf("is not an Elasticsearch time value (an integer and one of %s), got: %s",
+		strings.Join(elasticTimeUnits, ", "), v)
 }
 
 // RequiresSpecRotation returns false — API keys live in source config, not spec.

--- a/credential/types/api_key_test.go
+++ b/credential/types/api_key_test.go
@@ -155,6 +155,60 @@ func TestAPIKeyCredType_ValidateConfig(t *testing.T) {
 			wantErr:    true,
 			errMsg:     "api_key",
 		},
+		// --- Sources that create the key upstream ---
+		//
+		// These carry no api_key in the spec: the driver creates a fresh key at
+		// the upstream on every mint. Their absence from the allowlist made all
+		// three drivers unreachable, since nothing else accepts their source.
+		{
+			name:       "elastic source - no api_key required",
+			config:     map[string]string{},
+			sourceType: credential.SourceTypeElastic,
+			wantErr:    false,
+		},
+		{
+			name: "elastic source - full mint config",
+			config: map[string]string{
+				"key_name":         "ingest-writer",
+				"expiration":       "30d",
+				"role_descriptors": `{"reader":{"indices":[{"names":["logs-*"],"privileges":["read"]}]}}`,
+			},
+			sourceType: credential.SourceTypeElastic,
+			wantErr:    false,
+		},
+		{
+			name:       "elastic source - empty expiration is refused",
+			config:     map[string]string{"expiration": ""},
+			sourceType: credential.SourceTypeElastic,
+			wantErr:    true,
+			errMsg:     "must not be empty",
+		},
+		{
+			name:       "elastic source - Go duration notation is refused",
+			config:     map[string]string{"expiration": "1h30m"},
+			sourceType: credential.SourceTypeElastic,
+			wantErr:    true,
+			errMsg:     "not an Elasticsearch time value",
+		},
+		{
+			name:       "elastic source - malformed role_descriptors",
+			config:     map[string]string{"role_descriptors": "{not json"},
+			sourceType: credential.SourceTypeElastic,
+			wantErr:    true,
+			errMsg:     "role_descriptors",
+		},
+		{
+			name:       "grafana source - no api_key required",
+			config:     map[string]string{"role": "Viewer"},
+			sourceType: credential.SourceTypeGrafana,
+			wantErr:    false,
+		},
+		{
+			name:       "honeycomb source - no api_key required",
+			config:     map[string]string{"key_type": "ingest"},
+			sourceType: credential.SourceTypeHoneycomb,
+			wantErr:    false,
+		},
 		// --- Unsupported source types ---
 		{
 			name: "unsupported source type - github",
@@ -163,7 +217,7 @@ func TestAPIKeyCredType_ValidateConfig(t *testing.T) {
 			},
 			sourceType: "github",
 			wantErr:    true,
-			errMsg:     "require an apikey, local, vault, or aws source",
+			errMsg:     "require an apikey, local, vault, aws, elastic, grafana, or honeycomb source",
 		},
 		// --- Vault source ---
 		{
@@ -536,5 +590,24 @@ func TestAPIKeyCredType_KnownAdjunctFieldsAreDeclared(t *testing.T) {
 
 	for _, field := range ct.KnownAdjunctFields() {
 		assert.True(t, declared[field], "adjunct %q must be declared in ConfigSchema", field)
+	}
+}
+
+func TestValidateElasticTimeValue(t *testing.T) {
+	valid := []string{"1h", "24h", "30d", "90m", "45s", "500ms", "1000micros", "5nanos"}
+	for _, v := range valid {
+		t.Run("valid/"+v, func(t *testing.T) {
+			assert.NoError(t, validateElasticTimeValue(v))
+		})
+	}
+
+	// The Go-notation values are the point of having a parser of our own:
+	// time.ParseDuration accepts the last three and rejects "30d", which is the
+	// value the driver documentation leads with.
+	invalid := []string{"", "30", "d", "1.5h", "-1h", "1h30m", "30 days", "forever", "0h"}
+	for _, v := range invalid {
+		t.Run("invalid/"+v, func(t *testing.T) {
+			assert.Error(t, validateElasticTimeValue(v))
+		})
 	}
 }

--- a/credential/types/revocable_test.go
+++ b/credential/types/revocable_test.go
@@ -97,6 +97,22 @@ func TestRevocableRequiresLeaseID(t *testing.T) {
 			rawData:   map[string]interface{}{"api_token": "v1.0-test-token"},
 			leaseID:   "cf-lease",
 		},
+		{
+			// api_key is served by two families, and the leaseID is what tells
+			// them apart. The store-backed readers — the apikey and local specs,
+			// the vault static_apikey read, the aws secrets_manager read — return
+			// neither a TTL nor a leaseID, and must stay non-revocable: the key is
+			// someone else's to destroy. The drivers that create a key upstream
+			// (elastic, grafana, honeycomb) return both, and are revoked at
+			// session end.
+			//
+			// Not reachable: no api_key path returns a TTL without a leaseID.
+			name:      "api_key",
+			reachable: false,
+			credType:  NewAPIKeyCredType(),
+			rawData:   map[string]interface{}{"api_key": "sk-xxxxxxxxxxxxxxxxxxxx"},
+			leaseID:   "elastic:abc123",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
No spec could be created against an elastic source. The factory infers the `api_key` credential type, that type's source allowlist admitted only apikey, local, vault and aws, and no other type accepts an elastic source — so the documented flow failed at write time with no second route to the driver. The same hole covered grafana and honeycomb. Nothing caught it: the unit tests build driver literals directly, and the elastic e2e row drives the *provider* off a local source, so the driver had never been exercised end to end.

**Widening the allowlist is not enough on its own.** `key_name` is a credential field on an apikey source and the name of the key an elastic source is about to create, and the adjunct check refuses credential fields on a source that cannot carry them — so a documented mint parameter was refused, with advice to move to an apikey source, which mints nothing. Whether a name describes the credential is a property of the source, not of the name, so the exemption is keyed on the source type rather than added to the globally reserved keys, which would delete the check for the source that needs it.

**`api_key` is now revocable.** `Parse` gates that on a non-empty leaseID, so the sources that read a key out of a store keep returning none and stay untouched — the key is someone else's to destroy. The three that create a key upstream return one and all implement `Revoke`, and left false that lease reached nothing: the expiration manager is only told about a credential the type calls revocable, so every key minted for a caller outlived its session and sat at the upstream until its own expiry, which an elastic spec may set to 30d and a grafana token does not have at all. Revocation follows the *session*, not the key's expiry, which is what the registration is bounded by.

**Every config read now goes through a snapshot taken under a lock.** Rotation replaces the whole config map while requests are in flight on the shared driver, and mint, revoke, verify and cleanup all read it unsynchronised. The credential is passed to each request rather than read inside it, because both rotation stages issue HTTP while holding the lock and reading there would deadlock them; it also means a request that started before a rotation finishes with the key it started with.

**A failed commit no longer rolls back.** The manager persists the new config before committing, so restoring the old one left this instance authenticating as a key storage no longer recorded — and the next cycle read that rolled-back config and minted a replacement for it, stranding a fully privileged key every time it failed. The tree is split on this: vault does not roll back, scaleway and alicloud do not verify at all, and ibm does roll back, deliberately, to keep a cached token from outliving the key that minted it. The ibm case carries the same storage divergence and is worth revisiting on its own.

**Invalidation now reads the response body.** Elasticsearch answers with 200 and reports the per-key outcome inside, so taking the status alone let a rotation report a completed cleanup while the old source key stayed live. A key that is already gone stays success in both shapes it takes — previously invalidated, or reported not found — because cleanup failures are retried daily for a week before being abandoned, and a key nobody can find will not be found by retrying.

**Rotation orphans are contained.** The key prepare creates carried no expiration, so one abandoned by a failed persist, a failed commit or a restart before activation lived forever with the source key's privileges. The create no longer retries: the retry helper retries a transport error before it consults any status, and a lost acknowledgement for a request that arrived is exactly that. Keys already lost are reclaimed by a sweep at the top of prepare, the one moment when any staged key present is necessarily from an abandoned cycle. The sweep is scoped to the cluster principal this source authenticates as, so it cannot reach another source's mid-rotation key, and it excludes the key in use *by id* rather than by name or stamp, so absent metadata cannot make the live key look sweepable. Two sources sharing one principal would still sweep each other, a configuration already fatal without any sweep since either one's cleanup deletes the key the other holds.

**Smaller things this found.** A disabled principal still answers `_authenticate`, and reading only the username called such a source healthy at create and at every verification after it. A trailing slash on `elastic_url` reached the cluster as a doubled separator; every sibling driver trims and this one did not. An `expiration` set to empty was passed through as absent, and a key created without one never expires — it is now refused at spec write, with a parser for Elasticsearch time values rather than `time.ParseDuration`, which rejects the `30d` the documentation leads with and accepts fractions and negatives the cluster does not. An `api_key_id` set by hand overrode the decoded one unchecked, and rotation cleanup spends it on a DELETE. A lease of `elastic:` cleared the prefix guard with an empty id. The mint returns the key id and name for the audit record.

**Verification.** Unit suite and `-race` green; full e2e suite green. The race test was checked against the unsynchronised read and fails there; the two store tests were checked against the allowlist and the adjunct exemption separately, and each fails without its own half.

First of three: `feat/elastic-keyless-chaining` and `test/e2e-elastic-source` stack on top.