### PR TITLE
test(e2e): drive the elastic source driver end to end, both paths

### DIFF
--- a/e2e/fullchain/elastic_chaining_test.go
+++ b/e2e/fullchain/elastic_chaining_test.go
@@ -4,14 +4,9 @@ package fullchain
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
-	"time"
 
 	h "github.com/stephnangue/warden/e2e/helpers"
 )
@@ -26,9 +21,9 @@ import (
 // fresh cluster key rather than serving a stored one — so a spec-level reference
 // means nothing and is refused, with the guidance to move it to the source.
 //
-// These rows are also the first end-to-end exercise of the elastic source driver
-// at all. The mount in elastic_test.go drives the *provider* off a local source,
-// which never reaches this code.
+// The inline half of this driver is next door in elastic_source_test.go. Neither
+// is reached by the mount in elastic_test.go, which drives the *provider* off a
+// local source and never enters the driver at all.
 
 const (
 	// Written to secret/data/e2e/elastic-cluster-key and -pair by setup.sh, in
@@ -52,81 +47,6 @@ const (
 // cluster as exactly this, which is what makes the two rows below comparable.
 var elasticChainedClusterEncoded = base64.StdEncoding.EncodeToString(
 	[]byte(elasticChainedClusterID + ":" + elasticChainedClusterKey))
-
-// elasticMintedFor derives the key the stub issues from the cluster key that
-// authenticated the create. Deriving rather than returning a constant is what
-// carries "which secret was spent" all the way to the header the gateway
-// injects — a fixed value would look identical whichever key performed the call.
-func elasticMintedFor(clusterKey string) string {
-	return base64.StdEncoding.EncodeToString([]byte("fc-es-minted:" + clusterKey))
-}
-
-// elasticClusterStub serves the one Security API call a mint makes, and records
-// which cluster key was presented so a row can assert what was actually spent
-// rather than inferring it from the injected header alone.
-type elasticClusterStub struct {
-	*httptest.Server
-
-	mu        sync.Mutex
-	presented []string
-}
-
-func (s *elasticClusterStub) record(key string) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.presented = append(s.presented, key)
-}
-
-func (s *elasticClusterStub) observed() []string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return append([]string(nil), s.presented...)
-}
-
-func startElasticClusterStub(t *testing.T) *elasticClusterStub {
-	t.Helper()
-
-	stub := &elasticClusterStub{}
-	mux := http.NewServeMux()
-
-	mux.HandleFunc("/_security/api_key", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
-		}
-		clusterKey, ok := strings.CutPrefix(r.Header.Get("Authorization"), "ApiKey ")
-		if !ok || clusterKey == "" {
-			http.Error(w, "missing ApiKey credential", http.StatusUnauthorized)
-			return
-		}
-
-		var body map[string]interface{}
-		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-			http.Error(w, "bad json", http.StatusBadRequest)
-			return
-		}
-		// A key created without an expiration never expires, and nothing revokes a
-		// chained mint's key at lease end — so refuse here too. A cluster that
-		// accepted it would let that regression pass as a green row.
-		if exp, _ := body["expiration"].(string); exp == "" {
-			http.Error(w, "refusing to create a key with no expiration", http.StatusBadRequest)
-			return
-		}
-
-		stub.record(clusterKey)
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"id":         "fc-es-minted",
-			"name":       body["name"],
-			"encoded":    elasticMintedFor(clusterKey),
-			"expiration": time.Now().Add(time.Hour).UnixMilli(),
-		})
-	})
-
-	stub.Server = httptest.NewServer(mux)
-	t.Cleanup(stub.Close)
-	return stub
-}
 
 func elasticMustWrite(t *testing.T, method, path, body, what string) {
 	t.Helper()

--- a/e2e/fullchain/elastic_chaining_test.go
+++ b/e2e/fullchain/elastic_chaining_test.go
@@ -37,6 +37,7 @@ const (
 	// setup before it reaches the cleanup that would have cleared it.
 	elasticEncodedSecretSpec = "fc-es-key-from-vault"
 	elasticPairSecretSpec    = "fc-es-pair-from-vault"
+	elasticOddSecretSpec     = "fc-es-odd-from-vault"
 	elasticChainSource       = "fc-es-keyless-src"
 	elasticChainSpec         = "fc-es-chain-cred"
 	elasticChainAgentRole    = "fc-es-chain-agent"
@@ -75,7 +76,7 @@ func elasticMustRefuse(t *testing.T, path, body, wantIn, what string) {
 // setupElasticChain stands up one chain: a referenced spec over the given Vault
 // secret, a source holding no key that names it, an ordinary spec, and a role
 // selecting that spec.
-func setupElasticChain(t *testing.T, subj scalewaySubject, secretSpec, secretPath, secretField string, stub *elasticClusterStub) {
+func setupElasticChain(t *testing.T, subj scalewaySubject, secretSpec, secretPath, secretField, keyMap string, stub *elasticClusterStub) {
 	t.Helper()
 
 	// The referenced spec is minted as the calling agent, and both subjects derive
@@ -93,10 +94,17 @@ func setupElasticChain(t *testing.T, subj scalewaySubject, secretSpec, secretPat
 	clear()
 	t.Cleanup(clear)
 
-	elasticMustWrite(t, "POST", "sys/cred/specs/"+secretSpec, fmt.Sprintf(`{
-		"type":"key_value","source":%q,"config":{
-			"mint_method":"kv2_read","kv2_mount":"secret","secret_path":%q,
-			"subject_token_source":%q}}`, subj.source, secretPath, subj.name),
+	// json_key_map projects the stored payload before it ever reaches the elastic
+	// driver. It is a kv2_read concern, not an elastic one — an elastic spec is
+	// refused the key outright — which is exactly why the projection has to happen
+	// on the referenced spec.
+	refCfg := fmt.Sprintf(`"mint_method":"kv2_read","kv2_mount":"secret","secret_path":%q,"subject_token_source":%q`,
+		secretPath, subj.name)
+	if keyMap != "" {
+		refCfg += fmt.Sprintf(`,"json_key_map":%q`, keyMap)
+	}
+	elasticMustWrite(t, "POST", "sys/cred/specs/"+secretSpec,
+		fmt.Sprintf(`{"type":"key_value","source":%q,"config":{%s}}`, subj.source, refCfg),
 		"create the referenced secret spec "+secretSpec)
 
 	// No api_key and no api_key_id: validation refuses a source that keeps either
@@ -136,16 +144,23 @@ func TestElasticChaining_SourceFetchesTheClusterKeyPerRequest(t *testing.T) {
 		secretSpec string
 		secretPath string
 		field      string
+		keyMap     string
 	}{
-		{"pre_encoded", elasticEncodedSecretSpec, "e2e/elastic-cluster-key", "encoded"},
-		{"raw_half_beside_its_id", elasticPairSecretSpec, "e2e/elastic-cluster-pair", "api_key"},
+		{"pre_encoded", elasticEncodedSecretSpec, "e2e/elastic-cluster-key", "encoded", ""},
+		{"raw_half_beside_its_id", elasticPairSecretSpec, "e2e/elastic-cluster-pair", "api_key", ""},
+		// Stored under names the driver does not look for. secret_field renames
+		// only the single secret, and the id is read by name — so this payload is
+		// unusable until the referenced spec projects it, which makes json_key_map
+		// the one way to rename the id. The companion field is dropped by the same
+		// projection and must never be spent as a credential.
+		{"odd_names_projected", elasticOddSecretSpec, "e2e/elastic-cluster-odd", "api_key", "key=api_key,key_id=id"},
 	}
 
 	for _, subj := range scalewaySubjects {
 		for _, shape := range shapes {
 			t.Run(subj.name+"/"+shape.name, func(t *testing.T) {
 				stub := startElasticClusterStub(t)
-				setupElasticChain(t, subj, shape.secretSpec, shape.secretPath, shape.field, stub)
+				setupElasticChain(t, subj, shape.secretSpec, shape.secretPath, shape.field, shape.keyMap, stub)
 				upstream.Reset()
 
 				status, body, _ := h.ChainRequest(t, leaderPort, elasticEnv, h.ChainOpts{
@@ -193,7 +208,7 @@ func TestElasticChaining_PlacementAndShapeAreEnforced(t *testing.T) {
 
 	stub := startElasticClusterStub(t)
 	setupElasticChain(t, scalewaySubjects[0], elasticEncodedSecretSpec,
-		"e2e/elastic-cluster-key", "encoded", stub)
+		"e2e/elastic-cluster-key", "encoded", "", stub)
 
 	t.Run("a spec may not carry a reference of its own", func(t *testing.T) {
 		elasticMustRefuse(t, "sys/cred/specs/fc-es-spec-chained",
@@ -242,4 +257,54 @@ func TestElasticChaining_InlineSourceStillNeedsAKey(t *testing.T) {
 		fmt.Sprintf(`{"type":"elastic","config":{"elastic_url":%q,"tls_skip_verify":"true"}}`, stub.URL),
 		"api_key",
 		"a source with neither a key nor a reference")
+}
+
+// TestElasticChaining_UnprojectedPayloadIsRefusedBeforeAnyClusterCall is the
+// other half of the projected row above: the same Vault secret, the same
+// consuming source, and no json_key_map.
+//
+// It pins that the projection is load-bearing rather than incidental. Without it
+// the payload fails at the first hurdle — secret_field names api_key and the
+// stored field is called key — and would fail at the second even if it did not,
+// since the id is read by name and secret_field renames only the single secret.
+//
+// What it asserts is where the failure lands. The resolver refuses on the
+// material alone, before authenticating, so the cluster is never called: an
+// incomplete secret must not be spent as a credential to find out it was
+// incomplete. That is also what separates this from a stale-secret refusal,
+// which would have reached the cluster and been told no — and which the minting
+// layer would then retry, having evicted a perfectly good cached secret.
+func TestElasticChaining_UnprojectedPayloadIsRefusedBeforeAnyClusterCall(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startElasticClusterStub(t)
+	setupElasticChain(t, scalewaySubjects[0], elasticOddSecretSpec,
+		"e2e/elastic-cluster-odd", "api_key", "", stub)
+	stub.reset()
+	upstream.Reset()
+
+	status, body, _ := h.ChainRequest(t, leaderPort, elasticEnv, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Bearer:     h.FullChainUserJWT(t),
+		Role:       elasticChainAgentRole,
+		Path:       h.ProbePath("elastic-chained-unprojected"),
+	})
+	if status == 200 {
+		t.Fatalf("the request succeeded on a payload that carries no usable id: %s", string(body))
+	}
+	// Named specifically: any other 500 would pass a bare status check while
+	// meaning something entirely different.
+	if !strings.Contains(string(body), "chained secret material is incomplete") {
+		t.Errorf("the refusal did not name the incomplete material: %s", string(body))
+	}
+
+	if creates := stub.createdKeys(); len(creates) != 0 {
+		t.Errorf("the cluster was asked to create %d key(s) with material the driver could not resolve: %+v",
+			len(creates), creates)
+	}
+	// And nothing reached the upstream either, since there was no credential to
+	// inject.
+	if n := len(upstream.Requests()); n != 0 {
+		t.Errorf("the upstream saw %d request(s), want 0", n)
+	}
 }

--- a/e2e/fullchain/elastic_chaining_test.go
+++ b/e2e/fullchain/elastic_chaining_test.go
@@ -1,0 +1,325 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// An elastic source chains the cluster key that authenticates its own Security
+// API calls. Elasticsearch's own API-key creation has no assertion grant to
+// federate against, so as with ibm, keyless here means removing the key from
+// Warden rather than exchanging an identity for one.
+//
+// Chaining is a SOURCE concern for this driver, and only that. There is one mint
+// method and no second reading of the fetched material — every spec creates a
+// fresh cluster key rather than serving a stored one — so a spec-level reference
+// means nothing and is refused, with the guidance to move it to the source.
+//
+// These rows are also the first end-to-end exercise of the elastic source driver
+// at all. The mount in elastic_test.go drives the *provider* off a local source,
+// which never reaches this code.
+
+const (
+	// Written to secret/data/e2e/elastic-cluster-key and -pair by setup.sh, in
+	// the two shapes a vault holds an Elasticsearch key in.
+	elasticChainedClusterID  = "e2e-es-cluster-id"
+	elasticChainedClusterKey = "e2e-es-cluster-not-a-real-secret"
+
+	// Test-local, the source included, for the reason the other chained suites
+	// give: a killed run skips t.Cleanup, and a spec left hanging off a shared
+	// source would block that source from being deleted, failing the next run's
+	// setup before it reaches the cleanup that would have cleared it.
+	elasticEncodedSecretSpec = "fc-es-key-from-vault"
+	elasticPairSecretSpec    = "fc-es-pair-from-vault"
+	elasticChainSource       = "fc-es-keyless-src"
+	elasticChainSpec         = "fc-es-chain-cred"
+	elasticChainAgentRole    = "fc-es-chain-agent"
+)
+
+// elasticChainedClusterEncoded is the wire form of the cluster key: the base64
+// of "id:api_key" the cluster hands out. Both stored shapes must arrive at the
+// cluster as exactly this, which is what makes the two rows below comparable.
+var elasticChainedClusterEncoded = base64.StdEncoding.EncodeToString(
+	[]byte(elasticChainedClusterID + ":" + elasticChainedClusterKey))
+
+// elasticMintedFor derives the key the stub issues from the cluster key that
+// authenticated the create. Deriving rather than returning a constant is what
+// carries "which secret was spent" all the way to the header the gateway
+// injects — a fixed value would look identical whichever key performed the call.
+func elasticMintedFor(clusterKey string) string {
+	return base64.StdEncoding.EncodeToString([]byte("fc-es-minted:" + clusterKey))
+}
+
+// elasticClusterStub serves the one Security API call a mint makes, and records
+// which cluster key was presented so a row can assert what was actually spent
+// rather than inferring it from the injected header alone.
+type elasticClusterStub struct {
+	*httptest.Server
+
+	mu        sync.Mutex
+	presented []string
+}
+
+func (s *elasticClusterStub) record(key string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.presented = append(s.presented, key)
+}
+
+func (s *elasticClusterStub) observed() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.presented...)
+}
+
+func startElasticClusterStub(t *testing.T) *elasticClusterStub {
+	t.Helper()
+
+	stub := &elasticClusterStub{}
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/_security/api_key", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		clusterKey, ok := strings.CutPrefix(r.Header.Get("Authorization"), "ApiKey ")
+		if !ok || clusterKey == "" {
+			http.Error(w, "missing ApiKey credential", http.StatusUnauthorized)
+			return
+		}
+
+		var body map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+		// A key created without an expiration never expires, and nothing revokes a
+		// chained mint's key at lease end — so refuse here too. A cluster that
+		// accepted it would let that regression pass as a green row.
+		if exp, _ := body["expiration"].(string); exp == "" {
+			http.Error(w, "refusing to create a key with no expiration", http.StatusBadRequest)
+			return
+		}
+
+		stub.record(clusterKey)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":         "fc-es-minted",
+			"name":       body["name"],
+			"encoded":    elasticMintedFor(clusterKey),
+			"expiration": time.Now().Add(time.Hour).UnixMilli(),
+		})
+	})
+
+	stub.Server = httptest.NewServer(mux)
+	t.Cleanup(stub.Close)
+	return stub
+}
+
+func elasticMustWrite(t *testing.T, method, path, body, what string) {
+	t.Helper()
+	switch status, resp := h.APIRequest(t, method, path, leaderPort, body); status {
+	case 200, 201, 204:
+	default:
+		t.Fatalf("%s (status %d): %s", what, status, resp)
+	}
+}
+
+// elasticMustRefuse asserts a write is rejected and that the reason names what
+// the operator has to change. "not 200" would also pass for a 500, which would
+// mean something else entirely.
+func elasticMustRefuse(t *testing.T, path, body, wantIn, what string) {
+	t.Helper()
+	status, resp := h.APIRequest(t, "POST", path, leaderPort, body)
+	if status < 400 || status >= 500 {
+		t.Fatalf("%s: status %d, want a 4xx refusal (body: %s)", what, status, resp)
+	}
+	if !strings.Contains(string(resp), wantIn) {
+		t.Errorf("%s: refusal did not mention %q: %s", what, wantIn, resp)
+	}
+	t.Cleanup(func() { h.APIRequest(t, "DELETE", path, leaderPort, "") })
+}
+
+// setupElasticChain stands up one chain: a referenced spec over the given Vault
+// secret, a source holding no key that names it, an ordinary spec, and a role
+// selecting that spec.
+func setupElasticChain(t *testing.T, subj scalewaySubject, secretSpec, secretPath, secretField string, stub *elasticClusterStub) {
+	t.Helper()
+
+	// The referenced spec is minted as the calling agent, and both subjects derive
+	// that agent from an inbound JWT — agent_identity forwards it, warden_identity
+	// signs an assertion from the principal it established. This mount's default
+	// agent leg is a client certificate, which carries neither.
+	useJWTAgentLeg(t, elasticEnv)
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+elasticChainAgentRole, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+elasticChainSpec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+elasticChainSource, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+secretSpec, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	elasticMustWrite(t, "POST", "sys/cred/specs/"+secretSpec, fmt.Sprintf(`{
+		"type":"key_value","source":%q,"config":{
+			"mint_method":"kv2_read","kv2_mount":"secret","secret_path":%q,
+			"subject_token_source":%q}}`, subj.source, secretPath, subj.name),
+		"create the referenced secret spec "+secretSpec)
+
+	// No api_key and no api_key_id: validation refuses a source that keeps either
+	// while naming a chain. tls_skip_verify because the stub listens on http, the
+	// same allowance every other stubbed source in this suite takes.
+	elasticMustWrite(t, "POST", "sys/cred/sources/"+elasticChainSource, fmt.Sprintf(`{
+		"type":"elastic","config":{
+			"elastic_url":%q,"tls_skip_verify":"true",
+			"secret_spec":%q,"secret_field":%q}}`,
+		stub.URL, secretSpec, secretField),
+		"create the keyless elastic source")
+
+	// Ordinary: it inherits the chain from its source and carries no chaining
+	// config of its own, which is what source-level chaining means.
+	elasticMustWrite(t, "POST", "sys/cred/specs/"+elasticChainSpec,
+		`{"type":"api_key","source":"`+elasticChainSource+`","config":{"expiration":"1h"}}`,
+		"create the chained elastic spec")
+
+	elasticMustWrite(t, "POST", "auth/jwt/role/"+elasticChainAgentRole, `{
+		"token_policies":["`+elasticEnv.Policy()+`"],"cred_spec_name":"`+elasticChainSpec+`",
+		"user_claim":"sub","token_ttl":3600}`,
+		"create the chained agent role")
+}
+
+// TestElasticChaining_SourceFetchesTheClusterKeyPerRequest is the whole feature
+// in one row: the source stores no key, the referenced spec yields one, and the
+// key the gateway injects is the one this cluster minted for exactly that key.
+//
+// Both stored shapes are driven, and both must arrive at the cluster as the same
+// wire value — which is the point of resolving them by whether an id travels
+// alongside rather than by testing what the value decodes to.
+func TestElasticChaining_SourceFetchesTheClusterKeyPerRequest(t *testing.T) {
+	ensureEnv(t)
+
+	shapes := []struct {
+		name       string
+		secretSpec string
+		secretPath string
+		field      string
+	}{
+		{"pre_encoded", elasticEncodedSecretSpec, "e2e/elastic-cluster-key", "encoded"},
+		{"raw_half_beside_its_id", elasticPairSecretSpec, "e2e/elastic-cluster-pair", "api_key"},
+	}
+
+	for _, subj := range scalewaySubjects {
+		for _, shape := range shapes {
+			t.Run(subj.name+"/"+shape.name, func(t *testing.T) {
+				stub := startElasticClusterStub(t)
+				setupElasticChain(t, subj, shape.secretSpec, shape.secretPath, shape.field, stub)
+				upstream.Reset()
+
+				status, body, _ := h.ChainRequest(t, leaderPort, elasticEnv, h.ChainOpts{
+					AgentToken: h.GetDefaultJWT(t),
+					Bearer:     h.FullChainUserJWT(t),
+					Role:       elasticChainAgentRole,
+					Path:       h.ProbePath("elastic-chained-" + shape.name),
+				})
+				if status != 200 {
+					t.Fatalf("status %d, body %s", status, string(body))
+				}
+
+				// The stub derives what it issues from the key it was handed, so this
+				// header is the end-to-end proof that the FETCHED key performed the
+				// create — not an inline one a routing regression fell back to.
+				h.AssertChain(t, upstream, status, body, h.ChainWant{
+					Status:        200,
+					Injected:      map[string]string{"Authorization": "ApiKey " + elasticMintedFor(elasticChainedClusterEncoded)},
+					Absent:        h.AlwaysAbsent(),
+					UpstreamCalls: 1,
+				})
+
+				// And the cluster's own record agrees, which distinguishes a genuine
+				// chain from a header that merely looks right.
+				presented := stub.observed()
+				if len(presented) == 0 {
+					t.Fatal("the cluster stub saw no key creation at all")
+				}
+				for _, key := range presented {
+					if key != elasticChainedClusterEncoded {
+						t.Errorf("the create authenticated with %q, want the chained cluster key", key)
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestElasticChaining_PlacementAndShapeAreEnforced drives the refusals. A
+// reference on the spec would describe a secret the spec never spends, and a
+// source keeping a key beside a chain reads as keyless while storing the very
+// secret chaining removes.
+func TestElasticChaining_PlacementAndShapeAreEnforced(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startElasticClusterStub(t)
+	setupElasticChain(t, scalewaySubjects[0], elasticEncodedSecretSpec,
+		"e2e/elastic-cluster-key", "encoded", stub)
+
+	t.Run("a spec may not carry a reference of its own", func(t *testing.T) {
+		elasticMustRefuse(t, "sys/cred/specs/fc-es-spec-chained",
+			`{"type":"api_key","source":"`+elasticChainSource+`","config":{"secret_spec":"`+elasticEncodedSecretSpec+`"}}`,
+			"set secret_spec on the source",
+			"a spec naming its own reference")
+	})
+
+	t.Run("a chained source may not also store a cluster key", func(t *testing.T) {
+		elasticMustRefuse(t, "sys/cred/sources/fc-es-half-keyless",
+			fmt.Sprintf(`{"type":"elastic","config":{"elastic_url":%q,"tls_skip_verify":"true","secret_spec":%q,"api_key":"still-here"}}`,
+				stub.URL, elasticEncodedSecretSpec),
+			"api_key",
+			"a source keeping an inline key beside a reference")
+	})
+
+	// The id is derived from the key; one kept here beside a fetched key would
+	// name one key while presenting another's.
+	t.Run("a chained source may not keep the key id either", func(t *testing.T) {
+		elasticMustRefuse(t, "sys/cred/sources/fc-es-keeps-id",
+			fmt.Sprintf(`{"type":"elastic","config":{"elastic_url":%q,"tls_skip_verify":"true","secret_spec":%q,"api_key_id":"still-here"}}`,
+				stub.URL, elasticEncodedSecretSpec),
+			"api_key_id",
+			"a source keeping the key id beside a reference")
+	})
+
+	// A chained source holds no secret of its own, so there is nothing here to
+	// rotate — that passes to whoever owns the referenced spec.
+	t.Run("a chained source may not carry a rotation period", func(t *testing.T) {
+		elasticMustRefuse(t, "sys/cred/sources/fc-es-rotating",
+			fmt.Sprintf(`{"type":"elastic","rotation_period":3600,"config":{"elastic_url":%q,"tls_skip_verify":"true","secret_spec":%q}}`,
+				stub.URL, elasticEncodedSecretSpec),
+			"rotation_period",
+			"a chained source asking to rotate")
+	})
+}
+
+// TestElasticChaining_InlineSourceStillNeedsAKey pins the other half of the
+// dropped Required(): a source naming no chain must still be refused without a
+// key, rather than being accepted and failing at the first mint.
+func TestElasticChaining_InlineSourceStillNeedsAKey(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startElasticClusterStub(t)
+	elasticMustRefuse(t, "sys/cred/sources/fc-es-no-key",
+		fmt.Sprintf(`{"type":"elastic","config":{"elastic_url":%q,"tls_skip_verify":"true"}}`, stub.URL),
+		"api_key",
+		"a source with neither a key nor a reference")
+}

--- a/e2e/fullchain/elastic_cluster_stub_test.go
+++ b/e2e/fullchain/elastic_cluster_stub_test.go
@@ -1,0 +1,309 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// A stand-in Elasticsearch cluster, shared by the chained and inline elastic
+// suites so the two cannot drift apart in what they think a cluster does.
+//
+// It answers the three Security API calls the driver makes, and records what it
+// was asked, because most of what these rows assert is not the response — it is
+// which credential authenticated the call, and which keys were invalidated.
+
+// elasticMintedFor derives the key the stub issues from the cluster key that
+// authenticated the create. Deriving rather than returning a constant is what
+// carries "which secret was spent" all the way to the header the gateway
+// injects — a fixed value would look identical whichever key performed the call.
+func elasticMintedFor(clusterKey string) string {
+	return base64.StdEncoding.EncodeToString([]byte(elasticMintedKeyID + ":" + clusterKey))
+}
+
+const (
+	// elasticMintedKeyID is the id the stub gives every per-spec key. Fixed, so a
+	// row can name it without reading it back; the rotation keys below are the
+	// ones that need to be told apart.
+	elasticMintedKeyID = "fc-es-minted"
+
+	// elasticRotatedKeyPrefix stamps keys minted for a source rotation, which the
+	// stub tells apart by the metadata the driver sets. They need distinct ids: a
+	// rotation row asserts that the OLD key was invalidated, which is only
+	// meaningful if the new one is a different key.
+	elasticRotatedKeyPrefix = "fc-es-rotated-"
+)
+
+// elasticCreate is one recorded key creation.
+type elasticCreate struct {
+	// ClusterKey is the credential that authenticated the create — the answer to
+	// "which secret was spent".
+	ClusterKey string
+	// Body is the create request verbatim, so a row can assert the mint
+	// parameters an operator set actually reached the cluster.
+	Body map[string]interface{}
+	// MintedID is the id the stub issued for it.
+	MintedID string
+}
+
+// elasticClusterStub records what the driver asked of it. Every field is read
+// under the mutex: rotation runs on the manager's own goroutine, so a row
+// polling for its effects races the handler serving it.
+type elasticClusterStub struct {
+	*httptest.Server
+
+	mu          sync.Mutex
+	creates     []elasticCreate
+	invalidated []string
+	// batches records each invalidate call separately. A rotation invalidates
+	// twice for different reasons — the sweep reclaims orphans, then cleanup
+	// destroys the key just replaced — and only the grouping says which was
+	// which.
+	batches [][]string
+	// queryable is what the sweep's listing reports. Primed by a row that wants
+	// the sweep to find an abandoned key.
+	queryable []string
+	rotations int
+}
+
+func (s *elasticClusterStub) recordCreate(c elasticCreate) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.creates = append(s.creates, c)
+}
+
+// observed returns the cluster keys that authenticated a create, oldest first.
+func (s *elasticClusterStub) observed() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	keys := make([]string, 0, len(s.creates))
+	for _, c := range s.creates {
+		keys = append(keys, c.ClusterKey)
+	}
+	return keys
+}
+
+func (s *elasticClusterStub) createdKeys() []elasticCreate {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]elasticCreate(nil), s.creates...)
+}
+
+func (s *elasticClusterStub) invalidatedKeys() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.invalidated...)
+}
+
+// invalidateBatches returns each invalidate call as its own slice, oldest first.
+func (s *elasticClusterStub) invalidateBatches() [][]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([][]string(nil), s.batches...)
+}
+
+// reset clears the record. Standing a source and spec up already costs the
+// cluster a create and a delete — spec validation test-mints and then releases
+// the lease — so a row that means to count its own traffic starts from here.
+func (s *elasticClusterStub) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.creates = nil
+	s.invalidated = nil
+	s.batches = nil
+}
+
+// primeQueryable makes the sweep's listing report these key ids.
+func (s *elasticClusterStub) primeQueryable(ids ...string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.queryable = ids
+}
+
+// sawInvalidated reports whether the given id has been invalidated yet.
+func (s *elasticClusterStub) sawInvalidated(id string) bool {
+	for _, got := range s.invalidatedKeys() {
+		if got == id {
+			return true
+		}
+	}
+	return false
+}
+
+// awaitInvalidated waits for an id to be invalidated, and says what it did see
+// when it is not. A revocation runs on the expiration manager's timer, so there
+// is nothing to synchronise on but the effect itself.
+func (s *elasticClusterStub) awaitInvalidated(t *testing.T, id string, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if s.sawInvalidated(id) {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("key %q was never invalidated within %s; the cluster was asked to invalidate %v",
+		id, within, s.invalidatedKeys())
+}
+
+// elasticClusterKeyID reads the id half out of a pre-encoded cluster key, the
+// way the cluster itself would.
+func elasticClusterKeyID(encoded string) (string, bool) {
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", false
+	}
+	id, _, found := strings.Cut(string(raw), ":")
+	if !found || id == "" {
+		return "", false
+	}
+	return id, true
+}
+
+func startElasticClusterStub(t *testing.T) *elasticClusterStub {
+	t.Helper()
+
+	stub := &elasticClusterStub{}
+	mux := http.NewServeMux()
+
+	// The identity behind whichever key authenticated. The id is derived from the
+	// presented key rather than fixed, for two reasons: it is what makes the
+	// driver's api_key_id cross-check meaningful, and it is what lets this stub
+	// keep answering correctly after a rotation has replaced the source's key.
+	mux.HandleFunc("/_security/_authenticate", func(w http.ResponseWriter, r *http.Request) {
+		clusterKey, ok := strings.CutPrefix(r.Header.Get("Authorization"), "ApiKey ")
+		if !ok || clusterKey == "" {
+			http.Error(w, "missing ApiKey credential", http.StatusUnauthorized)
+			return
+		}
+		id, ok := elasticClusterKeyID(clusterKey)
+		if !ok {
+			http.Error(w, "credential is not a pre-encoded api key", http.StatusUnauthorized)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"username": "warden-e2e",
+			"enabled":  true,
+			"api_key":  map[string]interface{}{"id": id, "name": "warden-source"},
+		})
+	})
+
+	mux.HandleFunc("/_security/api_key", func(w http.ResponseWriter, r *http.Request) {
+		clusterKey, ok := strings.CutPrefix(r.Header.Get("Authorization"), "ApiKey ")
+		if !ok || clusterKey == "" {
+			http.Error(w, "missing ApiKey credential", http.StatusUnauthorized)
+			return
+		}
+
+		var body map[string]interface{}
+		if r.Body != nil {
+			_ = json.NewDecoder(r.Body).Decode(&body)
+		}
+
+		switch r.Method {
+		case http.MethodPost:
+			metadata, _ := body["metadata"].(map[string]interface{})
+			purpose, _ := metadata["purpose"].(string)
+
+			if purpose == "source_rotation" {
+				// A rotation key gets an id of its own, so a row asserting that the
+				// OLD key was invalidated is asserting something.
+				stub.mu.Lock()
+				stub.rotations++
+				id := fmt.Sprintf("%s%d", elasticRotatedKeyPrefix, stub.rotations)
+				stub.mu.Unlock()
+
+				stub.recordCreate(elasticCreate{ClusterKey: clusterKey, Body: body, MintedID: id})
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"id":      id,
+					"name":    body["name"],
+					"encoded": base64.StdEncoding.EncodeToString([]byte(id + ":rotated-secret")),
+				})
+				return
+			}
+
+			// A key created without an expiration never expires, and a chained mint
+			// is never revoked — so refuse one here too. A cluster that accepted it
+			// would let that regression pass as a green row.
+			if exp, _ := body["expiration"].(string); exp == "" {
+				http.Error(w, "refusing to create a key with no expiration", http.StatusBadRequest)
+				return
+			}
+
+			stub.recordCreate(elasticCreate{ClusterKey: clusterKey, Body: body, MintedID: elasticMintedKeyID})
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":         elasticMintedKeyID,
+				"name":       body["name"],
+				"encoded":    elasticMintedFor(clusterKey),
+				"expiration": time.Now().Add(time.Hour).UnixMilli(),
+			})
+
+		case http.MethodDelete:
+			ids, _ := body["ids"].([]interface{})
+			invalidated := make([]string, 0, len(ids))
+			for _, id := range ids {
+				if s, ok := id.(string); ok {
+					invalidated = append(invalidated, s)
+				}
+			}
+			stub.mu.Lock()
+			stub.invalidated = append(stub.invalidated, invalidated...)
+			stub.batches = append(stub.batches, invalidated)
+			// An invalidated key is no longer sweepable, which is what stops a
+			// second rotation from reclaiming the same one twice.
+			remaining := stub.queryable[:0:0]
+			for _, q := range stub.queryable {
+				gone := false
+				for _, done := range invalidated {
+					if q == done {
+						gone = true
+					}
+				}
+				if !gone {
+					remaining = append(remaining, q)
+				}
+			}
+			stub.queryable = remaining
+			stub.mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"invalidated_api_keys":            invalidated,
+				"previously_invalidated_api_keys": []string{},
+				"error_count":                     0,
+			})
+
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+
+	// The listing the rotation orphan sweep runs. Reports only what a row primed,
+	// so a suite that does not care about the sweep sees an empty cluster.
+	mux.HandleFunc("/_security/_query/api_key", func(w http.ResponseWriter, _ *http.Request) {
+		stub.mu.Lock()
+		found := make([]interface{}, 0, len(stub.queryable))
+		for _, id := range stub.queryable {
+			found = append(found, map[string]interface{}{"id": id, "name": "warden-source-rotated"})
+		}
+		stub.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"api_keys": found})
+	})
+
+	stub.Server = httptest.NewServer(mux)
+	t.Cleanup(stub.Close)
+	return stub
+}

--- a/e2e/fullchain/elastic_source_test.go
+++ b/e2e/fullchain/elastic_source_test.go
@@ -1,0 +1,303 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// The elastic source driver on its inline path: a source holding its own cluster
+// key, creating a scoped key per request.
+//
+// Nothing drove this code end to end before. The mount in elastic_test.go looks
+// like elastic coverage but runs off a LOCAL source, so it exercises the
+// provider's scheme dispatch and never enters the driver; the chaining suite
+// next door drives only the keyless path. What is left uncovered is most of what
+// the driver actually does: the authentication probe at source create, the mint,
+// revocation when a session ends, and the whole rotation cycle.
+
+const (
+	// The cluster key an inline source holds. Assembled rather than written out,
+	// for the reason elastic_test.go gives: a literal base64 blob of this length
+	// reads as a real credential to a secret scanner however synthetic it is.
+	elasticInlineKeyID  = "fc-es-inline-id"
+	elasticInlineSecret = "fc-es-inline-not-a-real-secret"
+
+	// Everything is test-local, the source included. A killed run skips
+	// t.Cleanup, and a spec left hanging off a shared source would block that
+	// source from being deleted, failing the next run's setup before it reaches
+	// the cleanup that would have cleared it. The rotation row needs its own for
+	// a second reason: rotation destroys keys.
+	elasticInlineSource    = "fc-es-inline-src"
+	elasticInlineSpec      = "fc-es-inline-cred"
+	elasticInlineAgentRole = "fc-es-inline-agent"
+
+	elasticRevokeSource    = "fc-es-revoke-src"
+	elasticRevokeSpec      = "fc-es-revoke-cred"
+	elasticRevokeAgentRole = "fc-es-revoke-agent"
+
+	elasticRotSource = "fc-es-rot-src"
+	elasticRotSpec   = "fc-es-rot-cred"
+
+	// The scoped key an inline spec asks for. key_name is the load-bearing one:
+	// it is also a credential field on an apikey source, so until the adjunct
+	// check learned that an elastic source spends it on the mint instead, a spec
+	// setting it was refused outright.
+	elasticSpecKeyName = "fc-es-ingest-writer"
+	elasticSpecRoles   = `{"reader":{"indices":[{"names":["logs-*"],"privileges":["read"]}]}}`
+)
+
+var elasticInlineEncoded = base64.StdEncoding.EncodeToString(
+	[]byte(elasticInlineKeyID + ":" + elasticInlineSecret))
+
+// setupElasticInlineSource stands up a source holding its own cluster key, a
+// spec naming the key to create, and a role selecting it.
+//
+// Creating the source is itself a test: validation builds the driver, which
+// authenticates against the cluster and checks that the key it configured is the
+// one the cluster says authenticated. A stub answering with a different identity
+// would fail here rather than at first use.
+func setupElasticInlineSource(t *testing.T, stub *elasticClusterStub, source, spec, role string, tokenTTL int, topLevel, extraConfig string) {
+	t.Helper()
+
+	useJWTAgentLeg(t, elasticEnv)
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+role, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+spec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+source, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	elasticMustWrite(t, "POST", "sys/cred/sources/"+source, fmt.Sprintf(`{
+		"type":"elastic"%s,"config":{
+			"elastic_url":%q,"tls_skip_verify":"true","api_key":%q%s}}`,
+		topLevel, stub.URL, elasticInlineEncoded, extraConfig),
+		"create the inline elastic source "+source)
+
+	elasticMustWrite(t, "POST", "sys/cred/specs/"+spec, fmt.Sprintf(`{
+		"type":"api_key","source":%q,"config":{
+			"key_name":%q,"expiration":"24h","role_descriptors":%q}}`,
+		source, elasticSpecKeyName, elasticSpecRoles),
+		"create the inline elastic spec "+spec)
+
+	if role != "" {
+		elasticMustWrite(t, "POST", "auth/jwt/role/"+role, fmt.Sprintf(`{
+			"token_policies":[%q],"cred_spec_name":%q,
+			"user_claim":"sub","token_ttl":%d}`,
+			elasticEnv.Policy(), spec, tokenTTL),
+			"create the inline agent role "+role)
+	}
+}
+
+// TestElasticSource_InlineMintCarriesTheSpecToTheCluster drives the inline path
+// end to end: the source authenticates with its own key, the cluster issues a
+// scoped one, and the gateway injects it.
+//
+// The assertion on the create body is the point. A spec's mint parameters are
+// the part of this driver an operator actually configures, and key_name in
+// particular could not be set at all until the adjunct check stopped treating it
+// as a credential field the source could not carry — so this row cannot pass
+// against the driver as it was.
+func TestElasticSource_InlineMintCarriesTheSpecToTheCluster(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startElasticClusterStub(t)
+	setupElasticInlineSource(t, stub, elasticInlineSource, elasticInlineSpec, elasticInlineAgentRole, 3600, "", "")
+
+	// Standing the spec up already cost the cluster a create and a delete: spec
+	// validation test-mints and then releases the lease. Start counting here.
+	stub.reset()
+	upstream.Reset()
+
+	status, body, _ := h.ChainRequest(t, leaderPort, elasticEnv, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Bearer:     h.FullChainUserJWT(t),
+		Role:       elasticInlineAgentRole,
+		Path:       h.ProbePath("elastic-inline-mint"),
+	})
+	if status != 200 {
+		t.Fatalf("status %d, body %s", status, string(body))
+	}
+
+	// The stub derives what it issues from the key that authenticated the create,
+	// so this header names the source's own key specifically.
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "ApiKey " + elasticMintedFor(elasticInlineEncoded)},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+
+	creates := stub.createdKeys()
+	if len(creates) != 1 {
+		t.Fatalf("the cluster saw %d key creations, want exactly 1: %+v", len(creates), creates)
+	}
+	got := creates[0]
+
+	if got.ClusterKey != elasticInlineEncoded {
+		t.Errorf("the create authenticated with %q, want the source's own key", got.ClusterKey)
+	}
+	if name, _ := got.Body["name"].(string); name != elasticSpecKeyName {
+		t.Errorf("created key name %q, want the spec's key_name %q", name, elasticSpecKeyName)
+	}
+	if exp, _ := got.Body["expiration"].(string); exp != "24h" {
+		t.Errorf("created key expiration %q, want the spec's 24h", exp)
+	}
+	// Sent as a JSON object, not the string the spec holds — the driver parses it
+	// before sending, and a cluster would reject the string form.
+	rd, ok := got.Body["role_descriptors"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("role_descriptors reached the cluster as %T, want a JSON object", got.Body["role_descriptors"])
+	}
+	if _, ok := rd["reader"]; !ok {
+		t.Errorf("role_descriptors did not carry the spec's role: %+v", rd)
+	}
+}
+
+// TestElasticSource_MintedKeyIsInvalidatedWhenTheSessionEnds is the row the
+// revocable change needs.
+//
+// A minted key is registered for expiry against the SESSION's lifetime, not the
+// key's own — so a role with a short token_ttl brings the revocation forward to
+// where a test can watch it. The key here asks for 24h; what ends it is the
+// agent's token running out five seconds later.
+//
+// Until api_key became revocable this lease reached nothing: the expiration
+// manager is only told about a credential the type calls revocable, so every key
+// minted for a caller outlived its session and sat at the cluster until its own
+// expiration. Without that fix this row fails by timing out, having watched a
+// cluster that was never asked to invalidate anything.
+func TestElasticSource_MintedKeyIsInvalidatedWhenTheSessionEnds(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startElasticClusterStub(t)
+	setupElasticInlineSource(t, stub, elasticRevokeSource, elasticRevokeSpec, elasticRevokeAgentRole, 5, "", "")
+
+	stub.reset()
+	upstream.Reset()
+
+	status, body, _ := h.ChainRequest(t, leaderPort, elasticEnv, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Bearer:     h.FullChainUserJWT(t),
+		Role:       elasticRevokeAgentRole,
+		Path:       h.ProbePath("elastic-inline-revoke"),
+	})
+	if status != 200 {
+		t.Fatalf("status %d, body %s", status, string(body))
+	}
+	if creates := stub.createdKeys(); len(creates) != 1 {
+		t.Fatalf("the cluster saw %d key creations, want exactly 1", len(creates))
+	}
+
+	// Nothing to synchronise on but the effect: the revocation runs on the
+	// expiration manager's own timer once the session's five seconds are up.
+	stub.awaitInvalidated(t, elasticMintedKeyID, 60*time.Second)
+
+	for _, id := range stub.invalidatedKeys() {
+		if id != elasticMintedKeyID {
+			t.Errorf("the cluster was asked to invalidate %q, which this row never minted", id)
+		}
+	}
+}
+
+// TestElasticSource_RotationStagesSweepsAndCleansUp drives a full source
+// rotation against a real cluster.
+//
+// Worth a row beyond the elastic specifics: the vault rotation row covers the
+// FAST path, where prepare and activate collapse into one job because Vault
+// reports a zero activation delay. Elastic reports a positive one, so this is
+// the staged path — prepare, persist, wait, activate, clean up — end to end.
+//
+// It also drives the orphan sweep, by priming the cluster with a rotation key an
+// earlier cycle would have abandoned. The sweep issues an authenticated bulk
+// delete, so what it is allowed to match is the whole of its safety: the live
+// key is primed as sweepable too, and the row asserts the sweep left it alone.
+func TestElasticSource_RotationStagesSweepsAndCleansUp(t *testing.T) {
+	ensureEnv(t)
+
+	const abandoned = "fc-es-abandoned-1"
+
+	stub := startElasticClusterStub(t)
+
+	// Primed before the source exists, because the source is enrolled for
+	// rotation the moment it is created and the first cycle is the one that
+	// sweeps. Both keys are listed as sweepable; only the abandoned one may be
+	// reclaimed, since the live key is excluded by id — which is what stops a
+	// sweep from destroying the credential its own source authenticates with.
+	stub.primeQueryable(abandoned, elasticInlineKeyID)
+
+	// No role: this source is here to rotate, not to serve a request.
+	setupElasticInlineSource(t, stub, elasticRotSource, elasticRotSpec, "", 0,
+		`,"rotation_period":15`, `,"activation_delay":"1s"`)
+
+	stub.reset()
+
+	// last_rotation is absent until one completes, so this waits for the field to
+	// appear rather than for a value to change.
+	deadline := time.Now().Add(120 * time.Second)
+	rotated := false
+	for time.Now().Before(deadline) {
+		readStatus, readBody := h.APIRequest(t, "GET", "sys/cred/sources/"+elasticRotSource, leaderPort, "")
+		if readStatus == 200 {
+			if last, _ := h.JSONPath(h.ParseJSON(t, readBody), "data.last_rotation").(string); last != "" {
+				rotated = true
+				break
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	if !rotated {
+		t.Fatalf("source %s never recorded a completed rotation within the deadline", elasticRotSource)
+	}
+
+	// The replacement key, stamped so an operator reading the cluster can tell
+	// what it is and which key it replaced.
+	var rotationCreate *elasticCreate
+	for i := range stub.createdKeys() {
+		c := stub.createdKeys()[i]
+		metadata, _ := c.Body["metadata"].(map[string]interface{})
+		if purpose, _ := metadata["purpose"].(string); purpose == "source_rotation" {
+			rotationCreate = &c
+			break
+		}
+	}
+	if rotationCreate == nil {
+		t.Fatalf("no key was created for the rotation; the cluster saw %+v", stub.createdKeys())
+	}
+	metadata, _ := rotationCreate.Body["metadata"].(map[string]interface{})
+	if replacing, _ := metadata["replacing"].(string); replacing != elasticInlineKeyID {
+		t.Errorf("the rotation key records replacing=%q, want the key it replaced (%q)", replacing, elasticInlineKeyID)
+	}
+	if rotationCreate.ClusterKey != elasticInlineEncoded {
+		t.Errorf("the rotation create authenticated with %q, want the key being replaced", rotationCreate.ClusterKey)
+	}
+
+	batches := stub.invalidateBatches()
+	if len(batches) == 0 {
+		t.Fatalf("the cluster was never asked to invalidate anything; a rotation should sweep and then clean up")
+	}
+
+	// The sweep runs first, at the top of prepare. It must have taken the
+	// abandoned key and left the one the source is still using.
+	sweep := batches[0]
+	if len(sweep) != 1 || sweep[0] != abandoned {
+		t.Errorf("the sweep invalidated %v, want exactly the abandoned key %q", sweep, abandoned)
+	}
+	for _, id := range sweep {
+		if id == elasticInlineKeyID {
+			t.Errorf("the sweep invalidated the key its own source authenticates with (%q)", id)
+		}
+	}
+
+	// And cleanup destroyed the key that was replaced — the point of rotating.
+	if !stub.sawInvalidated(elasticInlineKeyID) {
+		t.Errorf("the replaced key %q was never invalidated; it is still live at the cluster", elasticInlineKeyID)
+	}
+}

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -405,6 +405,24 @@ vault_api POST "secret/data/e2e/ibm-api-key" \
 vault_api POST "secret/data/e2e/ibm-cos-hmac" \
   '{"data":{"access_key_id":"E2EIBMCOSACCESSKEY00","secret_access_key":"e2e-ibm-cos-not-a-real-secret"}}'
 
+# The Elasticsearch cluster key an elastic source fetches per request instead of
+# storing. Two secrets, because the driver accepts the two shapes a vault holds
+# such a key in and chooses between them by whether an id travels alongside — a
+# branch worth driving through a real chain rather than only in unit tests.
+#
+# Pre-encoded: the base64 of "id:api_key" the cluster hands out as `encoded`,
+# which is what an operator copying from a create-key response will have.
+# Assembled with base64 rather than written out, for the reason elastic_test.go
+# gives: a literal blob of this length reads as a real credential to a secret
+# scanner however synthetic its contents.
+vault_api POST "secret/data/e2e/elastic-cluster-key" \
+  "{\"data\":{\"encoded\":\"$(printf 'e2e-es-cluster-id:e2e-es-cluster-not-a-real-secret' | base64)\"}}"
+
+# The pair shape: the raw key half beside its id, which is how a vault holds it
+# when the two were filed as separate fields.
+vault_api POST "secret/data/e2e/elastic-cluster-pair" \
+  '{"data":{"api_key":"e2e-es-cluster-not-a-real-secret","id":"e2e-es-cluster-id"}}'
+
 # Create policy for Warden-minted service tokens (read-only secrets access)
 echo "  Creating Vault policies..."
 vault_api PUT "sys/policies/acl/e2e-secrets-reader" \

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -423,6 +423,14 @@ vault_api POST "secret/data/e2e/elastic-cluster-key" \
 vault_api POST "secret/data/e2e/elastic-cluster-pair" \
   '{"data":{"api_key":"e2e-es-cluster-not-a-real-secret","id":"e2e-es-cluster-id"}}'
 
+# The same pair under names the driver does not look for, plus a companion field
+# that must never be vended. The driver reads the id by name and secret_field
+# renames only the single secret, so a payload shaped like this is unusable until
+# the referenced spec projects it with json_key_map — which is the one way to
+# rename the id, and the reason this fixture exists.
+vault_api POST "secret/data/e2e/elastic-cluster-odd" \
+  '{"data":{"key":"e2e-es-cluster-not-a-real-secret","key_id":"e2e-es-cluster-id","unrelated_field":"must-not-be-vended"}}'
+
 # Create policy for Warden-minted service tokens (read-only secrets access)
 echo "  Creating Vault policies..."
 vault_api PUT "sys/policies/acl/e2e-secrets-reader" \


### PR DESCRIPTION
The elastic source driver had never run end to end. The mount in `elastic_test.go` looks like elastic coverage but drives the *provider* off a **local** source, so it exercises the provider's scheme dispatch and never enters the driver at all — which left the mint, the authentication probe, revocation and the whole rotation cycle covered by unit tests alone.

**The chained path.** A source holding no cluster key, a referenced spec over a Vault secret, and a stub cluster that derives the key it issues from the key that authenticated the create. That derivation is what makes the assertion mean something: the header the gateway injects names the fetched key specifically, so a routing regression that fell back to an inline credential could not produce it. The stub's own record of what was presented is asserted too, which separates a genuine chain from a header that merely looks right.

Both stored shapes are driven, against the same cluster and asserted to arrive as the same wire value: the pre-encoded blob a cluster hands out, and the raw key half beside its id. That equivalence is the property the resolver exists to hold, and it is the half most likely to rot, since the alternative implementation — deciding by whether the value happens to base64-decode — passes every test that uses only one shape.

**The inline path**, and the two lifecycle events that follow a mint. A mint through the full chain asserts that the spec's parameters reached the cluster rather than only that a key came back: `key_name` is the load-bearing one, since it is also a credential field on an apikey source and a spec setting it was refused outright until the adjunct check learned that an elastic source spends it on the mint instead.

**A revocation**, which is the row the revocable change needed. A minted key is registered for expiry against the *session*'s lifetime rather than its own, so a role with a five-second token brings the revocation forward to where a test can watch it: the key asks for 24h and what ends it is the agent's token running out.

Checked against a cluster built with the change reverted, where it fails having watched a cluster that was never asked to invalidate anything. Worth saying plainly: the first attempt at that check *passed*, because `setup.sh` rebuilds the binary but does not restart already-running nodes, so the cluster was still on the pre-revert build. It very nearly went in as evidence.

**A rotation**, the first end-to-end coverage of the staged path with a real driver: the vault rotation row covers the fast path, where prepare and activate collapse into one job because Vault reports a zero activation delay. Elastic reports a positive one. The row also primes the cluster with a key an abandoned cycle would have left behind, and lists the live key as sweepable alongside it, so it asserts the sweep reclaimed the orphan and left the key its own source authenticates with — the property that bounds an authenticated bulk delete.

The stub lives in a file of its own so the two suites cannot drift in what they think a cluster does. Its `_authenticate` derives the identity from whichever key was presented rather than answering with a fixed one, which is what makes the driver's `api_key_id` cross-check mean something and what lets the same stub keep answering after a rotation has replaced the key. It also refuses a create carrying no expiration, since nothing revokes a chained mint's key at lease end and a cluster that accepted one would let that regression pass as a green row.

**Verification.** Full e2e suite green, 20/20 packages.

Third of three. Stacked on #570 — review #569 and #570 first; this diff is against #570.