### PR TITLE
feat(elastic): fetch the cluster key per request instead of storing one

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -1162,6 +1162,15 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 				if credential.GetString(spec.Config, "mint_method", "") != "access_keys" {
 					return logical.ErrBadRequestf("for an ibm source, set secret_spec on the source (the chained api key authenticates the source's own IAM token grant), not on the spec; a spec-level reference is for access_keys, whose credential is the referenced pair itself")
 				}
+			case credential.SourceTypeElastic:
+				// elastic chains only at the source: the fetched key authenticates
+				// its own Security API calls, and every spec on it creates a fresh
+				// cluster key rather than serving a stored one.
+				//
+				// The api_key type refuses this first and with the same guidance, so
+				// this is the layer that holds when the type registry is unavailable
+				// and credType is nil — the same reason the ovh arm below exists.
+				return logical.ErrBadRequestf("for an elastic source, set secret_spec on the source (the chained api key authenticates the source's own Security API calls), not on the spec")
 			}
 		}
 		// An oauth2 source that chains its client credential resolves the pair per mint,

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -2797,3 +2797,45 @@ func TestCredentialConfigStore_ValidateSpec_ElasticKeyNameIsAMintParameter(t *te
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "credential_fields")
 }
+
+// An elastic source chains the cluster key that authenticates its own Security
+// API calls, so the reference belongs on the source. A spec-level one would
+// leave the source's own setting unused at mint, so it is refused with guidance
+// rather than accepted and quietly ignored.
+//
+// The api_key type refuses this first and says the same thing; this is the
+// layer that holds when the type registry is unavailable, so the registry is
+// deliberately left unset here — which is also the only way to reach this arm.
+func TestCredentialConfigStore_ValidateSpec_ElasticChainsAtTheSource(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "es-cluster-key", Type: "vault_token", Source: "src",
+		Config: map[string]string{
+			"subject_token_source": "warden_identity",
+			"assertion_audience":   "test-aud",
+		},
+	}))
+
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "es-chained", Type: credential.SourceTypeElastic,
+		Config: map[string]string{credential.ConfigSecretSpec: "es-cluster-key"},
+	}))
+
+	t.Run("a spec on a chained source needs no reference of its own", func(t *testing.T) {
+		require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "es-chained-spec", Type: credential.TypeAPIKey, Source: "es-chained",
+			Config: map[string]string{"expiration": "1h"},
+		}))
+	})
+
+	t.Run("a spec-level reference is refused with guidance", func(t *testing.T) {
+		err := store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "es-spec-level", Type: credential.TypeAPIKey, Source: "es-chained",
+			Config: map[string]string{credential.ConfigSecretSpec: "es-cluster-key"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "set secret_spec on the source")
+	})
+}

--- a/credential/drivers/elastic_driver.go
+++ b/credential/drivers/elastic_driver.go
@@ -35,14 +35,17 @@ const elasticSweepPageSize = 100
 var _ credential.SourceDriver = (*ElasticDriver)(nil)
 var _ credential.Rotatable = (*ElasticDriver)(nil)
 var _ credential.SpecVerifier = (*ElasticDriver)(nil)
+var _ credential.ChainedSecretMinter = (*ElasticDriver)(nil)
 
-// ElasticDriver mints credentials from Elasticsearch clusters.
-// It creates API keys via the /_security/api_key endpoint and supports
-// rotation of the driver's own source API key.
+// ElasticDriver mints credentials from Elasticsearch clusters. Every spec on it
+// creates a scoped, expiring API key via /_security/api_key.
 //
-// The driver's source credentials (a pre-encoded API key) are used for:
-// - Minting new API keys for credential specs
-// - Rotating the source API key via the Security API
+// The cluster key those calls authenticate with comes from one of two places.
+// Held inline, it also rotates: the driver mints its own replacement through the
+// Security API and invalidates the old one. Chained (secret_spec), it is fetched
+// per mint from a referenced spec as the calling agent and kept nowhere, which
+// leaves nothing here to rotate — and nothing to revoke a minted key with once
+// the request is over, so those keys are left to their own expiration.
 type ElasticDriver struct {
 	credSource *credential.CredSource
 	logger     *logger.GatedLogger
@@ -96,6 +99,9 @@ func (f *ElasticDriverFactory) Type() string {
 
 // ValidateConfig validates Elasticsearch driver configuration using declarative schema
 func (f *ElasticDriverFactory) ValidateConfig(config map[string]string) error {
+	if err := validateElasticChainedConfig(config); err != nil {
+		return err
+	}
 	return credential.ValidateSchema(config,
 		credential.StringField("elastic_url").
 			Required().
@@ -119,9 +125,11 @@ func (f *ElasticDriverFactory) ValidateConfig(config map[string]string) error {
 			Describe("Elasticsearch cluster URL").
 			Example("https://my-cluster.es.us-east-1.aws.cloud.es.io"),
 
+		// Required only when the source holds its own key; a chained source is
+		// refused one outright. validateElasticChainedConfig enforces both halves
+		// of that, since the schema can express neither.
 		credential.StringField("api_key").
-			Required().
-			Describe("Pre-encoded Elasticsearch API key (base64 of id:api_key)").
+			Describe("Pre-encoded Elasticsearch API key (base64 of id:api_key); required unless secret_spec is set").
 			Example("dXNlcjpwYXNzd29yZA=="),
 
 		credential.StringField("api_key_id").
@@ -150,7 +158,45 @@ func (f *ElasticDriverFactory) ValidateConfig(config map[string]string) error {
 		credential.BoolField("tls_skip_verify").
 			Describe("Skip TLS certificate verification (development only)").
 			Example("false"),
+
+		credential.StringField(credential.ConfigSecretSpec).
+			Describe("Cred spec yielding the cluster API key, instead of storing one here").
+			Example("es-cluster-key"),
+
+		credential.StringField(credential.ConfigSecretField).
+			Describe("Field of the referenced credential holding the api key; an id, when one is needed, travels beside it under 'id'").
+			Example("api_key"),
+
+		credential.DurationField(credential.ConfigSecretCacheTTL).
+			Describe("How long to reuse the fetched cluster key before re-fetching (default: no caching)").
+			Example("30m"),
 	)
+}
+
+// validateElasticChainedConfig holds a source to exactly one way of getting its
+// cluster key.
+//
+// A chained source keeps neither the key — keeping it would leave a source that
+// reads as keyless while storing the very secret chaining removes — nor the id,
+// which is derived from the key and, kept beside a fetched one, would name one
+// key while presenting another's. There is nothing here for it to be used by
+// either: the id serves rotation cleanup, and a chained source does not rotate.
+func validateElasticChainedConfig(config map[string]string) error {
+	if credential.GetString(config, credential.ConfigSecretSpec, "") == "" {
+		// The schema cannot express "required unless another key is set", so the
+		// non-chained requirement lands here alongside its opposite.
+		if credential.GetString(config, "api_key", "") == "" {
+			return fmt.Errorf("api_key is required unless %s is set", credential.ConfigSecretSpec)
+		}
+		return nil
+	}
+	for _, key := range []string{"api_key", "api_key_id"} {
+		if credential.GetString(config, key, "") != "" {
+			return fmt.Errorf("%s must be omitted when %s is set; the referenced spec supplies the cluster key",
+				key, credential.ConfigSecretSpec)
+		}
+	}
+	return nil
 }
 
 // SensitiveConfigFields returns the list of config keys that should be masked in output
@@ -178,6 +224,14 @@ func (f *ElasticDriverFactory) Create(config map[string]string, log *logger.Gate
 		return nil, fmt.Errorf("invalid TLS configuration: %w", err)
 	}
 	driver.httpClient = httpClient
+
+	// A chained source holds nothing to decode and nothing to verify: the cluster
+	// key is fetched per mint, as the caller, and there is no caller at
+	// construction. Probing here would authenticate as whatever this source does
+	// not have, and fail every source create.
+	if driver.isChainedLocked() {
+		return driver, nil
+	}
 
 	encoded := credential.GetString(config, "api_key", "")
 
@@ -237,6 +291,41 @@ func (f *ElasticDriverFactory) Create(config map[string]string, log *logger.Gate
 func (d *ElasticDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	d.configMu.RLock()
 	auth := d.authSnapshotLocked()
+	chained := d.isChainedLocked()
+	d.configMu.RUnlock()
+
+	// A chained spec mints through MintFromSecret, which the minting layer routes
+	// it to. Arriving here means that routing was bypassed, so fail rather than
+	// fall through to an inline key this source does not have.
+	if chained || spec.Config[credential.ConfigSecretSpec] != "" {
+		return nil, nil, 0, "", fmt.Errorf("elastic: %s is set (credential chaining); this spec mints from fetched secret material, not directly",
+			credential.ConfigSecretSpec)
+	}
+
+	return d.mintAPIKey(ctx, auth, spec, false)
+}
+
+// MintFromSecret mints from a cluster API key fetched through credential
+// chaining, for a source that stores none of its own.
+func (d *ElasticDriver) MintFromSecret(ctx context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	d.configMu.RLock()
+	baseURL := d.authSnapshotLocked().baseURL
+	d.configMu.RUnlock()
+
+	auth, err := resolveChainedElasticAuth(baseURL, material)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+
+	return d.mintAPIKey(ctx, auth, spec, true)
+}
+
+// mintAPIKey creates one API key at the cluster. chained says where the
+// credential it authenticates with came from, which decides only how an
+// authentication refusal is reported: a fetched secret can be stale and worth
+// re-fetching, an inline one cannot.
+func (d *ElasticDriver) mintAPIKey(ctx context.Context, auth elasticAuth, spec *credential.CredSpec, chained bool) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	d.configMu.RLock()
 	prefix := credential.GetString(d.credSource.Config, "key_name_prefix", "warden")
 	d.configMu.RUnlock()
 
@@ -276,8 +365,16 @@ func (d *ElasticDriver) MintCredential(ctx context.Context, spec *credential.Cre
 		return nil, nil, 0, "", fmt.Errorf("failed to marshal create API key request: %w", err)
 	}
 
-	respBody, _, err := d.doElasticRequestWith(ctx, auth, http.MethodPost, "/_security/api_key", body, defaultElasticRetryConfig())
+	respBody, status, err := d.doElasticRequestWith(ctx, auth, http.MethodPost, "/_security/api_key", body, defaultElasticRetryConfig())
 	if err != nil {
+		// On the chained path a refusal to authenticate marks the fetched key as
+		// stale, so the minting layer evicts what it cached and retries once with
+		// a fresh read. An inline source has nothing to evict, and saying so would
+		// only send it round a loop that cannot change the outcome.
+		if chained && (status == http.StatusUnauthorized || status == http.StatusForbidden) {
+			return nil, nil, 0, "", fmt.Errorf("elastic: the cluster rejected the chained api key: %w (%w)",
+				credential.ErrChainedSecretRejected, err)
+		}
 		return nil, nil, 0, "", fmt.Errorf("failed to create Elasticsearch API key: %w", err)
 	}
 
@@ -342,7 +439,20 @@ func (d *ElasticDriver) Revoke(ctx context.Context, leaseID string) error {
 
 	d.configMu.RLock()
 	auth := d.authSnapshotLocked()
+	chained := d.isChainedLocked()
 	d.configMu.RUnlock()
+
+	// A chained source holds no key to authorise the delete, and revocation runs
+	// at lease expiry, where there is no caller to walk the chain as. That will
+	// never change, so returning an error would only send the expiration manager
+	// into backoff and then a daily retry, forever, for a request that cannot
+	// succeed. The key carries its own expiration — which is why a chained mint
+	// is refused an empty one.
+	if chained {
+		d.warn("cannot revoke a key minted from a chained cluster credential; it will live until it expires",
+			logger.String("key_id", truncateID(keyID, 8)))
+		return nil
+	}
 
 	if err := d.invalidateKeys(ctx, auth, []string{keyID}); err != nil {
 		return fmt.Errorf("failed to invalidate Elasticsearch API key %s: %w", truncateID(keyID, 8), err)
@@ -373,7 +483,15 @@ func (d *ElasticDriver) Cleanup(_ context.Context) error {
 func (d *ElasticDriver) VerifySpec(ctx context.Context, _ *credential.CredSpec) error {
 	d.configMu.RLock()
 	auth := d.authSnapshotLocked()
+	chained := d.isChainedLocked()
 	d.configMu.RUnlock()
+
+	// A chained source holds no key to verify — it is fetched per mint, as the
+	// caller, and there is no caller here. Reporting a missing api_key would
+	// describe config that is absent on purpose.
+	if chained {
+		return nil
+	}
 
 	if _, err := d.verifyAuthenticationWith(ctx, auth); err != nil {
 		return fmt.Errorf("Elasticsearch spec verification failed: %w", err)
@@ -391,6 +509,11 @@ func (d *ElasticDriver) VerifySpec(ctx context.Context, _ *credential.CredSpec) 
 func (d *ElasticDriver) SupportsRotation() bool {
 	d.configMu.RLock()
 	defer d.configMu.RUnlock()
+	// A chained source holds no key of its own: it lives at its source of truth,
+	// and whoever owns the referenced spec rotates it there.
+	if d.isChainedLocked() {
+		return false
+	}
 	return d.sourceAPIKeyID != ""
 }
 
@@ -534,6 +657,91 @@ func (d *ElasticDriver) CleanupRotation(ctx context.Context, cleanupConfig map[s
 // ============================================================================
 // Helpers
 // ============================================================================
+
+// isChained reports whether this source fetches its cluster key per mint rather
+// than holding one.
+func (d *ElasticDriver) isChained() bool {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return d.isChainedLocked()
+}
+
+// isChainedLocked is isChained for callers already holding configMu. Read locks
+// are not reentrant, so the two cannot be collapsed.
+func (d *ElasticDriver) isChainedLocked() bool {
+	return credential.GetString(d.credSource.Config, credential.ConfigSecretSpec, "") != ""
+}
+
+// resolveChainedElasticAuth turns fetched secret material into the credential a
+// request authenticates with.
+//
+// Elasticsearch hands a key out in two shapes and vaults store both: the
+// pre-encoded base64 of "id:api_key" that the cluster returns as `encoded`, and
+// the raw `api_key` half beside its `id`. Both are accepted, and which one is
+// present decides how the value is read — deliberately, rather than by testing
+// whether the value happens to base64-decode.
+//
+// That sniff is the tempting version and it is wrong: a raw half that decodes to
+// bytes containing a colon would be used verbatim with a garbage id, draw a 401,
+// and be reported as a stale secret — evicting a good cached entry and retrying
+// to no purpose. It reads as safe today only because Elasticsearch's raw halves
+// are unpadded base64url that the padded decoders reject, which is a property of
+// the cluster's current key length and not something to depend on.
+func resolveChainedElasticAuth(baseURL string, material credential.SecretMaterial) (elasticAuth, error) {
+	secret := material.Secret()
+
+	// Fall back to conventional names ONLY when no field was resolved. A field
+	// that resolved to nothing is a misconfigured secret_field — say so, rather
+	// than silently authenticating with some other value from the payload.
+	if secret == "" && material.Field == "" {
+		if secret = material.Data["api_key"]; secret == "" {
+			secret = material.Data["encoded"]
+		}
+	}
+	if secret == "" {
+		if material.Field != "" {
+			return elasticAuth{}, fmt.Errorf("elastic: %s %q is empty or absent in the fetched secret material: %w",
+				credential.ConfigSecretField, material.Field, credential.ErrChainedSecretIncomplete)
+		}
+		return elasticAuth{}, fmt.Errorf("elastic: no api key in fetched secret material (set %s, or store it under 'api_key' or 'encoded'): %w",
+			credential.ConfigSecretField, credential.ErrChainedSecretIncomplete)
+	}
+
+	// secret_field names the key, so pointing it at the id is a misconfiguration
+	// with a confusing failure: the id would be presented as the key, the cluster
+	// would answer 401, and that reads on this path as a stale secret.
+	if material.Field == "id" || material.Field == "api_key_id" {
+		return elasticAuth{}, fmt.Errorf("elastic: %s must name the api key, not %q; the id is read by name alongside it",
+			credential.ConfigSecretField, material.Field)
+	}
+
+	id := material.Data["id"]
+	if id == "" {
+		id = material.Data["api_key_id"]
+	}
+
+	if id != "" {
+		// An id travels with the key. If the value already encodes that same id it
+		// is the pre-encoded form and is used as it stands; otherwise it is the raw
+		// half and the pair is encoded here.
+		if decoded, err := decodeElasticAPIKeyID(secret); err == nil && decoded == id {
+			return elasticAuth{baseURL: baseURL, encoded: secret}, nil
+		}
+		return elasticAuth{
+			baseURL: baseURL,
+			encoded: base64.StdEncoding.EncodeToString([]byte(id + ":" + secret)),
+		}, nil
+	}
+
+	// With no id beside it, the value can only be the pre-encoded form — a raw
+	// half alone is not enough to authenticate with, and guessing is what this
+	// function exists to avoid.
+	if _, err := decodeElasticAPIKeyID(secret); err != nil {
+		return elasticAuth{}, fmt.Errorf("elastic: the fetched secret is not a pre-encoded api key and no id travels with it; store the pre-encoded 'encoded' value, or store the raw key beside its 'id': %w",
+			credential.ErrChainedSecretIncomplete)
+	}
+	return elasticAuth{baseURL: baseURL, encoded: secret}, nil
+}
 
 // warn logs a recoverable problem, if this driver has a logger at all. The
 // best-effort paths below — a sweep that could not list, an invalidation the

--- a/credential/drivers/elastic_driver_test.go
+++ b/credential/drivers/elastic_driver_test.go
@@ -395,13 +395,27 @@ func TestElasticDriver_Cleanup(t *testing.T) {
 }
 
 func TestElasticDriver_SupportsRotation(t *testing.T) {
+	newDriver := func(config map[string]string, keyID string) *ElasticDriver {
+		return &ElasticDriver{
+			credSource:     &credential.CredSource{Type: credential.SourceTypeElastic, Config: config},
+			sourceAPIKeyID: keyID,
+		}
+	}
+
 	t.Run("true when sourceAPIKeyID is set", func(t *testing.T) {
-		d := &ElasticDriver{sourceAPIKeyID: "key-123"}
+		d := newDriver(map[string]string{"api_key": "k"}, "key-123")
 		assert.True(t, d.SupportsRotation())
 	})
 
 	t.Run("false when sourceAPIKeyID is empty", func(t *testing.T) {
-		d := &ElasticDriver{}
+		d := newDriver(map[string]string{}, "")
+		assert.False(t, d.SupportsRotation())
+	})
+
+	// A chained source holds no key of its own to rotate: it lives at its source
+	// of truth, and whoever owns the referenced spec rotates it there.
+	t.Run("false when the cluster key is chained", func(t *testing.T) {
+		d := newDriver(map[string]string{credential.ConfigSecretSpec: "es-key"}, "key-123")
 		assert.False(t, d.SupportsRotation())
 	})
 }
@@ -908,7 +922,13 @@ func TestElasticDriver_RequestIncludesApiKeyHeader(t *testing.T) {
 // ============================================================================
 
 func TestElasticDriver_ConcurrentSupportsRotation(t *testing.T) {
-	d := &ElasticDriver{sourceAPIKeyID: "key-123"}
+	d := &ElasticDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeElastic,
+			Config: map[string]string{"api_key": "k"},
+		},
+		sourceAPIKeyID: "key-123",
+	}
 
 	done := make(chan bool, 10)
 	for i := 0; i < 10; i++ {
@@ -1239,4 +1259,291 @@ func TestElasticDriver_MintCredential_ReturnsKeyMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, metadata, "the audit record should name the key that was created")
 	assert.Equal(t, "new-key-id-123", metadata["key_id"])
+}
+
+// ============================================================================
+// Credential chaining
+// ============================================================================
+
+func newChainedElasticDriver(t *testing.T, serverURL string) *ElasticDriver {
+	t.Helper()
+	return &ElasticDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeElastic,
+			Config: map[string]string{
+				"elastic_url":                serverURL,
+				credential.ConfigSecretSpec:  "es-cluster-key",
+				credential.ConfigSecretField: "api_key",
+			},
+		},
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+func TestElasticDriverFactory_ValidateConfig_Chained(t *testing.T) {
+	f := &ElasticDriverFactory{}
+
+	t.Run("a chained source needs no api_key", func(t *testing.T) {
+		require.NoError(t, f.ValidateConfig(map[string]string{
+			"elastic_url":               "https://elastic.example.com",
+			credential.ConfigSecretSpec: "es-cluster-key",
+		}))
+	})
+
+	// Keeping the key would leave a source that reads as keyless while storing
+	// the very secret chaining removes.
+	t.Run("api_key beside secret_spec is refused", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"elastic_url":               "https://elastic.example.com",
+			"api_key":                   testEncodedAPIKey("id1", "secret"),
+			credential.ConfigSecretSpec: "es-cluster-key",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be omitted")
+	})
+
+	// The id is derived from the key; one kept here beside a fetched key would
+	// name one key while presenting another's.
+	t.Run("api_key_id beside secret_spec is refused", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{
+			"elastic_url":               "https://elastic.example.com",
+			"api_key_id":                "id1",
+			credential.ConfigSecretSpec: "es-cluster-key",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "api_key_id must be omitted")
+	})
+
+	t.Run("api_key is still required without secret_spec", func(t *testing.T) {
+		err := f.ValidateConfig(map[string]string{"elastic_url": "https://elastic.example.com"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "api_key is required")
+	})
+}
+
+// A chained source has no key to probe with and no caller to fetch one as, so
+// construction must not reach the cluster at all.
+func TestElasticDriverFactory_Create_ChainedMakesNoRequest(t *testing.T) {
+	var reached int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached++
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	f := &ElasticDriverFactory{}
+
+	driver, err := f.Create(map[string]string{
+		"elastic_url":               srv.URL,
+		credential.ConfigSecretSpec: "es-cluster-key",
+	}, log)
+	require.NoError(t, err)
+	require.NotNil(t, driver)
+	assert.Zero(t, reached, "creating a chained source must not authenticate")
+}
+
+func TestResolveChainedElasticAuth(t *testing.T) {
+	const id = "source-key-id"
+	const raw = "raw-api-key-half"
+	encoded := testEncodedAPIKey(id, raw)
+
+	t.Run("pre-encoded value with no id beside it", func(t *testing.T) {
+		auth, err := resolveChainedElasticAuth("https://es", credential.SecretMaterial{
+			Data:  map[string]string{"api_key": encoded},
+			Field: "api_key",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, encoded, auth.encoded)
+	})
+
+	t.Run("raw half composed with the id beside it", func(t *testing.T) {
+		auth, err := resolveChainedElasticAuth("https://es", credential.SecretMaterial{
+			Data:  map[string]string{"api_key": raw, "id": id},
+			Field: "api_key",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, encoded, auth.encoded, "the pair should be encoded here")
+	})
+
+	t.Run("pre-encoded value that already carries the id beside it", func(t *testing.T) {
+		auth, err := resolveChainedElasticAuth("https://es", credential.SecretMaterial{
+			Data:  map[string]string{"api_key": encoded, "id": id},
+			Field: "api_key",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, encoded, auth.encoded, "already encoded, so used as it stands")
+	})
+
+	t.Run("api_key_id is accepted as the id's name", func(t *testing.T) {
+		auth, err := resolveChainedElasticAuth("https://es", credential.SecretMaterial{
+			Data:  map[string]string{"api_key": raw, "api_key_id": id},
+			Field: "api_key",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, encoded, auth.encoded)
+	})
+
+	// The classification must not rest on whether a value happens to decode. A
+	// raw half that decodes to something with a colon would otherwise be sent
+	// verbatim with a garbage id, draw a 401, and be misread as a stale secret.
+	t.Run("a raw half that decodes to id:key shape is still composed", func(t *testing.T) {
+		decoyRaw := testEncodedAPIKey("someone-else", "value")
+		auth, err := resolveChainedElasticAuth("https://es", credential.SecretMaterial{
+			Data:  map[string]string{"api_key": decoyRaw, "id": id},
+			Field: "api_key",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, testEncodedAPIKey(id, decoyRaw), auth.encoded,
+			"the id beside it says this is the raw half, whatever it decodes to")
+	})
+
+	t.Run("conventional names when no field was resolved", func(t *testing.T) {
+		auth, err := resolveChainedElasticAuth("https://es", credential.SecretMaterial{
+			Data: map[string]string{"encoded": encoded},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, encoded, auth.encoded)
+	})
+
+	// A field that resolved to nothing is a misconfigured secret_field. Falling
+	// back would silently authenticate with some other value from the payload.
+	t.Run("a resolved-but-empty field is reported, not worked around", func(t *testing.T) {
+		_, err := resolveChainedElasticAuth("https://es", credential.SecretMaterial{
+			Data:  map[string]string{"wrong_name": encoded},
+			Field: "api_key",
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+		assert.Contains(t, err.Error(), "secret_field")
+	})
+
+	t.Run("secret_field naming the id is refused", func(t *testing.T) {
+		_, err := resolveChainedElasticAuth("https://es", credential.SecretMaterial{
+			Data:  map[string]string{"id": id, "api_key": raw},
+			Field: "id",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must name the api key")
+	})
+
+	t.Run("a raw half with no id is incomplete", func(t *testing.T) {
+		_, err := resolveChainedElasticAuth("https://es", credential.SecretMaterial{
+			Data:  map[string]string{"api_key": raw},
+			Field: "api_key",
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+	})
+
+	t.Run("empty material is incomplete", func(t *testing.T) {
+		_, err := resolveChainedElasticAuth("https://es", credential.SecretMaterial{
+			Data: map[string]string{},
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+	})
+}
+
+func TestElasticDriver_MintFromSecret(t *testing.T) {
+	var sawAuth string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_security/api_key", func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":         "minted-key",
+			"name":       "warden-chained",
+			"encoded":    testEncodedAPIKey("minted-key", "minted-secret"),
+			"expiration": time.Now().Add(time.Hour).UnixMilli(),
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	d := newChainedElasticDriver(t, srv.URL)
+
+	rawData, _, ttl, leaseID, err := d.MintFromSecret(context.TODO(),
+		&credential.CredSpec{Name: "chained-spec", Config: map[string]string{}},
+		credential.SecretMaterial{
+			Data:  map[string]string{"api_key": testEncodedAPIKey("cluster-id", "cluster-secret")},
+			Field: "api_key",
+		})
+	require.NoError(t, err)
+
+	assert.Equal(t, "ApiKey "+testEncodedAPIKey("cluster-id", "cluster-secret"), sawAuth,
+		"the fetched key is what authenticates the create")
+	assert.Equal(t, testEncodedAPIKey("minted-key", "minted-secret"), rawData["api_key"])
+	assert.Equal(t, "elastic:minted-key", leaseID)
+	assert.Positive(t, ttl)
+}
+
+// A refusal on the chained path marks the fetched key as stale so the minting
+// layer evicts what it cached and retries once. An inline source has nothing to
+// evict, so it must not carry the marker.
+func TestElasticDriver_MintFromSecret_MarksRejectedKey(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_security/api_key", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	spec := &credential.CredSpec{Name: "chained-spec", Config: map[string]string{}}
+
+	d := newChainedElasticDriver(t, srv.URL)
+	_, _, _, _, err := d.MintFromSecret(context.TODO(), spec, credential.SecretMaterial{
+		Data:  map[string]string{"api_key": testEncodedAPIKey("cluster-id", "stale")},
+		Field: "api_key",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, credential.ErrChainedSecretRejected)
+
+	inline := newTestElasticDriver(t, srv.URL)
+	_, _, _, _, err = inline.MintCredential(context.TODO(), spec)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected,
+		"an inline source has no fetched secret to evict")
+}
+
+// A chained spec routes through MintFromSecret. Reaching MintCredential means
+// that routing was bypassed, and there is no inline key here to fall back to.
+func TestElasticDriver_MintCredential_RefusesChained(t *testing.T) {
+	d := newChainedElasticDriver(t, "https://unused.example.com")
+
+	_, _, _, _, err := d.MintCredential(context.TODO(),
+		&credential.CredSpec{Name: "chained-spec", Config: map[string]string{}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential chaining")
+}
+
+// Revocation runs at lease expiry, where a chained source has neither a stored
+// key to authorise the delete nor a caller to walk the chain with. Returning an
+// error would only buy a week of retries for a request that cannot succeed.
+func TestElasticDriver_Revoke_ChainedIsANoOp(t *testing.T) {
+	var reached int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := newChainedElasticDriver(t, srv.URL)
+
+	require.NoError(t, d.Revoke(context.TODO(), "elastic:minted-key"))
+	assert.Zero(t, reached, "there is nothing to revoke with")
+}
+
+func TestElasticDriver_VerifySpec_ChainedIsANoOp(t *testing.T) {
+	var reached int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		reached++
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	d := newChainedElasticDriver(t, srv.URL)
+
+	require.NoError(t, d.VerifySpec(context.TODO(), &credential.CredSpec{Name: "s"}))
+	assert.Zero(t, reached, "a chained source holds no key to verify")
 }

--- a/credential/types/api_key.go
+++ b/credential/types/api_key.go
@@ -244,11 +244,21 @@ func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType str
 		return err
 	}
 
-	// Credential chaining is only meaningful for the apikey source, whose key is
-	// otherwise stored inline in the spec. The other source types fetch the key from
-	// their own backend (Vault KV / Secrets Manager), and local has no keyless path —
-	// reject secret_spec there rather than letting it fail late at mint time.
+	// Credential chaining at the SPEC level is only meaningful for the apikey
+	// source, whose key is otherwise stored inline in the spec. The store-backed
+	// sources fetch the key from their own backend, and local has no keyless path
+	// — reject secret_spec there rather than letting it fail late at mint time.
+	//
+	// An elastic source does chain, but the secret being chained is the cluster
+	// key that authenticates the source's own Security API calls, not this
+	// credential — so it belongs on the source, and a spec-level reference would
+	// leave the source's own setting unused at mint. Say which, since "not
+	// supported" would be false.
 	if config[credential.ConfigSecretSpec] != "" && sourceType != credential.SourceTypeAPIKey {
+		if sourceType == credential.SourceTypeElastic {
+			return fmt.Errorf("for an elastic source, set %s on the source (the chained api key authenticates the source's own Security API calls), not on the spec",
+				credential.ConfigSecretSpec)
+		}
 		return fmt.Errorf("secret_spec (credential chaining) is not supported with a %s source", sourceType)
 	}
 

--- a/credential/types/api_key_test.go
+++ b/credential/types/api_key_test.go
@@ -198,6 +198,16 @@ func TestAPIKeyCredType_ValidateConfig(t *testing.T) {
 			errMsg:     "role_descriptors",
 		},
 		{
+			// elastic chains at the source, not the spec: the fetched key
+			// authenticates the source's own Security API calls. "not supported"
+			// would be false, so the message says where it belongs.
+			name:       "elastic source - spec-level secret_spec points at the source",
+			config:     map[string]string{credential.ConfigSecretSpec: "es-cluster-key"},
+			sourceType: credential.SourceTypeElastic,
+			wantErr:    true,
+			errMsg:     "set secret_spec on the source",
+		},
+		{
 			name:       "grafana source - no api_key required",
 			config:     map[string]string{"role": "Viewer"},
 			sourceType: credential.SourceTypeGrafana,


### PR DESCRIPTION
An elastic source held the privileged cluster API key in its own config, which is the shape chaining exists to remove. It can now name a spec that yields that key instead, and Warden fetches it per mint as the calling agent, spends it on one Security API call and keeps nothing — the same conversion scaleway, ovh, ibm and github have already had. This moves `elastic` to **Keyless: chaining** in the driver matrix.

**Chaining is a source concern here**, as it is for gitlab and oauth2: the fetched key authenticates the driver's own calls rather than being the credential a spec serves. There is one mint method and no second reading of the material, so a spec-level reference means nothing, and it is refused with the guidance to move it to the source rather than accepted and then unused at mint. The `api_key` type says so first; the store arm holds when the type registry is unavailable.

**The material is read in the two shapes a vault stores an Elasticsearch key in**: the pre-encoded base64 of `id:api_key` the cluster returns as `encoded`, and the raw key half beside its `id`. Which shape it is, is decided by whether an id travels with it — not by testing whether the value happens to base64-decode.

That sniff is the version that looks obvious and is wrong: a raw half decoding to bytes with a colon would be sent verbatim with a garbage id, draw a 401, and be reported as a stale secret, evicting a good cached entry and retrying to no purpose. It reads as safe today only because Elasticsearch's raw halves are unpadded base64url that the padded decoders reject, which is a property of the current key length rather than a guarantee. A `secret_field` that resolved to nothing is reported instead of worked around, and one pointed at the id is refused outright, since presenting the id as the key produces exactly that misread 401.

**A chained source is refused both an `api_key` and an `api_key_id`.** The key because keeping it leaves a source that reads as keyless while storing the secret chaining removes; the id because it is derived from the key, and one kept beside a fetched key would name one key while presenting another's. Neither has a use: the id serves rotation cleanup, and a chained source does not rotate — `SupportsRotation` says so, the key lives at its source of truth, and whoever owns the referenced spec rotates it there.

Construction makes no request when chained, since there is no key to probe with and no caller to fetch one as, and `VerifySpec` is a no-op for the same reason: demanding an `api_key` would report config that is absent on purpose as broken.

**Revocation is where this costs something.** A chained mint still hands out a lease, but revocation runs at lease expiry, with no stored key to authorise the delete and no caller to walk the chain with — and that will never change, so it warns and returns rather than sending the expiration manager into a daily retry for a request that cannot succeed. What bounds those keys instead is their expiration, which the driver defaults to 1h and now refuses to leave empty.

A cluster refusal on the chained path is marked so the minting layer evicts the key it cached and retries once with a fresh read. Only on that path: an inline source has no fetched secret to evict, and marking it would send it round a loop that cannot change the outcome.

**Usage.**

```bash
warden cred source create es-prod -json '{
  "type":"elastic",
  "config":{"elastic_url":"https://my-cluster.es.us-east-1.aws.cloud.es.io",
            "secret_spec":"es-key-in-vault",
            "secret_field":"api_key",
            "secret_cache_ttl":"30m"}}'
```

**Verification.** Unit suite and `-race` green; full e2e suite green.

Second of three. Stacked on #569 — review that first; this diff is against it. `test/e2e-elastic-source` stacks on this.