### PR TITLE
feat(grafana): fetch the privileged token per request instead of storing one

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -1113,6 +1113,18 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 		}
 	}
 
+	// A grafana spec mints tokens on a service account the operator provisioned, so
+	// it must name one — its own, or the source's default. This is the layer that
+	// can see both: the credential type is handed the source's TYPE but never its
+	// config, so it validates the value's shape and cannot check that a value
+	// exists at all. Checked here rather than left to mint time because a spec
+	// naming no account fails every request it ever serves.
+	if source.Type == credential.SourceTypeGrafana &&
+		credential.GetString(spec.Config, "service_account_id", "") == "" &&
+		credential.GetString(source.Config, "service_account_id", "") == "" {
+		return logical.ErrBadRequestf("service_account_id is required for a grafana spec: set it on the spec, or on the source as a default; Warden mints tokens on an account you provision in Grafana, it does not create one")
+	}
+
 	// Credential chaining: when this spec (spec-level, wins) or its source
 	// (source-level) references another cred spec as its secret source, validate the
 	// referenced secret-spec. The consuming driver's eligibility (it must implement
@@ -1550,6 +1562,20 @@ func (s *CredentialConfigStore) checkBoundSpecsStillCarried(ctx context.Context,
 			return logical.ErrBadRequestf(
 				"spec %q sets credential field(s) %s that this source would no longer carry: keep them in credential_fields, or remove them from the spec first",
 				spec.Name, strings.Join(missing, ", "))
+		}
+
+		// A grafana spec may take its service account from the source's default.
+		// Dropping that default is accepted by source validation on its own — the
+		// key is optional there — and would leave every silent spec failing at
+		// mint with nothing at write time having said so. The spec-level guard
+		// cannot catch it either: it runs when a SPEC is written, and nothing is
+		// being written here.
+		if source.Type == credential.SourceTypeGrafana &&
+			credential.GetString(source.Config, "service_account_id", "") == "" &&
+			credential.GetString(spec.Config, "service_account_id", "") == "" {
+			return logical.ErrBadRequestf(
+				"spec %q relies on this source's service_account_id default, which this update would remove: set service_account_id on the spec first, or keep the default",
+				spec.Name)
 		}
 	}
 	return nil

--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -1119,10 +1119,26 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 	// config, so it validates the value's shape and cannot check that a value
 	// exists at all. Checked here rather than left to mint time because a spec
 	// naming no account fails every request it ever serves.
-	if source.Type == credential.SourceTypeGrafana &&
-		credential.GetString(spec.Config, "service_account_id", "") == "" &&
-		credential.GetString(source.Config, "service_account_id", "") == "" {
-		return logical.ErrBadRequestf("service_account_id is required for a grafana spec: set it on the spec, or on the source as a default; Warden mints tokens on an account you provision in Grafana, it does not create one")
+	if source.Type == credential.SourceTypeGrafana {
+		if credential.GetString(spec.Config, "service_account_id", "") == "" &&
+			credential.GetString(source.Config, "service_account_id", "") == "" {
+			return logical.ErrBadRequestf("service_account_id is required for a grafana spec: set it on the spec, or on the source as a default; Warden mints tokens on an account you provision in Grafana, it does not create one")
+		}
+		// A chained grafana source cannot revoke — there is no caller at lease
+		// expiry to fetch its token as — so a token it mints stays live until its
+		// own expiry however the lease ended. The driver refuses an over-long one
+		// at mint; this is the same rule where an operator can act on it, at the
+		// write that introduces it. Only this layer can apply it: the credential
+		// type is handed the source's TYPE but never its config, so it cannot tell
+		// a chained source from an inline one.
+		if source.Config[credential.ConfigSecretSpec] != "" {
+			if raw := credential.GetString(spec.Config, "token_expiry", ""); raw != "" {
+				if d, err := time.ParseDuration(raw); err == nil && d > drivers.GrafanaChainedMaxTokenExpiry {
+					return logical.ErrBadRequestf("'token_expiry' %s exceeds the %s ceiling for a chained grafana source: revocation cannot run without a caller to fetch the token as, so a minted token stays live until it expires",
+						raw, drivers.GrafanaChainedMaxTokenExpiry)
+				}
+			}
+		}
 	}
 
 	// Credential chaining: when this spec (spec-level, wins) or its source
@@ -1183,6 +1199,11 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 				// this is the layer that holds when the type registry is unavailable
 				// and credType is nil — the same reason the ovh arm below exists.
 				return logical.ErrBadRequestf("for an elastic source, set secret_spec on the source (the chained api key authenticates the source's own Security API calls), not on the spec")
+			case credential.SourceTypeGrafana:
+				// Same shape as elastic: the fetched token authenticates the source's
+				// own service-account calls, and every spec on it mints a fresh token
+				// rather than serving a stored one.
+				return logical.ErrBadRequestf("for a grafana source, set secret_spec on the source (the chained token authenticates the source's own service-account calls), not on the spec")
 			}
 		}
 		// An oauth2 source that chains its client credential resolves the pair per mint,

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -2729,27 +2729,74 @@ func TestCredentialConfigStore_ValidateSpec_UpstreamMintingSources(t *testing.T)
 	require.NoError(t, types.RegisterBuiltinTypes(store.core.credentialTypeRegistry))
 	store.core.credentialDriverRegistry = nil
 
-	for _, sourceType := range []string{
-		credential.SourceTypeElastic,
-		credential.SourceTypeGrafana,
-		credential.SourceTypeHoneycomb,
+	for _, tc := range []struct {
+		sourceType string
+		// grafana mints on an account the operator provisioned, so its spec must
+		// name one; the others create the credential's container themselves.
+		specConfig map[string]string
+	}{
+		{sourceType: credential.SourceTypeElastic, specConfig: map[string]string{}},
+		{sourceType: credential.SourceTypeGrafana, specConfig: map[string]string{"service_account_id": "42"}},
+		{sourceType: credential.SourceTypeHoneycomb, specConfig: map[string]string{}},
 	} {
-		t.Run(sourceType, func(t *testing.T) {
-			source := &credential.CredSource{Name: sourceType + "-src", Type: sourceType}
+		t.Run(tc.sourceType, func(t *testing.T) {
+			source := &credential.CredSource{Name: tc.sourceType + "-src", Type: tc.sourceType}
 			require.NoError(t, store.CreateSource(ctx, source))
 
 			spec := &credential.CredSpec{
-				Name:   sourceType + "-spec",
+				Name:   tc.sourceType + "-spec",
 				Type:   credential.TypeAPIKey,
 				Source: source.Name,
 				MinTTL: 5 * time.Minute,
 				MaxTTL: 1 * time.Hour,
-				Config: map[string]string{},
+				Config: tc.specConfig,
 			}
 			require.NoError(t, store.CreateSpec(ctx, spec),
-				"a spec against a %s source must be creatable", sourceType)
+				"a spec against a %s source must be creatable", tc.sourceType)
 		})
 	}
+}
+
+// A grafana spec mints tokens on a provisioned service account, so it must name
+// one — its own, or the source's default. Only this layer sees both configs: the
+// credential type is handed the source's TYPE but never its config, so it can
+// check the value's shape and not whether a value exists at all.
+func TestCredentialConfigStore_ValidateSpec_GrafanaNeedsAServiceAccount(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+
+	store.core.credentialTypeRegistry = credential.NewTypeRegistry()
+	require.NoError(t, types.RegisterBuiltinTypes(store.core.credentialTypeRegistry))
+	store.core.credentialDriverRegistry = nil
+
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "g-bare", Type: credential.SourceTypeGrafana,
+	}))
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "g-default", Type: credential.SourceTypeGrafana,
+		Config: map[string]string{"service_account_id": "7"},
+	}))
+
+	newSpec := func(name, source string, config map[string]string) *credential.CredSpec {
+		return &credential.CredSpec{
+			Name: name, Type: credential.TypeAPIKey, Source: source,
+			MinTTL: 5 * time.Minute, MaxTTL: time.Hour, Config: config,
+		}
+	}
+
+	t.Run("neither level names an account", func(t *testing.T) {
+		err := store.CreateSpec(ctx, newSpec("g1", "g-bare", map[string]string{}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "service_account_id is required")
+	})
+
+	t.Run("the spec names one", func(t *testing.T) {
+		require.NoError(t, store.CreateSpec(ctx, newSpec("g2", "g-bare",
+			map[string]string{"service_account_id": "42"})))
+	})
+
+	t.Run("the source's default covers a silent spec", func(t *testing.T) {
+		require.NoError(t, store.CreateSpec(ctx, newSpec("g3", "g-default", map[string]string{})))
+	})
 }
 
 // An elastic spec naming the key to create must be accepted. key_name is also a
@@ -2837,5 +2884,54 @@ func TestCredentialConfigStore_ValidateSpec_ElasticChainsAtTheSource(t *testing.
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "set secret_spec on the source")
+	})
+}
+
+// Dropping a grafana source's service_account_id default strands every spec that
+// relied on it: source validation accepts the edit on its own (the key is
+// optional there), and the spec-level guard runs only when a spec is written.
+func TestCredentialConfigStore_UpdateSource_GrafanaDefaultAccountIsLoadBearing(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+
+	store.core.credentialTypeRegistry = credential.NewTypeRegistry()
+	require.NoError(t, types.RegisterBuiltinTypes(store.core.credentialTypeRegistry))
+	store.core.credentialDriverRegistry = nil
+
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "gf-default", Type: credential.SourceTypeGrafana,
+		Config: map[string]string{"admin_token": "glsa_x", "service_account_id": "42"},
+	}))
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "gf-silent", Type: credential.TypeAPIKey, Source: "gf-default",
+		MinTTL: 5 * time.Minute, MaxTTL: time.Hour, Config: map[string]string{},
+	}))
+
+	t.Run("removing the default a silent spec relies on is refused", func(t *testing.T) {
+		err := store.UpdateSource(ctx, &credential.CredSource{
+			Name: "gf-default", Type: credential.SourceTypeGrafana,
+			Config: map[string]string{"admin_token": "glsa_x"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "relies on this source's service_account_id default")
+	})
+
+	// The accepting half is not reachable here: a config change that passes
+	// validation goes on to tear the cached driver down through
+	// core.credentialManager, which this harness does not build. The e2e suite
+	// covers a spec naming its own account.
+	t.Run("a spec naming its own account does not rely on the default", func(t *testing.T) {
+		require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "gf-explicit", Type: credential.TypeAPIKey, Source: "gf-default",
+			MinTTL: 5 * time.Minute, MaxTTL: time.Hour,
+			Config: map[string]string{"service_account_id": "57"},
+		}))
+		err := store.UpdateSource(ctx, &credential.CredSource{
+			Name: "gf-default", Type: credential.SourceTypeGrafana,
+			Config: map[string]string{"admin_token": "glsa_x"},
+		})
+		// Still refused, but for gf-silent — never for gf-explicit.
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "gf-silent")
+		assert.NotContains(t, err.Error(), "gf-explicit")
 	})
 }

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -2935,3 +2935,123 @@ func TestCredentialConfigStore_UpdateSource_GrafanaDefaultAccountIsLoadBearing(t
 		assert.NotContains(t, err.Error(), "gf-explicit")
 	})
 }
+
+// A grafana source chains the privileged token that authenticates its own
+// service-account calls, so the reference belongs on the source — the same shape
+// as elastic above, and refused at this layer for the same reason: the api_key
+// type says it first, and this is what holds when the type registry is
+// unavailable and credType is nil.
+func TestCredentialConfigStore_ValidateSpec_GrafanaChainsAtTheSource(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "grafana-admin-token", Type: "vault_token", Source: "src",
+		Config: map[string]string{
+			"subject_token_source": "warden_identity",
+			"assertion_audience":   "test-aud",
+		},
+	}))
+
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "grafana-chained", Type: credential.SourceTypeGrafana,
+		Config: map[string]string{
+			credential.ConfigSecretSpec: "grafana-admin-token",
+			"service_account_id":        "42",
+		},
+	}))
+
+	t.Run("a spec on a chained source needs no reference of its own", func(t *testing.T) {
+		require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "grafana-chained-spec", Type: credential.TypeAPIKey, Source: "grafana-chained",
+			Config: map[string]string{"token_expiry": "1h"},
+		}))
+	})
+
+	t.Run("a spec-level reference is refused with guidance", func(t *testing.T) {
+		err := store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "grafana-spec-level", Type: credential.TypeAPIKey, Source: "grafana-chained",
+			Config: map[string]string{credential.ConfigSecretSpec: "grafana-admin-token"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "set secret_spec on the source")
+	})
+
+	// A chained source holds no privileged token to rotate; the referenced spec's
+	// owner rotates it at the source of truth.
+	t.Run("rotation_period on a chained source is refused", func(t *testing.T) {
+		err := store.CreateSource(ctx, &credential.CredSource{
+			Name: "grafana-chained-rotating", Type: credential.SourceTypeGrafana,
+			RotationPeriod: time.Hour,
+			Config:         map[string]string{credential.ConfigSecretSpec: "grafana-admin-token"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rotation_period does not apply to a chained source")
+	})
+
+	// The account still has to be named: chaining supplies the token that manages
+	// tokens, not the account they are minted on.
+	t.Run("a chained source still needs a service account", func(t *testing.T) {
+		require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+			Name: "grafana-chained-bare", Type: credential.SourceTypeGrafana,
+			Config: map[string]string{credential.ConfigSecretSpec: "grafana-admin-token"},
+		}))
+		err := store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "grafana-no-account", Type: credential.TypeAPIKey, Source: "grafana-chained-bare",
+			Config: map[string]string{},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "service_account_id is required")
+	})
+}
+
+// A chained grafana source cannot revoke, so a token it mints stays live until
+// its own expiry however the lease ended. The driver refuses an over-long one at
+// mint; this is the same rule at the write that introduces it, and only this
+// layer can apply it — the credential type is handed the source's TYPE but never
+// its config, so it cannot tell a chained source from an inline one.
+func TestCredentialConfigStore_ValidateSpec_GrafanaChainedTokenExpiryIsCapped(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "gf-token", Type: "vault_token", Source: "src",
+		Config: map[string]string{
+			"subject_token_source": "warden_identity",
+			"assertion_audience":   "test-aud",
+		},
+	}))
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "gf-chained", Type: credential.SourceTypeGrafana,
+		Config: map[string]string{
+			credential.ConfigSecretSpec: "gf-token",
+			"service_account_id":        "42",
+		},
+	}))
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "gf-inline", Type: credential.SourceTypeGrafana,
+		Config: map[string]string{"admin_token": "glsa_x", "service_account_id": "42"},
+	}))
+
+	spec := func(name, source, expiry string) *credential.CredSpec {
+		return &credential.CredSpec{
+			Name: name, Type: credential.TypeAPIKey, Source: source,
+			MinTTL: 5 * time.Minute, MaxTTL: time.Hour,
+			Config: map[string]string{"token_expiry": expiry},
+		}
+	}
+
+	t.Run("an over-long lifetime on a chained source is refused", func(t *testing.T) {
+		err := store.CreateSpec(ctx, spec("gf-long", "gf-chained", "720h"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ceiling for a chained grafana source")
+	})
+
+	t.Run("the same lifetime is fine inline, where revocation is precise", func(t *testing.T) {
+		require.NoError(t, store.CreateSpec(ctx, spec("gf-long-inline", "gf-inline", "720h")))
+	})
+
+	t.Run("a lifetime within the ceiling is accepted", func(t *testing.T) {
+		require.NoError(t, store.CreateSpec(ctx, spec("gf-short", "gf-chained", "1h")))
+	})
+}

--- a/credential/drivers/grafana_driver.go
+++ b/credential/drivers/grafana_driver.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/helper"
 	"github.com/stephnangue/warden/helper/httputil"
 	"github.com/stephnangue/warden/logger"
 )
@@ -23,28 +26,49 @@ const grafanaMaxRetryAttempts = 3
 // grafanaDefaultTokenExpiry is the default TTL for minted service account tokens
 const grafanaDefaultTokenExpiry = 1 * time.Hour
 
-// grafanaDefaultNamePrefix is the default prefix for minted service accounts
+// grafanaDefaultNamePrefix is the default prefix for minted token names
 const grafanaDefaultNamePrefix = "warden-"
 
-// grafanaDefaultRole is the default role for minted service accounts
-const grafanaDefaultRole = "Viewer"
+// Sweep bounds. See startSweep and sweepExpiredTokens for why each exists.
+const (
+	grafanaSweepInterval = 10 * time.Minute
+	// A sweep that could not list retries sooner than one that finished. The
+	// listing failing is the same event that breaks revocation — a token the
+	// server will not accept — so parking the account for the full interval
+	// would mute the sweep exactly when it is the only thing still working.
+	grafanaSweepRetryInterval = 1 * time.Minute
+	grafanaSweepTimeout       = 2 * time.Minute
+)
 
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*GrafanaDriver)(nil)
 var _ credential.SpecVerifier = (*GrafanaDriver)(nil)
+var _ credential.RotationConfigValidator = (*GrafanaDriverFactory)(nil)
 
-// GrafanaDriver mints credentials from the Grafana HTTP API.
+// GrafanaDriver mints tokens on a service account an operator provisioned.
 //
-// The source config holds connection info (grafana_url) and an admin service
-// account token with permissions to create/delete service accounts. Per-spec
-// config controls the role, TTL, and naming of minted service accounts.
+// The source holds connection info (grafana_url) and a privileged service-account
+// token able to manage tokens on that account. Each spec names the account its
+// credentials are issued against — service_account_id, falling back to a
+// source-level default — and the shape of the token: its lifetime, and the prefix
+// its name carries.
 //
-// MintCredential creates a temporary service account and generates a token
-// with a bounded TTL. Revoke deletes the service account (and all its tokens).
+// Warden does not create service accounts. The account is provisioned in Grafana
+// with whatever role it should have, and a minted token inherits that role, so a
+// spec cannot ask for privilege the operator did not already grant. MintCredential
+// creates one token on the named account; Revoke deletes that one token, leaving
+// the account and every other token on it untouched.
 type GrafanaDriver struct {
 	credSource *credential.CredSource
 	logger     *logger.GatedLogger
 	httpClient *http.Client
+
+	// sweepNext records the earliest each service account may be swept again,
+	// keyed by account id. Per account rather than per driver because a sweep
+	// only ever looks at one account: a single timestamp would be spent by
+	// whichever spec minted first and starve the rest.
+	sweepMu   sync.Mutex
+	sweepNext map[string]time.Time
 }
 
 // GrafanaDriverFactory creates GrafanaDriver instances
@@ -68,7 +92,12 @@ func (f *GrafanaDriverFactory) ValidateConfig(config map[string]string) error {
 
 		credential.StringField("admin_token").
 			Required().
-			Describe("Admin service account token with ServiceAccount admin permissions"),
+			Describe("Service-account token able to manage tokens on the provisioned account"),
+
+		credential.StringField("service_account_id").
+			Custom(validateGrafanaServiceAccountID).
+			Describe("Default provisioned service account that specs mint tokens on; a spec may name its own").
+			Example("42"),
 
 		credential.StringField("ca_data").
 			Custom(ValidateCAData).
@@ -84,6 +113,17 @@ func (f *GrafanaDriverFactory) SensitiveConfigFields() []string {
 	return []string{"admin_token", "ca_data"}
 }
 
+// ValidateRotationConfig refuses a rotation_period on a grafana source.
+//
+// The driver holds one long-lived privileged token that it never re-issues: it has
+// no Rotatable implementation, and Grafana offers no self-rotation for a
+// service-account token. Without this, a rotation_period is accepted at write time
+// and then fails every cycle forever, parked and retried by the rotation manager
+// and visible only in server logs — see credential.RotationConfigValidator.
+func (f *GrafanaDriverFactory) ValidateRotationConfig(_ map[string]string) error {
+	return fmt.Errorf("rotation does not apply to a grafana source; its privileged token is issued in Grafana and rotated there, so set rotation_period=0")
+}
+
 // InferCredentialType always returns api_key for Grafana sources.
 func (f *GrafanaDriverFactory) InferCredentialType(_ map[string]string) (string, error) {
 	return credential.TypeAPIKey, nil
@@ -96,7 +136,8 @@ func (f *GrafanaDriverFactory) Create(config map[string]string, log *logger.Gate
 			Type:   credential.SourceTypeGrafana,
 			Config: config,
 		},
-		logger: log.WithSubsystem(credential.SourceTypeGrafana),
+		logger:    log.WithSubsystem(credential.SourceTypeGrafana),
+		sweepNext: map[string]time.Time{},
 	}
 
 	httpClient, err := BuildHTTPClient(config, 30*time.Second)
@@ -113,129 +154,185 @@ func (d *GrafanaDriver) getGrafanaURL() string {
 	return strings.TrimRight(credential.GetString(d.credSource.Config, "grafana_url", ""), "/")
 }
 
-// getAdminToken returns the admin service account token from source config
+// getAdminToken returns the privileged service account token from source config
 func (d *GrafanaDriver) getAdminToken() string {
 	return credential.GetString(d.credSource.Config, "admin_token", "")
 }
 
-// MintCredential creates a temporary Grafana service account and token.
+// warn logs a recoverable problem, if this driver has a logger at all. The
+// best-effort paths below — a sweep that could not list, a token it could not
+// delete — report only this way, and a driver built without a logger must not turn
+// that report into a panic.
+func (d *GrafanaDriver) warn(msg string, fields ...logger.TypedField) {
+	if d.logger != nil {
+		d.logger.Warn(msg, fields...)
+	}
+}
+
+// resolveGrafanaServiceAccountID returns the account a spec mints against: its own
+// service_account_id, or the source's default.
 //
-// Flow:
-//  1. POST /api/serviceaccounts — create a service account with the specified role
-//  2. POST /api/serviceaccounts/{id}/tokens — create a token with secondsToLive
-//  3. Return {"api_key": "<token>"} with TTL matching token expiry
+// The spec wins so that one source — one Grafana, one privileged token — can serve
+// several accounts, which is how a read-only spec and an editing one coexist: the
+// account's role is the credential's privilege, so different privileges mean
+// different accounts.
+func (d *GrafanaDriver) resolveGrafanaServiceAccountID(spec *credential.CredSpec) (string, error) {
+	saID := credential.GetString(spec.Config, "service_account_id", "")
+	if saID == "" {
+		saID = credential.GetString(d.credSource.Config, "service_account_id", "")
+	}
+	if saID == "" {
+		return "", fmt.Errorf("service_account_id is required: set it on the spec, or on the source as a default; Warden mints tokens on an account you provision in Grafana, it does not create one")
+	}
+	if err := validateGrafanaServiceAccountID(saID); err != nil {
+		return "", err
+	}
+	return saID, nil
+}
+
+// MintCredential creates one token on the spec's provisioned service account.
 //
-// The leaseID is the service account ID, used for cleanup on Revoke.
+// POST /api/serviceaccounts/{id}/tokens returns the token's id alongside the key
+// itself, and that id is what the lease carries: revocation deletes the one token,
+// not the account it hangs off.
 func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	role := credential.GetString(spec.Config, "role", grafanaDefaultRole)
+	saID, err := d.resolveGrafanaServiceAccountID(spec)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+
+	// The sweep reclaims only names carrying the default prefix, so a spec whose
+	// prefix leaves that namespace would mint tokens nothing ever removes. Spec
+	// validation refuses it at write time; this holds for a spec that predates
+	// the check.
 	namePrefix := credential.GetString(spec.Config, "name_prefix", grafanaDefaultNamePrefix)
-	tokenExpiry := credential.GetDuration(spec.Config, "token_expiry", grafanaDefaultTokenExpiry)
-	orgID := credential.GetString(spec.Config, "org_id", "")
-
-	// Validate role
-	switch role {
-	case "Viewer", "Editor", "Admin":
-	default:
-		return nil, nil, 0, "", fmt.Errorf("invalid role '%s': must be Viewer, Editor, or Admin", role)
+	if !strings.HasPrefix(namePrefix, grafanaDefaultNamePrefix) {
+		return nil, nil, 0, "", fmt.Errorf("name_prefix %q must start with %q, or the tokens it names fall outside what the sweep reclaims",
+			namePrefix, grafanaDefaultNamePrefix)
 	}
 
-	// Step 1: Create a service account
-	saName := fmt.Sprintf("%s%s-%d", namePrefix, spec.Name, time.Now().UnixMilli())
-	saBody, err := json.Marshal(map[string]interface{}{
-		"name":       saName,
-		"role":       role,
-		"isDisabled": false,
-	})
-	if err != nil {
-		return nil, nil, 0, "", fmt.Errorf("failed to marshal service account request: %w", err)
+	// Parsed here rather than through credential.GetDuration, which swallows a
+	// parse error and hands back the default: "60" would mint an hour while the
+	// spec said sixty of something. Spec validation refuses that at write time,
+	// but this path is also reached by a spec that predates the check and by one
+	// written with verification skipped, which is the whole reason for re-checking.
+	tokenExpiry := grafanaDefaultTokenExpiry
+	if raw, present := spec.Config["token_expiry"]; present {
+		parsed, err := time.ParseDuration(raw)
+		if err != nil {
+			return nil, nil, 0, "", fmt.Errorf("token_expiry %q is not a duration (an integer and a unit, such as 30m or 24h)", raw)
+		}
+		tokenExpiry = parsed
 	}
 
-	saResp, _, err := d.doGrafanaRequest(ctx, http.MethodPost, "/api/serviceaccounts", saBody, orgID)
-	if err != nil {
-		return nil, nil, 0, "", fmt.Errorf("failed to create service account: %w", err)
-	}
-
-	var saResult struct {
-		ID int64 `json:"id"`
-	}
-	if err := json.Unmarshal(saResp, &saResult); err != nil {
-		return nil, nil, 0, "", fmt.Errorf("failed to parse service account response: %w", err)
-	}
-	if saResult.ID == 0 {
-		return nil, nil, 0, "", fmt.Errorf("Grafana API returned service account with ID 0")
-	}
-
-	// Step 2: Create a token for the service account
+	// Grafana reads secondsToLive=0 as "no expiration", so anything under a second
+	// truncates into a token it will never expire — carrying the account's full
+	// role.
 	secondsToLive := int64(tokenExpiry.Seconds())
-	tokenBody, err := json.Marshal(map[string]interface{}{
-		"name":          "warden-token",
+	if secondsToLive < 1 {
+		return nil, nil, 0, "", fmt.Errorf("token_expiry %s is under one second, which Grafana would read as a token that never expires; give a lifetime of 1s or more", tokenExpiry)
+	}
+
+	// Token names are unique per service account, and every spec now mints against
+	// an account it may share — so the name carries a random suffix as well as a
+	// timestamp. Two mints of the same spec in the same millisecond would otherwise
+	// collide, and the loser's error would read as a Grafana fault rather than a
+	// name clash.
+	tokenName := fmt.Sprintf("%s%s-%d-%s", namePrefix, spec.Name, time.Now().UnixMilli(), helper.GenerateRandomString(8))
+
+	body, err := json.Marshal(map[string]interface{}{
+		"name":          tokenName,
 		"secondsToLive": secondsToLive,
 	})
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("failed to marshal token request: %w", err)
 	}
 
-	tokenPath := fmt.Sprintf("/api/serviceaccounts/%d/tokens", saResult.ID)
-	tokenResp, _, err := d.doGrafanaRequest(ctx, http.MethodPost, tokenPath, tokenBody, orgID)
+	// Not retried: creating a token is not idempotent, and Grafana refuses a
+	// duplicate name on the same account. A retry after a lost response would draw
+	// that refusal and report a failed mint while the token the first attempt
+	// created stands — unknown to Warden, and unrevokable until it expires.
+	path := fmt.Sprintf("/api/serviceaccounts/%s/tokens", url.PathEscape(saID))
+	respBody, _, err := d.doGrafanaRequestWith(ctx, http.MethodPost, path, body, grafanaCreateRetryConfig)
 	if err != nil {
-		// Best-effort cleanup: delete the service account we just created
-		d.deleteServiceAccount(ctx, saResult.ID, orgID)
-		return nil, nil, 0, "", fmt.Errorf("failed to create service account token: %w", err)
+		return nil, nil, 0, "", fmt.Errorf("failed to create token on service account %s: %w", saID, err)
 	}
 
-	var tokenResult struct {
-		Key string `json:"key"`
+	var result struct {
+		ID   int64  `json:"id"`
+		Name string `json:"name"`
+		Key  string `json:"key"`
 	}
-	if err := json.Unmarshal(tokenResp, &tokenResult); err != nil {
-		d.deleteServiceAccount(ctx, saResult.ID, orgID)
+	if err := json.Unmarshal(respBody, &result); err != nil {
 		return nil, nil, 0, "", fmt.Errorf("failed to parse token response: %w", err)
 	}
-	if tokenResult.Key == "" {
-		d.deleteServiceAccount(ctx, saResult.ID, orgID)
+	if result.Key == "" {
 		return nil, nil, 0, "", fmt.Errorf("Grafana API returned empty token key")
+	}
+	if result.ID <= 0 {
+		// Without an id there is nothing to revoke, and the token would live to its
+		// own expiry with no lease naming it. Refuse rather than hand out a
+		// credential Warden cannot take back.
+		return nil, nil, 0, "", fmt.Errorf("Grafana API returned a token with no id; it could never be revoked, so it was not issued")
 	}
 
 	// Return credential as api_key for BearerAPIKeyExtractor compatibility
 	rawData := map[string]interface{}{
-		"api_key": tokenResult.Key,
+		"api_key": result.Key,
 	}
 
-	// leaseID encodes orgID and service account ID for cleanup.
-	// Format: "<orgID>:<saID>" when orgID is set, "<saID>" otherwise.
-	var leaseID string
-	if orgID != "" {
-		leaseID = fmt.Sprintf("%s:%d", orgID, saResult.ID)
-	} else {
-		leaseID = fmt.Sprintf("%d", saResult.ID)
+	// The token name is the only thing telling one lease from another in Grafana's
+	// own view, where every token on the account acts as the same identity. Record
+	// it so the two audit trails can be joined.
+	metadata := map[string]interface{}{
+		"token_id":           fmt.Sprintf("%d", result.ID),
+		"token_name":         tokenName,
+		"service_account_id": saID,
 	}
+
+	// The lease is the truncated lifetime Grafana was actually asked for, not the
+	// configured duration: a fractional second kept here would leave the lease
+	// outliving the token it names.
+	leaseTTL := time.Duration(secondsToLive) * time.Second
+	leaseID := fmt.Sprintf("%s:%d", saID, result.ID)
 
 	if d.logger != nil {
 		d.logger.Debug("minted Grafana service account token",
 			logger.String("spec", spec.Name),
-			logger.String("service_account", saName),
-			logger.String("role", role),
-			logger.String("ttl", tokenExpiry.String()),
+			logger.String("service_account_id", saID),
+			logger.String("token_name", tokenName),
+			logger.String("ttl", leaseTTL.String()),
 		)
 	}
 
-	return rawData, nil, tokenExpiry, leaseID, nil
+	d.startSweep(saID)
+
+	return rawData, metadata, leaseTTL, leaseID, nil
 }
 
-// Revoke deletes the service account (and all its tokens) identified by leaseID.
+// Revoke deletes the one token identified by leaseID, leaving the service account
+// and every other token on it untouched.
 func (d *GrafanaDriver) Revoke(ctx context.Context, leaseID string) error {
 	if leaseID == "" {
 		return nil
 	}
 
-	saID, orgID := parseGrafanaLeaseID(leaseID)
-	path := fmt.Sprintf("/api/serviceaccounts/%s", saID)
-	if _, _, err := d.doGrafanaRequest(ctx, http.MethodDelete, path, nil, orgID); err != nil {
-		return fmt.Errorf("failed to delete service account %s: %w", leaseID, err)
+	saID, tokenID, err := parseGrafanaLeaseID(leaseID)
+	if err != nil {
+		return err
+	}
+
+	// 200 = deleted, 404 = already gone — both are success. Returning an error for a
+	// token that is no longer there would send the expiration manager into backoff
+	// and then a daily retry, forever, for a request that can never succeed.
+	path := fmt.Sprintf("/api/serviceaccounts/%s/tokens/%s", url.PathEscape(saID), url.PathEscape(tokenID))
+	if _, _, err := d.doGrafanaRequest(ctx, http.MethodDelete, path, nil, 200, 204, 404); err != nil {
+		return fmt.Errorf("failed to delete token %s: %w", leaseID, err)
 	}
 
 	if d.logger != nil {
-		d.logger.Debug("revoked Grafana service account",
-			logger.String("service_account_id", leaseID),
+		d.logger.Debug("revoked Grafana service account token",
+			logger.String("lease", leaseID),
 		)
 	}
 
@@ -249,24 +346,89 @@ func (d *GrafanaDriver) Type() string {
 
 // Cleanup releases resources
 func (d *GrafanaDriver) Cleanup(_ context.Context) error {
-	d.httpClient.CloseIdleConnections()
+	if d.httpClient != nil {
+		d.httpClient.CloseIdleConnections()
+	}
 	return nil
 }
 
-// VerifySpec validates spec credentials by making a lightweight API call.
-// Creates a test service account, verifies the minted token works, then cleans up.
+// VerifySpec checks that the account the spec mints against exists and that this
+// source's token can see it.
+//
+// A test mint runs immediately before this and already proves a token can be
+// created, so what this adds is the one thing that mint cannot distinguish — an
+// account id naming nothing — plus the account's role, which is the privilege every
+// credential from this spec will carry and is otherwise invisible from Warden's
+// side.
 func (d *GrafanaDriver) VerifySpec(ctx context.Context, spec *credential.CredSpec) error {
-	// Verify the admin token works by listing service accounts
-	if _, _, err := d.doGrafanaRequest(ctx, http.MethodGet, "/api/serviceaccounts/search?perpage=1", nil, ""); err != nil {
-		return fmt.Errorf("admin token verification failed (GET /api/serviceaccounts/search): %w", err)
+	saID, err := d.resolveGrafanaServiceAccountID(spec)
+	if err != nil {
+		return err
+	}
+
+	path := fmt.Sprintf("/api/serviceaccounts/%s", url.PathEscape(saID))
+	respBody, status, err := d.doGrafanaRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		// Reading an account takes a scope that minting a token on it does not, so a
+		// deliberately write-scoped privileged token is a legitimate configuration.
+		// The mint has already succeeded; failing here would refuse a spec that works.
+		if status == http.StatusForbidden {
+			return nil
+		}
+		return fmt.Errorf("service account %s is not reachable (GET /api/serviceaccounts/%s): %w", saID, saID, err)
+	}
+
+	var account struct {
+		Name       string `json:"name"`
+		Role       string `json:"role"`
+		IsDisabled bool   `json:"isDisabled"`
+	}
+	if err := json.Unmarshal(respBody, &account); err != nil {
+		// Reachability was the question, and it was answered. The response shape is
+		// Grafana's business and varies by version.
+		return nil
+	}
+	if account.IsDisabled {
+		return fmt.Errorf("service account %s (%s) is disabled in Grafana; tokens minted on it would not authenticate", saID, account.Name)
+	}
+	if d.logger != nil {
+		d.logger.Debug("verified Grafana service account",
+			logger.String("spec", spec.Name),
+			logger.String("service_account_id", saID),
+			logger.String("role", account.Role),
+		)
 	}
 	return nil
 }
 
 // --- HTTP helpers ---
 
-// doGrafanaRequest executes an authenticated HTTP request to the Grafana API.
-func (d *GrafanaDriver) doGrafanaRequest(ctx context.Context, method, path string, body []byte, orgID string) ([]byte, int, error) {
+// defaultGrafanaRetryConfig is the shared retry configuration for Grafana API calls.
+var defaultGrafanaRetryConfig = httputil.HTTPRetryConfig{
+	MaxAttempts:       grafanaMaxRetryAttempts,
+	MaxBodySize:       grafanaMaxResponseBodySize,
+	RetryableStatuses: []int{http.StatusTooManyRequests, 500},
+	BaseBackoff:       1 * time.Second,
+	JitterPercent:     20,
+}
+
+// grafanaCreateRetryConfig is used for creating a token, which is not idempotent:
+// Grafana refuses a duplicate name on the same account, so a retry after a lost
+// response cannot succeed and only hides the token the first attempt created.
+var grafanaCreateRetryConfig = httputil.HTTPRetryConfig{
+	MaxAttempts: 1,
+	MaxBodySize: grafanaMaxResponseBodySize,
+}
+
+// doGrafanaRequest executes an authenticated HTTP request to the Grafana API with
+// the default retry policy. Optional okStatuses override the default 2xx success
+// check (e.g. pass 200, 204, 404 to treat an already-deleted token as success).
+func (d *GrafanaDriver) doGrafanaRequest(ctx context.Context, method, path string, body []byte, okStatuses ...int) ([]byte, int, error) {
+	return d.doGrafanaRequestWith(ctx, method, path, body, defaultGrafanaRetryConfig, okStatuses...)
+}
+
+// doGrafanaRequestWith is doGrafanaRequest with an explicit retry policy.
+func (d *GrafanaDriver) doGrafanaRequestWith(ctx context.Context, method, path string, body []byte, retry httputil.HTTPRetryConfig, okStatuses ...int) ([]byte, int, error) {
 	apiURL := d.getGrafanaURL() + path
 
 	headers := map[string]string{
@@ -276,28 +438,18 @@ func (d *GrafanaDriver) doGrafanaRequest(ctx context.Context, method, path strin
 	if body != nil {
 		headers["Content-Type"] = "application/json"
 	}
-	if orgID != "" {
-		headers["X-Grafana-Org-Id"] = orgID
-	}
-
-	retryConfig := httputil.HTTPRetryConfig{
-		MaxAttempts:       grafanaMaxRetryAttempts,
-		MaxBodySize:       grafanaMaxResponseBodySize,
-		RetryableStatuses: []int{http.StatusTooManyRequests, 500},
-		BaseBackoff:       1 * time.Second,
-		JitterPercent:     20,
-	}
 
 	httpReq := httputil.HTTPRequest{
-		Method:  method,
-		URL:     apiURL,
-		Body:    body,
-		Headers: headers,
+		Method:     method,
+		URL:        apiURL,
+		Body:       body,
+		Headers:    headers,
+		OKStatuses: okStatuses,
 	}
 
-	respBody, status, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retryConfig)
-	if err != nil && d.logger != nil {
-		d.logger.Warn("Grafana API request failed",
+	respBody, status, err := httputil.ExecuteWithRetry(ctx, d.httpClient, httpReq, retry)
+	if err != nil {
+		d.warn("Grafana API request failed",
 			logger.String("method", method),
 			logger.String("path", path),
 			logger.String("error", err.Error()),
@@ -306,24 +458,147 @@ func (d *GrafanaDriver) doGrafanaRequest(ctx context.Context, method, path strin
 	return respBody, status, err
 }
 
-// parseGrafanaLeaseID splits a leaseID into (saID, orgID).
-// Format: "<orgID>:<saID>" or "<saID>" (legacy / default org).
-func parseGrafanaLeaseID(leaseID string) (saID, orgID string) {
-	if i := strings.LastIndex(leaseID, ":"); i >= 0 {
-		return leaseID[i+1:], leaseID[:i]
+// --- Reclaiming expired tokens ---
+
+// startSweep reclaims one account's expired tokens, at most once per interval.
+//
+// Grafana does not remove a service-account token when it expires: it stays listed
+// on the account, inert but accumulating. Revoke normally takes it away first, but
+// not always — a revoke that failed for good, a node that died between mint and
+// register — so the sweep runs on every mint path rather than only where it is
+// load-bearing.
+//
+// It runs detached, on its own context: a sweep is a list plus a delete per
+// reclaimed token, and run inline on the caller's context it would add that to the
+// tail of a live request, or be cancelled the moment the mint returns.
+func (d *GrafanaDriver) startSweep(saID string) {
+	// Claimed under the lock rather than with a check-then-set pair: concurrent
+	// mints on one account are the normal case, and a gap between them lets every
+	// one of them launch a sweep.
+	d.sweepMu.Lock()
+	// Built lazily: a driver assembled by hand rather than through the factory is
+	// a legitimate thing to have, and a nil map here would panic on it.
+	if d.sweepNext == nil {
+		d.sweepNext = map[string]time.Time{}
 	}
-	return leaseID, ""
+	now := time.Now()
+	if next, ok := d.sweepNext[saID]; ok && now.Before(next) {
+		d.sweepMu.Unlock()
+		return
+	}
+	d.sweepNext[saID] = now.Add(grafanaSweepInterval)
+	d.sweepMu.Unlock()
+
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), grafanaSweepTimeout)
+		defer cancel()
+		if !d.sweepExpiredTokens(ctx, saID) {
+			// Bring the next attempt forward. The interval above exists to stop a
+			// busy spec sweeping on every request, not to sit out an outage.
+			d.sweepMu.Lock()
+			d.sweepNext[saID] = time.Now().Add(grafanaSweepRetryInterval)
+			d.sweepMu.Unlock()
+		}
+	}()
 }
 
-// deleteServiceAccount is a best-effort cleanup helper.
-func (d *GrafanaDriver) deleteServiceAccount(ctx context.Context, id int64, orgID string) {
-	path := fmt.Sprintf("/api/serviceaccounts/%d", id)
-	if _, _, err := d.doGrafanaRequest(ctx, http.MethodDelete, path, nil, orgID); err != nil && d.logger != nil {
-		d.logger.Warn("failed to cleanup service account",
-			logger.String("id", fmt.Sprintf("%d", id)),
-			logger.String("error", err.Error()),
-		)
+// sweepExpiredTokens deletes the expired tokens on an account that Warden minted.
+//
+// Grafana reports expiry itself, per token, so there is no heuristic here: no stamp
+// to parse, no lifetime to re-derive from config that may since have changed. The
+// listing covers one account and is a flat array, so there is nothing to paginate.
+//
+// What it will touch is bounded by name. The account is provisioned by an operator
+// and may be shared — with other tooling, or with a token someone issued by hand —
+// so only names carrying the Warden prefix are considered. Deleting every expired
+// token would be destroying objects this source does not own.
+// It reports whether the listing succeeded. A sweep that could not even read the
+// account has not done its job, and the caller brings the next attempt forward.
+func (d *GrafanaDriver) sweepExpiredTokens(ctx context.Context, saID string) bool {
+	path := fmt.Sprintf("/api/serviceaccounts/%s/tokens", url.PathEscape(saID))
+	respBody, _, err := d.doGrafanaRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		d.warn("could not list service account tokens to reclaim expired ones",
+			logger.String("service_account_id", saID),
+			logger.String("error", err.Error()))
+		return false
 	}
+
+	var tokens []struct {
+		ID         int64  `json:"id"`
+		Name       string `json:"name"`
+		HasExpired bool   `json:"hasExpired"`
+	}
+	if err := json.Unmarshal(respBody, &tokens); err != nil {
+		d.warn("could not decode the service account token listing",
+			logger.String("service_account_id", saID),
+			logger.String("error", err.Error()))
+		return false
+	}
+
+	var deleted int
+	for _, token := range tokens {
+		if !token.HasExpired || token.ID <= 0 || !isGrafanaWardenTokenName(token.Name) {
+			continue
+		}
+		delPath := fmt.Sprintf("/api/serviceaccounts/%s/tokens/%d", url.PathEscape(saID), token.ID)
+		if _, _, err := d.doGrafanaRequest(ctx, http.MethodDelete, delPath, nil, 200, 204, 404); err != nil {
+			// Another node sweeping the same account is expected and harmless; a
+			// real failure just leaves the token for the next sweep.
+			d.warn("could not reclaim an expired token",
+				logger.String("service_account_id", saID),
+				logger.String("token_id", fmt.Sprintf("%d", token.ID)),
+				logger.String("error", err.Error()))
+			continue
+		}
+		deleted++
+	}
+
+	if deleted > 0 && d.logger != nil {
+		d.logger.Info("reclaimed expired Grafana tokens",
+			logger.String("service_account_id", saID),
+			logger.Int("count", deleted))
+	}
+	return true
+}
+
+// isGrafanaWardenTokenName reports whether a token name is one this driver writes.
+//
+// It matches the default prefix rather than any spec's configured one: a sweep
+// covers a whole account, which several specs with different prefixes may share,
+// and a name that does not announce itself as Warden's is left alone either way.
+func isGrafanaWardenTokenName(name string) bool {
+	return strings.HasPrefix(name, grafanaDefaultNamePrefix)
+}
+
+// parseGrafanaLeaseID splits a leaseID into (saID, tokenID).
+//
+// Both halves are numeric and both are interpolated into a request path, and they
+// reach this function from persisted state rather than from the mint that wrote
+// them — so a lease that is not of this shape is refused rather than sent.
+func parseGrafanaLeaseID(leaseID string) (saID, tokenID string, err error) {
+	saID, tokenID, found := strings.Cut(leaseID, ":")
+	if !found {
+		return "", "", fmt.Errorf("invalid lease ID %q: expected \"<service account id>:<token id>\"", leaseID)
+	}
+	if err := validateGrafanaServiceAccountID(saID); err != nil {
+		return "", "", fmt.Errorf("invalid lease ID %q: %w", leaseID, err)
+	}
+	if n, convErr := strconv.ParseInt(tokenID, 10, 64); convErr != nil || n <= 0 {
+		return "", "", fmt.Errorf("invalid lease ID %q: token id %q is not a positive number", leaseID, tokenID)
+	}
+	return saID, tokenID, nil
+}
+
+// validateGrafanaServiceAccountID checks an account id is what Grafana issues: a
+// positive integer. It is interpolated into a request path, and a value that is not
+// a number would be sent there and answered with an opaque 404.
+func validateGrafanaServiceAccountID(v string) error {
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || n <= 0 {
+		return fmt.Errorf("service_account_id must be a positive integer (the numeric id Grafana gives the account), got: %s", v)
+	}
+	return nil
 }
 
 // validateGrafanaURL validates that the grafana_url is a well-formed HTTPS URL.

--- a/credential/drivers/grafana_driver.go
+++ b/credential/drivers/grafana_driver.go
@@ -40,9 +40,25 @@ const (
 	grafanaSweepTimeout       = 2 * time.Minute
 )
 
+// GrafanaChainedMaxTokenExpiry bounds how long a token minted from a chained
+// source may live.
+//
+// Exported because the config store applies the same rule at spec-write time,
+// where an operator can act on it — it is the only layer that can see both the
+// spec's lifetime and whether its source is chained.
+//
+// Such a source cannot revoke: revocation runs at lease expiry, where there is no
+// caller to fetch the chained token as. So a minted token stays valid until its
+// own expiry however the lease ended — and a lease can end early, well before
+// token_expiry, leaving a live credential nothing will take back until the sweep
+// sees Grafana report it expired. That window is the exposure, and an operator
+// asking for 720h would be asking for a month of it.
+const GrafanaChainedMaxTokenExpiry = 24 * time.Hour
+
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*GrafanaDriver)(nil)
 var _ credential.SpecVerifier = (*GrafanaDriver)(nil)
+var _ credential.ChainedSecretMinter = (*GrafanaDriver)(nil)
 var _ credential.RotationConfigValidator = (*GrafanaDriverFactory)(nil)
 
 // GrafanaDriver mints tokens on a service account an operator provisioned.
@@ -58,6 +74,13 @@ var _ credential.RotationConfigValidator = (*GrafanaDriverFactory)(nil)
 // spec cannot ask for privilege the operator did not already grant. MintCredential
 // creates one token on the named account; Revoke deletes that one token, leaving
 // the account and every other token on it untouched.
+//
+// Held inline, the privileged token authenticates every call. Chained
+// (secret_spec), it is fetched per mint from a referenced spec as the calling
+// agent and kept nowhere — which leaves nothing to revoke with once the request
+// is over, since revocation runs at lease expiry where there is no caller to walk
+// the chain as. The minted token still expires on its own, and the sweep reclaims
+// what it leaves behind.
 type GrafanaDriver struct {
 	credSource *credential.CredSource
 	logger     *logger.GatedLogger
@@ -81,6 +104,9 @@ func (f *GrafanaDriverFactory) Type() string {
 
 // ValidateConfig validates Grafana source configuration using declarative schema.
 func (f *GrafanaDriverFactory) ValidateConfig(config map[string]string) error {
+	if err := validateGrafanaChainedConfig(config); err != nil {
+		return err
+	}
 	return credential.ValidateSchema(config,
 		credential.StringField("grafana_url").
 			Required().
@@ -90,9 +116,11 @@ func (f *GrafanaDriverFactory) ValidateConfig(config map[string]string) error {
 			Describe("Grafana API base URL").
 			Example("https://mystack.grafana.net"),
 
+		// Required only when the source holds its own token; a chained source is
+		// refused one outright. validateGrafanaChainedConfig enforces both halves of
+		// that, since the schema can express neither.
 		credential.StringField("admin_token").
-			Required().
-			Describe("Service-account token able to manage tokens on the provisioned account"),
+			Describe("Service-account token able to manage tokens on the provisioned account; required unless secret_spec is set"),
 
 		credential.StringField("service_account_id").
 			Custom(validateGrafanaServiceAccountID).
@@ -105,7 +133,42 @@ func (f *GrafanaDriverFactory) ValidateConfig(config map[string]string) error {
 
 		credential.BoolField("tls_skip_verify").
 			Describe("Skip TLS certificate verification (development only)"),
+
+		credential.StringField(credential.ConfigSecretSpec).
+			Describe("Cred spec yielding the privileged token, instead of storing one here").
+			Example("grafana-admin-token"),
+
+		credential.StringField(credential.ConfigSecretField).
+			Describe("Field of the referenced credential holding the privileged token").
+			Example("admin_token"),
+
+		credential.DurationField(credential.ConfigSecretCacheTTL).
+			Describe("How long to reuse the fetched token before re-fetching (default: no caching)").
+			Example("30m"),
 	)
+}
+
+// validateGrafanaChainedConfig holds a source to exactly one way of getting its
+// privileged token.
+//
+// A chained source keeps none of its own: keeping one would leave a source that
+// reads as keyless while storing the very secret chaining removes, and there is
+// nothing here that could use it — the fetched token authenticates every call, and
+// the paths that run without a caller are disabled rather than falling back to it.
+func validateGrafanaChainedConfig(config map[string]string) error {
+	if credential.GetString(config, credential.ConfigSecretSpec, "") == "" {
+		// The schema cannot express "required unless another key is set", so the
+		// non-chained requirement lands here alongside its opposite.
+		if credential.GetString(config, "admin_token", "") == "" {
+			return fmt.Errorf("admin_token is required unless %s is set", credential.ConfigSecretSpec)
+		}
+		return nil
+	}
+	if credential.GetString(config, "admin_token", "") != "" {
+		return fmt.Errorf("admin_token must be omitted when %s is set; the referenced spec supplies the privileged token",
+			credential.ConfigSecretSpec)
+	}
+	return nil
 }
 
 // SensitiveConfigFields returns source config keys that should be masked.
@@ -169,6 +232,12 @@ func (d *GrafanaDriver) warn(msg string, fields ...logger.TypedField) {
 	}
 }
 
+// isChained reports whether this source fetches its privileged token per mint
+// rather than holding one.
+func (d *GrafanaDriver) isChained() bool {
+	return credential.GetString(d.credSource.Config, credential.ConfigSecretSpec, "") != ""
+}
+
 // resolveGrafanaServiceAccountID returns the account a spec mints against: its own
 // service_account_id, or the source's default.
 //
@@ -196,6 +265,62 @@ func (d *GrafanaDriver) resolveGrafanaServiceAccountID(spec *credential.CredSpec
 // itself, and that id is what the lease carries: revocation deletes the one token,
 // not the account it hangs off.
 func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// A chained spec mints through MintFromSecret, which the minting layer routes
+	// it to. Arriving here means that routing was bypassed, so fail rather than
+	// fall through to an inline token this source does not have.
+	if d.isChained() || spec.Config[credential.ConfigSecretSpec] != "" {
+		return nil, nil, 0, "", fmt.Errorf("grafana: %s is set (credential chaining); this spec mints from fetched secret material, not directly",
+			credential.ConfigSecretSpec)
+	}
+	return d.mintToken(ctx, d.getAdminToken(), spec, false)
+}
+
+// MintFromSecret mints from a privileged token fetched through credential
+// chaining, for a source that stores none of its own.
+func (d *GrafanaDriver) MintFromSecret(ctx context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	token, err := resolveChainedGrafanaToken(material)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+	return d.mintToken(ctx, token, spec, true)
+}
+
+// resolveChainedGrafanaToken reads the privileged token out of fetched secret
+// material.
+//
+// Grafana has one wire shape for this — an opaque bearer token — so unlike elastic
+// there is nothing here to disambiguate; the only question is which key of the
+// payload holds it.
+func resolveChainedGrafanaToken(material credential.SecretMaterial) (string, error) {
+	token := material.Secret()
+
+	// Fall back to conventional names ONLY when no field was resolved. A field that
+	// resolved to nothing is a misconfigured secret_field — say so, rather than
+	// silently authenticating with some other value from the payload.
+	if token == "" && material.Field == "" {
+		for _, key := range []string{"admin_token", "api_key", "token"} {
+			if token = material.Data[key]; token != "" {
+				break
+			}
+		}
+	}
+	if token == "" {
+		if material.Field != "" {
+			return "", fmt.Errorf("grafana: %s %q is empty or absent in the fetched secret material: %w",
+				credential.ConfigSecretField, material.Field, credential.ErrChainedSecretIncomplete)
+		}
+		return "", fmt.Errorf("grafana: no privileged token in fetched secret material (set %s, or store it under 'admin_token', 'api_key' or 'token'): %w",
+			credential.ConfigSecretField, credential.ErrChainedSecretIncomplete)
+	}
+	return token, nil
+}
+
+// mintToken creates one token on the spec's account.
+//
+// chained says where the privileged token it authenticates with came from, which
+// decides only how an authentication refusal is reported: a fetched token can be
+// stale and worth re-fetching, an inline one cannot.
+func (d *GrafanaDriver) mintToken(ctx context.Context, adminToken string, spec *credential.CredSpec, chained bool) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	saID, err := d.resolveGrafanaServiceAccountID(spec)
 	if err != nil {
 		return nil, nil, 0, "", err
@@ -233,6 +358,16 @@ func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.Cre
 		return nil, nil, 0, "", fmt.Errorf("token_expiry %s is under one second, which Grafana would read as a token that never expires; give a lifetime of 1s or more", tokenExpiry)
 	}
 
+	// A chained source cannot revoke, so a token it mints stays live until its own
+	// expiry — including when the lease ends early, which the sweep cannot help
+	// with because it only reclaims tokens Grafana already reports as expired.
+	// That window is the whole exposure, so it is bounded here rather than left to
+	// whatever an operator typed.
+	if chained && tokenExpiry > GrafanaChainedMaxTokenExpiry {
+		return nil, nil, 0, "", fmt.Errorf("token_expiry %s exceeds the %s ceiling for a chained source: revocation cannot run without a caller to fetch the token as, so a minted token stays live until it expires",
+			tokenExpiry, GrafanaChainedMaxTokenExpiry)
+	}
+
 	// Token names are unique per service account, and every spec now mints against
 	// an account it may share — so the name carries a random suffix as well as a
 	// timestamp. Two mints of the same spec in the same millisecond would otherwise
@@ -253,8 +388,16 @@ func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.Cre
 	// that refusal and report a failed mint while the token the first attempt
 	// created stands — unknown to Warden, and unrevokable until it expires.
 	path := fmt.Sprintf("/api/serviceaccounts/%s/tokens", url.PathEscape(saID))
-	respBody, _, err := d.doGrafanaRequestWith(ctx, http.MethodPost, path, body, grafanaCreateRetryConfig)
+	respBody, status, err := d.doGrafanaRequestWith(ctx, adminToken, http.MethodPost, path, body, grafanaCreateRetryConfig)
 	if err != nil {
+		// On the chained path a refusal to authenticate marks the fetched token as
+		// stale, so the minting layer evicts what it cached and retries once with a
+		// fresh read. An inline source has nothing to evict, and saying so would only
+		// send it round a loop that cannot change the outcome.
+		if chained && (status == http.StatusUnauthorized || status == http.StatusForbidden) {
+			return nil, nil, 0, "", fmt.Errorf("grafana: the server rejected the chained privileged token: %w (%w)",
+				credential.ErrChainedSecretRejected, err)
+		}
 		return nil, nil, 0, "", fmt.Errorf("failed to create token on service account %s: %w", saID, err)
 	}
 
@@ -305,7 +448,7 @@ func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.Cre
 		)
 	}
 
-	d.startSweep(saID)
+	d.startSweep(adminToken, saID)
 
 	return rawData, metadata, leaseTTL, leaseID, nil
 }
@@ -322,11 +465,24 @@ func (d *GrafanaDriver) Revoke(ctx context.Context, leaseID string) error {
 		return err
 	}
 
+	// A chained source holds no token to authorise the delete, and revocation runs
+	// at lease expiry, where there is no caller to walk the chain as. That will
+	// never change, so returning an error would only send the expiration manager
+	// into backoff and then a daily retry, forever, for a request that cannot
+	// succeed. The minted token carries its own expiry — which is why a mint is
+	// refused a lifetime Grafana would round to "never" — and a later mint's sweep
+	// reclaims it.
+	if d.isChained() {
+		d.warn("cannot revoke a token minted from a chained privileged token; it expires on its own and is swept on a later mint",
+			logger.String("lease", leaseID))
+		return nil
+	}
+
 	// 200 = deleted, 404 = already gone — both are success. Returning an error for a
 	// token that is no longer there would send the expiration manager into backoff
 	// and then a daily retry, forever, for a request that can never succeed.
 	path := fmt.Sprintf("/api/serviceaccounts/%s/tokens/%s", url.PathEscape(saID), url.PathEscape(tokenID))
-	if _, _, err := d.doGrafanaRequest(ctx, http.MethodDelete, path, nil, 200, 204, 404); err != nil {
+	if _, _, err := d.doGrafanaRequest(ctx, d.getAdminToken(), http.MethodDelete, path, nil, 200, 204, 404); err != nil {
 		return fmt.Errorf("failed to delete token %s: %w", leaseID, err)
 	}
 
@@ -366,8 +522,16 @@ func (d *GrafanaDriver) VerifySpec(ctx context.Context, spec *credential.CredSpe
 		return err
 	}
 
+	// A chained source holds no token to probe with — it is fetched per mint, as
+	// the caller, and there is no caller here. Belt and braces: the store does not
+	// call this for a chained spec at all, which is why the account id above is
+	// checked by the store rather than relied on here.
+	if d.isChained() {
+		return nil
+	}
+
 	path := fmt.Sprintf("/api/serviceaccounts/%s", url.PathEscape(saID))
-	respBody, status, err := d.doGrafanaRequest(ctx, http.MethodGet, path, nil)
+	respBody, status, err := d.doGrafanaRequest(ctx, d.getAdminToken(), http.MethodGet, path, nil)
 	if err != nil {
 		// Reading an account takes a scope that minting a token on it does not, so a
 		// deliberately write-scoped privileged token is a legitimate configuration.
@@ -423,17 +587,21 @@ var grafanaCreateRetryConfig = httputil.HTTPRetryConfig{
 // doGrafanaRequest executes an authenticated HTTP request to the Grafana API with
 // the default retry policy. Optional okStatuses override the default 2xx success
 // check (e.g. pass 200, 204, 404 to treat an already-deleted token as success).
-func (d *GrafanaDriver) doGrafanaRequest(ctx context.Context, method, path string, body []byte, okStatuses ...int) ([]byte, int, error) {
-	return d.doGrafanaRequestWith(ctx, method, path, body, defaultGrafanaRetryConfig, okStatuses...)
+func (d *GrafanaDriver) doGrafanaRequest(ctx context.Context, adminToken, method, path string, body []byte, okStatuses ...int) ([]byte, int, error) {
+	return d.doGrafanaRequestWith(ctx, adminToken, method, path, body, defaultGrafanaRetryConfig, okStatuses...)
 }
 
 // doGrafanaRequestWith is doGrafanaRequest with an explicit retry policy.
-func (d *GrafanaDriver) doGrafanaRequestWith(ctx context.Context, method, path string, body []byte, retry httputil.HTTPRetryConfig, okStatuses ...int) ([]byte, int, error) {
+//
+// The privileged token is passed in rather than read from config: a chained
+// source holds none, and the one it authenticates with belongs to the request
+// that fetched it.
+func (d *GrafanaDriver) doGrafanaRequestWith(ctx context.Context, adminToken, method, path string, body []byte, retry httputil.HTTPRetryConfig, okStatuses ...int) ([]byte, int, error) {
 	apiURL := d.getGrafanaURL() + path
 
 	headers := map[string]string{
 		"Accept":        "application/json",
-		"Authorization": "Bearer " + d.getAdminToken(),
+		"Authorization": "Bearer " + adminToken,
 	}
 	if body != nil {
 		headers["Content-Type"] = "application/json"
@@ -471,7 +639,7 @@ func (d *GrafanaDriver) doGrafanaRequestWith(ctx context.Context, method, path s
 // It runs detached, on its own context: a sweep is a list plus a delete per
 // reclaimed token, and run inline on the caller's context it would add that to the
 // tail of a live request, or be cancelled the moment the mint returns.
-func (d *GrafanaDriver) startSweep(saID string) {
+func (d *GrafanaDriver) startSweep(adminToken, saID string) {
 	// Claimed under the lock rather than with a check-then-set pair: concurrent
 	// mints on one account are the normal case, and a gap between them lets every
 	// one of them launch a sweep.
@@ -492,7 +660,7 @@ func (d *GrafanaDriver) startSweep(saID string) {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), grafanaSweepTimeout)
 		defer cancel()
-		if !d.sweepExpiredTokens(ctx, saID) {
+		if !d.sweepExpiredTokens(ctx, adminToken, saID) {
 			// Bring the next attempt forward. The interval above exists to stop a
 			// busy spec sweeping on every request, not to sit out an outage.
 			d.sweepMu.Lock()
@@ -514,9 +682,9 @@ func (d *GrafanaDriver) startSweep(saID string) {
 // token would be destroying objects this source does not own.
 // It reports whether the listing succeeded. A sweep that could not even read the
 // account has not done its job, and the caller brings the next attempt forward.
-func (d *GrafanaDriver) sweepExpiredTokens(ctx context.Context, saID string) bool {
+func (d *GrafanaDriver) sweepExpiredTokens(ctx context.Context, adminToken, saID string) bool {
 	path := fmt.Sprintf("/api/serviceaccounts/%s/tokens", url.PathEscape(saID))
-	respBody, _, err := d.doGrafanaRequest(ctx, http.MethodGet, path, nil)
+	respBody, _, err := d.doGrafanaRequest(ctx, adminToken, http.MethodGet, path, nil)
 	if err != nil {
 		d.warn("could not list service account tokens to reclaim expired ones",
 			logger.String("service_account_id", saID),
@@ -542,7 +710,7 @@ func (d *GrafanaDriver) sweepExpiredTokens(ctx context.Context, saID string) boo
 			continue
 		}
 		delPath := fmt.Sprintf("/api/serviceaccounts/%s/tokens/%d", url.PathEscape(saID), token.ID)
-		if _, _, err := d.doGrafanaRequest(ctx, http.MethodDelete, delPath, nil, 200, 204, 404); err != nil {
+		if _, _, err := d.doGrafanaRequest(ctx, adminToken, http.MethodDelete, delPath, nil, 200, 204, 404); err != nil {
 			// Another node sweeping the same account is expected and harmless; a
 			// real failure just leaves the token for the next sweep.
 			d.warn("could not reclaim an expired token",

--- a/credential/drivers/grafana_driver_test.go
+++ b/credential/drivers/grafana_driver_test.go
@@ -361,9 +361,10 @@ func TestGrafanaDriver_MintCredential_TokenNamesAreUnique(t *testing.T) {
 		mu.Unlock()
 
 		if duplicate {
-			// What Grafana does with a name already on the account.
+			// What Grafana does with a name already on the account: ErrDuplicateToken,
+			// an errutil.BadRequest, so 400 and never retryable.
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte(`{"message":"service account token with given name already exists"}`))
+			w.Write([]byte(`{"messageId":"serviceaccounts.ErrTokenAlreadyExists","message":"service account token with name busy already exists in the organization"}`))
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -550,13 +551,13 @@ func TestGrafanaDriver_SweepRetriesSoonerAfterAFailedListing(t *testing.T) {
 	defer server.Close()
 
 	driver := grafanaTestDriver(server, nil)
-	require.False(t, driver.sweepExpiredTokens(context.Background(), "42"),
+	require.False(t, driver.sweepExpiredTokens(context.Background(), "glsa_admin", "42"),
 		"a listing that failed must not report success")
 
 	// Now through startSweep, which is what owns the backoff. It stamps the full
 	// interval up front to stop a stampede, then brings it back in when the sweep
 	// reports failure — so the value read here is the driver's, not this test's.
-	driver.startSweep("42")
+	driver.startSweep("glsa_admin", "42")
 
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
@@ -765,7 +766,7 @@ func TestGrafanaDriver_SweepExpiredTokens(t *testing.T) {
 	defer server.Close()
 
 	driver := grafanaTestDriver(server, nil)
-	driver.sweepExpiredTokens(context.Background(), "42")
+	driver.sweepExpiredTokens(context.Background(), "glsa_admin", "42")
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -781,7 +782,7 @@ func TestGrafanaDriver_SweepExpiredTokens_ListFailureIsHarmless(t *testing.T) {
 
 	driver := grafanaTestDriver(server, nil)
 	assert.NotPanics(t, func() {
-		driver.sweepExpiredTokens(context.Background(), "42")
+		driver.sweepExpiredTokens(context.Background(), "glsa_admin", "42")
 	}, "a driver without a logger must not panic on the warn path")
 }
 
@@ -803,9 +804,9 @@ func TestGrafanaDriver_SweepRateLimitIsPerAccount(t *testing.T) {
 	defer server.Close()
 
 	driver := grafanaTestDriver(server, nil)
-	driver.startSweep("42")
-	driver.startSweep("57")
-	driver.startSweep("42") // inside the interval; must not sweep again
+	driver.startSweep("glsa_admin", "42")
+	driver.startSweep("glsa_admin", "57")
+	driver.startSweep("glsa_admin", "42") // inside the interval; must not sweep again
 
 	for i := 0; i < 2; i++ {
 		select {
@@ -837,6 +838,251 @@ func TestIsGrafanaWardenTokenName(t *testing.T) {
 	assert.False(t, isGrafanaWardenTokenName("my-warden-token"))
 }
 
+// --- Credential chaining (keyless source) ---
+
+func TestGrafanaDriverFactory_ValidateConfig_Chained(t *testing.T) {
+	factory := &GrafanaDriverFactory{}
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "secret_spec without admin_token",
+			config: map[string]string{
+				"grafana_url":               "https://mystack.grafana.net",
+				credential.ConfigSecretSpec: "grafana-admin-token",
+			},
+		},
+		{
+			name: "secret_spec with the modifiers",
+			config: map[string]string{
+				"grafana_url":                   "https://mystack.grafana.net",
+				"service_account_id":            "42",
+				credential.ConfigSecretSpec:     "grafana-admin-token",
+				credential.ConfigSecretField:    "admin_token",
+				credential.ConfigSecretCacheTTL: "30m",
+			},
+		},
+		{
+			// Keeping the token would leave a source that reads as keyless while
+			// storing the very secret chaining removes.
+			name: "admin_token alongside secret_spec is refused",
+			config: map[string]string{
+				"grafana_url":               "https://mystack.grafana.net",
+				"admin_token":               "glsa_still_here",
+				credential.ConfigSecretSpec: "grafana-admin-token",
+			},
+			wantErr: true,
+			errMsg:  "admin_token must be omitted",
+		},
+		{
+			name:    "neither admin_token nor secret_spec is refused",
+			config:  map[string]string{"grafana_url": "https://mystack.grafana.net"},
+			wantErr: true,
+			errMsg:  "admin_token is required unless",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := factory.ValidateConfig(tt.config)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestResolveChainedGrafanaToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		material credential.SecretMaterial
+		want     string
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name:     "secret_field names the token",
+			material: credential.SecretMaterial{Data: map[string]string{"admin_token": "glsa_a", "other": "x"}, Field: "admin_token"},
+			want:     "glsa_a",
+		},
+		{
+			name:     "conventional name admin_token",
+			material: credential.SecretMaterial{Data: map[string]string{"admin_token": "glsa_b"}},
+			want:     "glsa_b",
+		},
+		{
+			name:     "conventional name api_key",
+			material: credential.SecretMaterial{Data: map[string]string{"api_key": "glsa_c"}},
+			want:     "glsa_c",
+		},
+		{
+			name:     "conventional name token",
+			material: credential.SecretMaterial{Data: map[string]string{"token": "glsa_d"}},
+			want:     "glsa_d",
+		},
+		{
+			// A field that resolved to nothing is a misconfigured secret_field. Say
+			// so, rather than silently authenticating with some other value from the
+			// payload — admin_token is present here and must NOT be used.
+			name:     "a resolved-to-nothing secret_field does not fall back",
+			material: credential.SecretMaterial{Data: map[string]string{"admin_token": "glsa_e"}, Field: "wrong_name"},
+			wantErr:  true,
+			errMsg:   "is empty or absent",
+		},
+		{
+			name:     "no token at all",
+			material: credential.SecretMaterial{Data: map[string]string{"unrelated": "x"}},
+			wantErr:  true,
+			errMsg:   "no privileged token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveChainedGrafanaToken(tt.material)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGrafanaDriver_MintFromSecret(t *testing.T) {
+	var gotAuth, gotPath string
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			gotAuth, gotPath = r.Header.Get("Authorization"), r.URL.Path
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": 31, "key": "glsa_minted"})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[]`)
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{
+		"admin_token":               "", // a chained source holds none
+		credential.ConfigSecretSpec: "grafana-admin-token",
+	})
+
+	rawData, metadata, ttl, leaseID, err := driver.MintFromSecret(context.Background(),
+		grafanaSpec("kv", map[string]string{"service_account_id": "42"}),
+		credential.SecretMaterial{Data: map[string]string{"admin_token": "glsa_chained_admin"}})
+	require.NoError(t, err)
+
+	assert.Equal(t, "glsa_minted", rawData["api_key"])
+	assert.Equal(t, time.Hour, ttl)
+	assert.Equal(t, "42:31", leaseID)
+	assert.Equal(t, "42", metadata["service_account_id"])
+	assert.Equal(t, "/api/serviceaccounts/42/tokens", gotPath)
+	assert.Equal(t, "Bearer glsa_chained_admin", gotAuth,
+		"the chained token must authenticate, not a stored one")
+}
+
+// Routing a chained spec is the minting layer's job. Arriving at MintCredential
+// means it was bypassed, and falling through would authenticate with an empty
+// token.
+func TestGrafanaDriver_MintCredential_RefusesChainedSource(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("nothing should reach Grafana")
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{
+		"admin_token":               "",
+		credential.ConfigSecretSpec: "grafana-admin-token",
+	})
+
+	_, _, _, _, err := driver.MintCredential(context.Background(),
+		grafanaSpec("x", map[string]string{"service_account_id": "42"}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential chaining")
+}
+
+// A fetched token can be stale and worth re-fetching; an inline one cannot, and
+// saying so would send it round a loop that cannot change the outcome.
+func TestGrafanaDriver_ChainedRejectionMarksSecretStale(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"message":"Unauthorized"}`))
+	}))
+	defer server.Close()
+
+	spec := grafanaSpec("x", map[string]string{"service_account_id": "42"})
+
+	chained := grafanaTestDriver(server, map[string]string{
+		"admin_token":               "",
+		credential.ConfigSecretSpec: "grafana-admin-token",
+	})
+	_, _, _, _, err := chained.MintFromSecret(context.Background(), spec,
+		credential.SecretMaterial{Data: map[string]string{"admin_token": "glsa_stale"}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, credential.ErrChainedSecretRejected)
+
+	inline := grafanaTestDriver(server, nil)
+	_, _, _, _, err = inline.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected,
+		"an inline source has nothing to evict")
+}
+
+// Revocation runs at lease expiry, where a chained source has no caller to fetch
+// its privileged token as. An error there would only feed the daily irrevocable
+// loop.
+func TestGrafanaDriver_Revoke_ChainedIsNoOp(t *testing.T) {
+	var called atomic.Int32
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{
+		"admin_token":               "",
+		credential.ConfigSecretSpec: "grafana-admin-token",
+	})
+
+	require.NoError(t, driver.Revoke(context.Background(), "42:7"))
+	assert.Equal(t, int32(0), called.Load(), "nothing should reach Grafana")
+
+	// A malformed lease is still refused: that check does not depend on a token.
+	require.Error(t, driver.Revoke(context.Background(), "42"))
+}
+
+func TestGrafanaDriver_VerifySpec_ChainedIsNoOp(t *testing.T) {
+	var called atomic.Int32
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{
+		"admin_token":               "",
+		credential.ConfigSecretSpec: "grafana-admin-token",
+	})
+
+	require.NoError(t, driver.VerifySpec(context.Background(),
+		grafanaSpec("x", map[string]string{"service_account_id": "42"})))
+	assert.Equal(t, int32(0), called.Load())
+}
+
 // --- Helpers ---
 
 func TestValidateGrafanaServiceAccountID(t *testing.T) {
@@ -858,7 +1104,7 @@ func TestGrafanaDriver_AuthorizationHeader(t *testing.T) {
 	defer server.Close()
 
 	driver := grafanaTestDriver(server, map[string]string{"admin_token": "glsa_my_admin_token"})
-	_, _, err := driver.doGrafanaRequest(context.Background(), http.MethodGet, "/api/serviceaccounts/42", nil)
+	_, _, err := driver.doGrafanaRequest(context.Background(), driver.getAdminToken(), http.MethodGet, "/api/serviceaccounts/42", nil)
 	require.NoError(t, err)
 }
 
@@ -893,4 +1139,36 @@ func TestValidateGrafanaURL_TLSSkipVerify(t *testing.T) {
 	require.NoError(t, validateGrafanaURL("http://grafana.local", true))
 	require.NoError(t, validateGrafanaURL("https://grafana.local", true))
 	require.Error(t, validateGrafanaURL("ftp://grafana.local", true))
+}
+
+// A chained source cannot revoke, so a token it mints stays live until its own
+// expiry however the lease ended. That window is bounded; the inline path, which
+// revokes precisely, is not.
+func TestGrafanaDriver_ChainedTokenExpiryIsCapped(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": 4, "key": "glsa_x"})
+	}))
+	defer server.Close()
+
+	spec := grafanaSpec("long", map[string]string{
+		"service_account_id": "42",
+		"token_expiry":       "720h",
+	})
+
+	chained := grafanaTestDriver(server, map[string]string{
+		"admin_token":               "",
+		credential.ConfigSecretSpec: "grafana-admin-token",
+	})
+	_, _, _, _, err := chained.MintFromSecret(context.Background(), spec,
+		credential.SecretMaterial{Data: map[string]string{"admin_token": "glsa_chained"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ceiling for a chained source")
+
+	// The same lifetime is fine inline, where revocation removes the token
+	// precisely when the lease ends.
+	inline := grafanaTestDriver(server, nil)
+	_, _, ttl, _, err := inline.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, 720*time.Hour, ttl)
 }

--- a/credential/drivers/grafana_driver_test.go
+++ b/credential/drivers/grafana_driver_test.go
@@ -7,14 +7,42 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// grafanaTestDriver builds a driver against a stub, with the given source config
+// keys layered onto the connection ones.
+func grafanaTestDriver(server *httptest.Server, config map[string]string) *GrafanaDriver {
+	full := map[string]string{
+		"grafana_url": server.URL,
+		"admin_token": "glsa_admin",
+	}
+	for k, v := range config {
+		full[k] = v
+	}
+	return &GrafanaDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeGrafana,
+			Config: full,
+		},
+		httpClient: server.Client(),
+	}
+}
+
+func grafanaSpec(name string, config map[string]string) *credential.CredSpec {
+	if config == nil {
+		config = map[string]string{}
+	}
+	return &credential.CredSpec{Name: name, Type: credential.TypeAPIKey, Config: config}
+}
 
 func TestGrafanaDriverFactory_Type(t *testing.T) {
 	factory := &GrafanaDriverFactory{}
@@ -50,21 +78,34 @@ func TestGrafanaDriverFactory_ValidateConfig(t *testing.T) {
 				"grafana_url": "https://mystack.grafana.net",
 				"admin_token": "glsa_test_token",
 			},
-			wantErr: false,
 		},
 		{
-			name: "missing grafana_url",
+			name: "with a default service account",
 			config: map[string]string{
-				"admin_token": "glsa_test_token",
+				"grafana_url":        "https://mystack.grafana.net",
+				"admin_token":        "glsa_test_token",
+				"service_account_id": "42",
 			},
+		},
+		{
+			name: "non-numeric default service account",
+			config: map[string]string{
+				"grafana_url":        "https://mystack.grafana.net",
+				"admin_token":        "glsa_test_token",
+				"service_account_id": "my-account",
+			},
+			wantErr: true,
+			errMsg:  "positive integer",
+		},
+		{
+			name:    "missing grafana_url",
+			config:  map[string]string{"admin_token": "glsa_test_token"},
 			wantErr: true,
 			errMsg:  "grafana_url",
 		},
 		{
-			name: "missing admin_token",
-			config: map[string]string{
-				"grafana_url": "https://mystack.grafana.net",
-			},
+			name:    "missing admin_token",
+			config:  map[string]string{"grafana_url": "https://mystack.grafana.net"},
 			wantErr: true,
 			errMsg:  "admin_token",
 		},
@@ -84,7 +125,6 @@ func TestGrafanaDriverFactory_ValidateConfig(t *testing.T) {
 				"admin_token":     "glsa_test_token",
 				"tls_skip_verify": "true",
 			},
-			wantErr: false,
 		},
 	}
 
@@ -101,6 +141,18 @@ func TestGrafanaDriverFactory_ValidateConfig(t *testing.T) {
 	}
 }
 
+// A rotation_period on a grafana source is accepted and then fails every cycle
+// forever, visible only in server logs — so the factory refuses it outright.
+func TestGrafanaDriverFactory_ValidateRotationConfig(t *testing.T) {
+	factory := &GrafanaDriverFactory{}
+	err := factory.ValidateRotationConfig(map[string]string{
+		"grafana_url": "https://mystack.grafana.net",
+		"admin_token": "glsa_admin",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rotation does not apply")
+}
+
 func TestGrafanaDriverFactory_Create(t *testing.T) {
 	factory := &GrafanaDriverFactory{}
 	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
@@ -114,35 +166,25 @@ func TestGrafanaDriverFactory_Create(t *testing.T) {
 }
 
 func TestGrafanaDriver_Type(t *testing.T) {
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type:   credential.SourceTypeGrafana,
-			Config: map[string]string{},
-		},
-	}
+	driver := &GrafanaDriver{credSource: &credential.CredSource{Type: credential.SourceTypeGrafana}}
 	assert.Equal(t, credential.SourceTypeGrafana, driver.Type())
 }
 
 func TestGrafanaDriver_Cleanup(t *testing.T) {
 	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type:   credential.SourceTypeGrafana,
-			Config: map[string]string{},
-		},
+		credSource: &credential.CredSource{Type: credential.SourceTypeGrafana},
 		httpClient: &http.Client{},
 	}
-	err := driver.Cleanup(context.Background())
-	assert.NoError(t, err)
+	assert.NoError(t, driver.Cleanup(context.Background()))
+}
+
+func TestGrafanaDriver_Cleanup_NilHTTPClient(t *testing.T) {
+	driver := &GrafanaDriver{credSource: &credential.CredSource{Type: credential.SourceTypeGrafana}}
+	assert.NoError(t, driver.Cleanup(context.Background()))
 }
 
 func TestGrafanaDriver_NotRotatable(t *testing.T) {
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type:   credential.SourceTypeGrafana,
-			Config: map[string]string{},
-		},
-	}
-	var sd credential.SourceDriver = driver
+	var sd credential.SourceDriver = &GrafanaDriver{credSource: &credential.CredSource{}}
 	_, ok := sd.(credential.Rotatable)
 	assert.False(t, ok, "GrafanaDriver should not implement credential.Rotatable")
 }
@@ -156,397 +198,668 @@ func TestGrafanaDriver_GetGrafanaURL(t *testing.T) {
 	assert.Equal(t, "https://mystack.grafana.net", driver.getGrafanaURL())
 }
 
+// --- Resolving the provisioned account ---
+
+func TestGrafanaDriver_ResolveServiceAccountID(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer server.Close()
+
+	t.Run("the spec's id wins over the source default", func(t *testing.T) {
+		d := grafanaTestDriver(server, map[string]string{"service_account_id": "1"})
+		saID, err := d.resolveGrafanaServiceAccountID(grafanaSpec("s", map[string]string{"service_account_id": "42"}))
+		require.NoError(t, err)
+		assert.Equal(t, "42", saID)
+	})
+
+	t.Run("the source default applies when the spec is silent", func(t *testing.T) {
+		d := grafanaTestDriver(server, map[string]string{"service_account_id": "7"})
+		saID, err := d.resolveGrafanaServiceAccountID(grafanaSpec("s", nil))
+		require.NoError(t, err)
+		assert.Equal(t, "7", saID)
+	})
+
+	t.Run("neither is an error naming the fix", func(t *testing.T) {
+		d := grafanaTestDriver(server, nil)
+		_, err := d.resolveGrafanaServiceAccountID(grafanaSpec("s", nil))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "service_account_id is required")
+		assert.Contains(t, err.Error(), "it does not create one")
+	})
+
+	t.Run("a non-numeric id is refused", func(t *testing.T) {
+		d := grafanaTestDriver(server, nil)
+		_, err := d.resolveGrafanaServiceAccountID(grafanaSpec("s", map[string]string{"service_account_id": "abc"}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "positive integer")
+	})
+}
+
+// --- Mint ---
+
 func TestGrafanaDriver_MintCredential(t *testing.T) {
-	var saCreateCalled, tokenCreateCalled atomic.Int32
+	var tokenPath, tokenName string
+	var secondsToLive float64
+	var createCalled atomic.Int32
 
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts":
-			saCreateCalled.Add(1)
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/tokens") {
+			createCalled.Add(1)
+			tokenPath = r.URL.Path
+			assert.Equal(t, "Bearer glsa_admin", r.Header.Get("Authorization"))
 
 			var body map[string]interface{}
 			json.NewDecoder(r.Body).Decode(&body)
-			assert.Equal(t, "Viewer", body["role"])
-			assert.Equal(t, false, body["isDisabled"])
-			name, _ := body["name"].(string)
-			assert.True(t, strings.HasPrefix(name, "warden-"), "SA name should start with warden-")
+			tokenName, _ = body["name"].(string)
+			secondsToLive, _ = body["secondsToLive"].(float64)
 
 			w.WriteHeader(http.StatusOK)
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"id": 42,
+				"id": 7, "name": tokenName, "key": "glsa_minted_token_123",
 			})
-
-		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts/42/tokens":
-			tokenCreateCalled.Add(1)
-
-			var body map[string]interface{}
-			json.NewDecoder(r.Body).Decode(&body)
-			assert.Equal(t, "warden-token", body["name"])
-			secondsToLive, _ := body["secondsToLive"].(float64)
-			assert.Equal(t, float64(3600), secondsToLive)
-
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
-				"key": "glsa_minted_token_123",
-			})
-
-		default:
-			w.WriteHeader(http.StatusNotFound)
+			return
 		}
+		// The sweep's token listing.
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[]`)
 	}))
 	defer server.Close()
 
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type: credential.SourceTypeGrafana,
-			Config: map[string]string{
-				"grafana_url": server.URL,
-				"admin_token": "glsa_admin_token",
-			},
-		},
-		httpClient: server.Client(),
-	}
-
-	spec := &credential.CredSpec{
-		Name:   "test-viewer",
-		Type:   credential.TypeAPIKey,
-		Config: map[string]string{},
-	}
-
-	rawData, _, ttl, leaseID, err := driver.MintCredential(context.Background(), spec)
+	driver := grafanaTestDriver(server, nil)
+	rawData, metadata, ttl, leaseID, err := driver.MintCredential(context.Background(),
+		grafanaSpec("dashboards", map[string]string{"service_account_id": "42"}))
 	require.NoError(t, err)
+
 	assert.Equal(t, "glsa_minted_token_123", rawData["api_key"])
 	assert.Equal(t, grafanaDefaultTokenExpiry, ttl)
-	assert.Equal(t, "42", leaseID)
-	assert.Equal(t, int32(1), saCreateCalled.Load())
-	assert.Equal(t, int32(1), tokenCreateCalled.Load())
+	assert.Equal(t, float64(3600), secondsToLive)
+	assert.Equal(t, "42:7", leaseID, "the lease names the token, not just the account")
+	assert.Equal(t, "/api/serviceaccounts/42/tokens", tokenPath,
+		"the token is created on the provisioned account; no account is created")
+	assert.Equal(t, int32(1), createCalled.Load())
+
+	// The token name is the only thing distinguishing one lease from another in
+	// Grafana's view, so it is recorded.
+	assert.Equal(t, "7", metadata["token_id"])
+	assert.Equal(t, tokenName, metadata["token_name"])
+	assert.Equal(t, "42", metadata["service_account_id"])
+	assert.True(t, strings.HasPrefix(tokenName, "warden-dashboards-"), "got %q", tokenName)
 }
 
 func TestGrafanaDriver_MintCredential_CustomConfig(t *testing.T) {
+	var tokenPath, tokenName string
+	var secondsToLive float64
+
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts":
+		if r.Method == http.MethodPost {
+			tokenPath = r.URL.Path
 			var body map[string]interface{}
 			json.NewDecoder(r.Body).Decode(&body)
-			assert.Equal(t, "Admin", body["role"])
-			name, _ := body["name"].(string)
-			assert.True(t, strings.HasPrefix(name, "myprefix-"), "SA name should start with custom prefix")
-
-			// Verify org_id header
-			assert.Equal(t, "99", r.Header.Get("X-Grafana-Org-Id"))
-
+			tokenName, _ = body["name"].(string)
+			secondsToLive, _ = body["secondsToLive"].(float64)
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{"id": 100})
-
-		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts/100/tokens":
-			var body map[string]interface{}
-			json.NewDecoder(r.Body).Decode(&body)
-			secondsToLive, _ := body["secondsToLive"].(float64)
-			assert.Equal(t, float64(1800), secondsToLive) // 30m
-
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{"key": "glsa_custom"})
-
-		default:
-			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": 9, "key": "glsa_custom"})
+			return
 		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[]`)
 	}))
 	defer server.Close()
 
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type: credential.SourceTypeGrafana,
-			Config: map[string]string{
-				"grafana_url": server.URL,
-				"admin_token": "glsa_admin",
-			},
-		},
-		httpClient: server.Client(),
-	}
-
-	spec := &credential.CredSpec{
-		Name: "test-admin",
-		Type: credential.TypeAPIKey,
-		Config: map[string]string{
-			"role":         "Admin",
-			"token_expiry": "30m",
-			"name_prefix":  "myprefix-",
-			"org_id":       "99",
-		},
-	}
-
-	rawData, _, _, leaseID, err := driver.MintCredential(context.Background(), spec)
+	// A source default the spec overrides.
+	driver := grafanaTestDriver(server, map[string]string{"service_account_id": "1"})
+	rawData, _, ttl, leaseID, err := driver.MintCredential(context.Background(),
+		grafanaSpec("editor", map[string]string{
+			"service_account_id": "57",
+			"token_expiry":       "30m",
+			"name_prefix":        "warden-myprefix-",
+		}))
 	require.NoError(t, err)
+
 	assert.Equal(t, "glsa_custom", rawData["api_key"])
-	assert.Equal(t, "99:100", leaseID)
+	assert.Equal(t, 30*time.Minute, ttl)
+	assert.Equal(t, float64(1800), secondsToLive)
+	assert.Equal(t, "57:9", leaseID)
+	assert.Equal(t, "/api/serviceaccounts/57/tokens", tokenPath)
+	assert.True(t, strings.HasPrefix(tokenName, "warden-myprefix-editor-"), "got %q", tokenName)
 }
 
-func TestGrafanaDriver_MintCredential_InvalidRole(t *testing.T) {
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type: credential.SourceTypeGrafana,
-			Config: map[string]string{
-				"grafana_url": "https://grafana.test",
-				"admin_token": "test",
-			},
-		},
-		httpClient: &http.Client{},
-	}
+func TestGrafanaDriver_MintCredential_NoServiceAccount(t *testing.T) {
+	var called atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
 
-	spec := &credential.CredSpec{
-		Name: "test-bad-role",
-		Type: credential.TypeAPIKey,
-		Config: map[string]string{
-			"role": "SuperAdmin",
-		},
-	}
-
-	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
+	driver := grafanaTestDriver(server, nil)
+	_, _, _, _, err := driver.MintCredential(context.Background(), grafanaSpec("x", nil))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid role")
+	assert.Contains(t, err.Error(), "service_account_id is required")
+	assert.Equal(t, int32(0), called.Load(), "nothing should reach Grafana")
 }
 
-func TestGrafanaDriver_MintCredential_SACreateFails(t *testing.T) {
+// Token names are unique per service account, and specs now share one — so two
+// mints in the same millisecond must not collide.
+func TestGrafanaDriver_MintCredential_TokenNamesAreUnique(t *testing.T) {
+	var mu sync.Mutex
+	names := map[string]bool{}
+	var nextID atomic.Int64
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `[]`)
+			return
+		}
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
+		name, _ := body["name"].(string)
+
+		mu.Lock()
+		duplicate := names[name]
+		names[name] = true
+		mu.Unlock()
+
+		if duplicate {
+			// What Grafana does with a name already on the account.
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"message":"service account token with given name already exists"}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": nextID.Add(1), "key": "glsa_" + name})
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{"service_account_id": "42"})
+	spec := grafanaSpec("busy", nil)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 16)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _, _, _, errs[i] = driver.MintCredential(context.Background(), spec)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoError(t, err, "mint %d collided on the token name", i)
+	}
+}
+
+// Creating a token is not idempotent: a retry after a lost response draws Grafana's
+// duplicate-name refusal, so the mint reports failure while the first attempt's
+// token stands, unknown to Warden and unrevokable until it expires.
+func TestGrafanaDriver_MintCredential_CreateNotRetried(t *testing.T) {
+	var createCalled atomic.Int32
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		createCalled.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"message":"boom"}`))
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{"service_account_id": "42"})
+	_, _, _, _, err := driver.MintCredential(context.Background(), grafanaSpec("x", nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create token")
+	assert.Equal(t, int32(1), createCalled.Load(), "a 500 on create must not be retried")
+}
+
+// Grafana reads secondsToLive=0 as "never expires", and a zero lease TTL reads to
+// Warden as a static credential — so a sub-second lifetime must be refused before
+// either sees it.
+func TestGrafanaDriver_MintCredential_SubSecondExpiryRefused(t *testing.T) {
+	var called atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{"service_account_id": "42"})
+	for _, expiry := range []string{"0s", "500ms", "999ms"} {
+		t.Run(expiry, func(t *testing.T) {
+			_, _, _, _, err := driver.MintCredential(context.Background(),
+				grafanaSpec("tiny", map[string]string{"token_expiry": expiry}))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "never expires")
+		})
+	}
+	assert.Equal(t, int32(0), called.Load(), "nothing should reach Grafana")
+}
+
+// The lease must not outlive the token: Grafana is asked for whole seconds, so the
+// TTL Warden records is the truncated value, not the configured one.
+func TestGrafanaDriver_MintCredential_LeaseTTLMatchesSecondsToLive(t *testing.T) {
+	var secondsToLive float64
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `[]`)
+			return
+		}
+		var body map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&body)
+		secondsToLive, _ = body["secondsToLive"].(float64)
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": 3, "key": "glsa_x"})
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{"service_account_id": "42"})
+	_, _, ttl, _, err := driver.MintCredential(context.Background(),
+		grafanaSpec("trunc", map[string]string{"token_expiry": "90s500ms"}))
+	require.NoError(t, err)
+	assert.Equal(t, float64(90), secondsToLive)
+	assert.Equal(t, 90*time.Second, ttl, "the lease must not outlive the token")
+}
+
+// A token with no id could never be revoked, so it is refused rather than issued.
+func TestGrafanaDriver_MintCredential_NoTokenID(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"key": "glsa_orphan"})
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{"service_account_id": "42"})
+	_, _, _, _, err := driver.MintCredential(context.Background(), grafanaSpec("x", nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could never be revoked")
+}
+
+func TestGrafanaDriver_MintCredential_EmptyTokenKey(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": 5, "key": ""})
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{"service_account_id": "42"})
+	_, _, _, _, err := driver.MintCredential(context.Background(), grafanaSpec("x", nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty token key")
+}
+
+func TestGrafanaDriver_MintCredential_APIError(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusForbidden)
 		w.Write([]byte(`{"message":"Insufficient permissions"}`))
 	}))
 	defer server.Close()
 
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type: credential.SourceTypeGrafana,
-			Config: map[string]string{
-				"grafana_url": server.URL,
-				"admin_token": "glsa_bad_token",
-			},
-		},
-		httpClient: server.Client(),
-	}
-
-	spec := &credential.CredSpec{
-		Name:   "test-fail",
-		Type:   credential.TypeAPIKey,
-		Config: map[string]string{},
-	}
-
-	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
+	driver := grafanaTestDriver(server, map[string]string{"service_account_id": "42"})
+	_, _, _, _, err := driver.MintCredential(context.Background(), grafanaSpec("x", nil))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to create service account")
+	assert.Contains(t, err.Error(), "failed to create token on service account 42")
 }
 
-func TestGrafanaDriver_MintCredential_TokenCreateFails_CleansUpSA(t *testing.T) {
-	var deleteCalled atomic.Int32
-
+// The sweep reclaims only names carrying the default prefix, so a spec that
+// wandered outside it would mint tokens nothing ever removes — and on a chained
+// source, where revocation cannot run either, that is permanent.
+func TestGrafanaDriver_MintCredential_NamePrefixMustStayInTheSweptNamespace(t *testing.T) {
+	var called atomic.Int32
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts":
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{"id": 77})
-
-		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts/77/tokens":
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte(`{"message":"Internal error"}`))
-
-		case r.Method == http.MethodDelete && r.URL.Path == "/api/serviceaccounts/77":
-			deleteCalled.Add(1)
-			w.WriteHeader(http.StatusOK)
-
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
+		called.Add(1)
+		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type: credential.SourceTypeGrafana,
-			Config: map[string]string{
-				"grafana_url": server.URL,
-				"admin_token": "glsa_admin",
-			},
-		},
-		httpClient: server.Client(),
-	}
-
-	spec := &credential.CredSpec{
-		Name:   "test-cleanup",
-		Type:   credential.TypeAPIKey,
-		Config: map[string]string{},
-	}
-
-	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
+	driver := grafanaTestDriver(server, map[string]string{"service_account_id": "42"})
+	_, _, _, _, err := driver.MintCredential(context.Background(),
+		grafanaSpec("x", map[string]string{"name_prefix": "acme-"}))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to create service account token")
-	assert.Equal(t, int32(1), deleteCalled.Load(), "should cleanup service account on token create failure")
+	assert.Contains(t, err.Error(), "must start with")
+	assert.Equal(t, int32(0), called.Load(), "nothing should reach Grafana")
 }
 
-func TestGrafanaDriver_MintCredential_EmptyTokenKey(t *testing.T) {
-	var deleteCalled atomic.Int32
-
+// GetDuration swallows a parse error and returns the default, so a spec that
+// predates the write-time check — or one written with verification skipped —
+// would mint an hour while saying sixty of something.
+func TestGrafanaDriver_MintCredential_UnparseableExpiryIsRefusedAtMint(t *testing.T) {
+	var called atomic.Int32
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts":
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{"id": 88})
-
-		case r.Method == http.MethodPost && r.URL.Path == "/api/serviceaccounts/88/tokens":
-			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{"key": ""})
-
-		case r.Method == http.MethodDelete && r.URL.Path == "/api/serviceaccounts/88":
-			deleteCalled.Add(1)
-			w.WriteHeader(http.StatusOK)
-
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
+		called.Add(1)
+		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type: credential.SourceTypeGrafana,
-			Config: map[string]string{
-				"grafana_url": server.URL,
-				"admin_token": "glsa_admin",
-			},
-		},
-		httpClient: server.Client(),
-	}
-
-	spec := &credential.CredSpec{
-		Name:   "test-empty-key",
-		Type:   credential.TypeAPIKey,
-		Config: map[string]string{},
-	}
-
-	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
+	driver := grafanaTestDriver(server, map[string]string{"service_account_id": "42"})
+	_, _, _, _, err := driver.MintCredential(context.Background(),
+		grafanaSpec("x", map[string]string{"token_expiry": "60"}))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "empty token key")
-	assert.Equal(t, int32(1), deleteCalled.Load(), "should cleanup on empty token key")
+	assert.Contains(t, err.Error(), "not a duration")
+	assert.Equal(t, int32(0), called.Load(), "nothing should reach Grafana")
 }
 
+// A sweep that could not even list has not done its job. Parking the account for
+// the full interval would mute it exactly when the thing it compensates for —
+// a token the server will not accept — is what just broke.
+func TestGrafanaDriver_SweepRetriesSoonerAfterAFailedListing(t *testing.T) {
+	var listCalls atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		listCalls.Add(1)
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, nil)
+	require.False(t, driver.sweepExpiredTokens(context.Background(), "42"),
+		"a listing that failed must not report success")
+
+	// Now through startSweep, which is what owns the backoff. It stamps the full
+	// interval up front to stop a stampede, then brings it back in when the sweep
+	// reports failure — so the value read here is the driver's, not this test's.
+	driver.startSweep("42")
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		driver.sweepMu.Lock()
+		next, ok := driver.sweepNext["42"]
+		driver.sweepMu.Unlock()
+		if ok && time.Until(next) <= grafanaSweepRetryInterval {
+			return // the failed sweep pulled its own next attempt forward
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("a failed sweep left the account parked for the full interval")
+}
+
+// --- Revoke ---
+
+// Revocation deletes the one token, leaving the provisioned account and every other
+// token on it untouched.
 func TestGrafanaDriver_Revoke(t *testing.T) {
-	var deleteCalled atomic.Int32
+	var method, path string
 
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodDelete && r.URL.Path == "/api/serviceaccounts/42" {
-			deleteCalled.Add(1)
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		w.WriteHeader(http.StatusNotFound)
+		method, path = r.Method, r.URL.Path
+		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type: credential.SourceTypeGrafana,
-			Config: map[string]string{
-				"grafana_url": server.URL,
-				"admin_token": "glsa_admin",
-			},
-		},
-		httpClient: server.Client(),
-	}
-
-	err := driver.Revoke(context.Background(), "42")
-	require.NoError(t, err)
-	assert.Equal(t, int32(1), deleteCalled.Load())
+	driver := grafanaTestDriver(server, nil)
+	require.NoError(t, driver.Revoke(context.Background(), "42:7"))
+	assert.Equal(t, http.MethodDelete, method)
+	assert.Equal(t, "/api/serviceaccounts/42/tokens/7", path,
+		"the token is deleted, not the account")
 }
 
 func TestGrafanaDriver_Revoke_EmptyLeaseID(t *testing.T) {
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type:   credential.SourceTypeGrafana,
-			Config: map[string]string{},
-		},
-	}
-	err := driver.Revoke(context.Background(), "")
-	assert.NoError(t, err)
+	driver := &GrafanaDriver{credSource: &credential.CredSource{Config: map[string]string{}}}
+	assert.NoError(t, driver.Revoke(context.Background(), ""))
+}
+
+// A token deleted out of band must not fail revocation: an error here sends the
+// expiration manager into backoff and then a daily retry, forever, for a request
+// that can never succeed.
+func TestGrafanaDriver_Revoke_AlreadyGone(t *testing.T) {
+	var called atomic.Int32
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"token not found"}`))
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, nil)
+	require.NoError(t, driver.Revoke(context.Background(), "42:7"))
+	assert.Equal(t, int32(1), called.Load(), "404 is success, and must not be retried")
 }
 
 func TestGrafanaDriver_Revoke_APIError(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte(`{"message":"Service account not found"}`))
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"message":"Internal error"}`))
 	}))
 	defer server.Close()
 
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type: credential.SourceTypeGrafana,
-			Config: map[string]string{
-				"grafana_url": server.URL,
-				"admin_token": "glsa_admin",
-			},
-		},
-		httpClient: server.Client(),
-	}
-
-	err := driver.Revoke(context.Background(), "999")
+	driver := grafanaTestDriver(server, nil)
+	err := driver.Revoke(context.Background(), "42:7")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to delete service account")
+	assert.Contains(t, err.Error(), "failed to delete token")
 }
 
-func TestGrafanaDriver_VerifySpec(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodGet, r.Method)
-		assert.Equal(t, "/api/serviceaccounts/search", r.URL.Path)
-		assert.Equal(t, "1", r.URL.Query().Get("perpage"))
-		assert.Equal(t, "Bearer glsa_admin", r.Header.Get("Authorization"))
+// Both halves reach Revoke from persisted state and are interpolated into a request
+// path, so a lease that is not of this shape is refused rather than sent.
+func TestGrafanaDriver_Revoke_MalformedLease(t *testing.T) {
+	var called atomic.Int32
 
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, nil)
+	for _, lease := range []string{"42", "42:../../admin/users", "abc:7", "42:0"} {
+		err := driver.Revoke(context.Background(), lease)
+		require.Error(t, err, "lease %q", lease)
+		assert.Contains(t, err.Error(), "invalid lease ID")
+	}
+	assert.Equal(t, int32(0), called.Load(), "nothing should reach Grafana")
+}
+
+func TestParseGrafanaLeaseID(t *testing.T) {
+	saID, tokenID, err := parseGrafanaLeaseID("42:7")
+	require.NoError(t, err)
+	assert.Equal(t, "42", saID)
+	assert.Equal(t, "7", tokenID)
+
+	for _, lease := range []string{"", "42", "42:", ":7", "abc:7", "42:abc", "42:0", "0:7", "42:7:9"} {
+		_, _, err := parseGrafanaLeaseID(lease)
+		assert.Error(t, err, "lease %q must not parse", lease)
+	}
+}
+
+// --- VerifySpec ---
+
+func TestGrafanaDriver_VerifySpec(t *testing.T) {
+	var path string
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path = r.URL.Path
+		assert.Equal(t, "Bearer glsa_admin", r.Header.Get("Authorization"))
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"totalCount":      1,
-			"serviceAccounts": []interface{}{},
+			"id": 42, "name": "warden-reader", "role": "Viewer", "isDisabled": false,
 		})
 	}))
 	defer server.Close()
 
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type: credential.SourceTypeGrafana,
-			Config: map[string]string{
-				"grafana_url": server.URL,
-				"admin_token": "glsa_admin",
-			},
-		},
-		httpClient: server.Client(),
-	}
-
-	err := driver.VerifySpec(context.Background(), &credential.CredSpec{
-		Name:   "test",
-		Config: map[string]string{},
-	})
-	require.NoError(t, err)
+	driver := grafanaTestDriver(server, nil)
+	require.NoError(t, driver.VerifySpec(context.Background(),
+		grafanaSpec("x", map[string]string{"service_account_id": "42"})))
+	assert.Equal(t, "/api/serviceaccounts/42", path)
 }
 
-func TestGrafanaDriver_VerifySpec_Unauthorized(t *testing.T) {
+func TestGrafanaDriver_VerifySpec_MissingAccount(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte(`{"message":"Unauthorized"}`))
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"message":"service account not found"}`))
 	}))
 	defer server.Close()
 
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type: credential.SourceTypeGrafana,
-			Config: map[string]string{
-				"grafana_url": server.URL,
-				"admin_token": "glsa_bad_token",
-			},
-		},
-		httpClient: server.Client(),
+	driver := grafanaTestDriver(server, nil)
+	err := driver.VerifySpec(context.Background(),
+		grafanaSpec("x", map[string]string{"service_account_id": "999"}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service account 999 is not reachable")
+}
+
+// A disabled account's tokens do not authenticate, so the spec would mint
+// credentials that never work.
+func TestGrafanaDriver_VerifySpec_DisabledAccount(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"id": 42, "name": "warden-reader", "role": "Viewer", "isDisabled": true,
+		})
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, nil)
+	err := driver.VerifySpec(context.Background(),
+		grafanaSpec("x", map[string]string{"service_account_id": "42"}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is disabled in Grafana")
+}
+
+// Reading an account takes a scope minting a token on it does not, so a
+// write-scoped privileged token is legitimate — and the mint that ran just before
+// this already proved it works.
+func TestGrafanaDriver_VerifySpec_ForbiddenIsAccepted(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"message":"access denied"}`))
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, nil)
+	require.NoError(t, driver.VerifySpec(context.Background(),
+		grafanaSpec("x", map[string]string{"service_account_id": "42"})))
+}
+
+func TestGrafanaDriver_VerifySpec_NoServiceAccount(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, nil)
+	err := driver.VerifySpec(context.Background(), grafanaSpec("x", nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "service_account_id is required")
+}
+
+// --- Sweep ---
+
+// Grafana leaves an expired token listed on the account. The sweep reclaims the
+// ones Warden minted, and only those: the account is operator-provisioned and may
+// be shared.
+func TestGrafanaDriver_SweepExpiredTokens(t *testing.T) {
+	var mu sync.Mutex
+	var deleted []string
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode([]map[string]interface{}{
+				{"id": 1, "name": "warden-dashboards-1-aaa", "hasExpired": true},
+				{"id": 2, "name": "warden-dashboards-2-bbb", "hasExpired": false},
+				{"id": 3, "name": "ci-pipeline-token", "hasExpired": true}, // not ours
+				{"id": 4, "name": "warden-editor-3-ccc", "hasExpired": true},
+			})
+			return
+		}
+		mu.Lock()
+		deleted = append(deleted, strings.TrimPrefix(r.URL.Path, "/api/serviceaccounts/42/tokens/"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, nil)
+	driver.sweepExpiredTokens(context.Background(), "42")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.ElementsMatch(t, []string{"1", "4"}, deleted,
+		"only expired tokens Warden minted: not the live one, not the hand-issued one")
+}
+
+func TestGrafanaDriver_SweepExpiredTokens_ListFailureIsHarmless(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, nil)
+	assert.NotPanics(t, func() {
+		driver.sweepExpiredTokens(context.Background(), "42")
+	}, "a driver without a logger must not panic on the warn path")
+}
+
+// A single timestamp per driver would be spent by whichever spec minted first,
+// starving every other account on the same source.
+func TestGrafanaDriver_SweepRateLimitIsPerAccount(t *testing.T) {
+	var mu sync.Mutex
+	var listed []string
+	done := make(chan struct{}, 8)
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		listed = append(listed, r.URL.Path)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[]`)
+		done <- struct{}{}
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, nil)
+	driver.startSweep("42")
+	driver.startSweep("57")
+	driver.startSweep("42") // inside the interval; must not sweep again
+
+	for i := 0; i < 2; i++ {
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for the sweeps")
+		}
 	}
 
-	err := driver.VerifySpec(context.Background(), &credential.CredSpec{
-		Name:   "test",
-		Config: map[string]string{},
-	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "admin token verification failed")
+	// Settle before concluding. Waiting for exactly two and asserting immediately
+	// would pass a rate limiter that merely made the third sweep slower rather
+	// than suppressing it.
+	select {
+	case <-done:
+		t.Fatal("a third sweep ran; the repeat for account 42 should have been rate-limited away")
+	case <-time.After(time.Second):
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.ElementsMatch(t,
+		[]string{"/api/serviceaccounts/42/tokens", "/api/serviceaccounts/57/tokens"}, listed,
+		"each account sweeps once; the repeat for 42 is rate-limited away")
+}
+
+func TestIsGrafanaWardenTokenName(t *testing.T) {
+	assert.True(t, isGrafanaWardenTokenName("warden-dashboards-123-abc"))
+	assert.False(t, isGrafanaWardenTokenName("ci-pipeline-token"))
+	assert.False(t, isGrafanaWardenTokenName("my-warden-token"))
+}
+
+// --- Helpers ---
+
+func TestValidateGrafanaServiceAccountID(t *testing.T) {
+	for _, v := range []string{"1", "42", "999999"} {
+		assert.NoError(t, validateGrafanaServiceAccountID(v), "id %q", v)
+	}
+	for _, v := range []string{"", "0", "-1", "abc", "4.2", "42 ", "../42"} {
+		assert.Error(t, validateGrafanaServiceAccountID(v), "id %q must be refused", v)
+	}
+}
+
+func TestGrafanaDriver_AuthorizationHeader(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer glsa_my_admin_token", r.Header.Get("Authorization"))
+		assert.Equal(t, "application/json", r.Header.Get("Accept"))
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{}`)
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{"admin_token": "glsa_my_admin_token"})
+	_, _, err := driver.doGrafanaRequest(context.Background(), http.MethodGet, "/api/serviceaccounts/42", nil)
+	require.NoError(t, err)
 }
 
 func TestValidateGrafanaURL(t *testing.T) {
@@ -580,75 +893,4 @@ func TestValidateGrafanaURL_TLSSkipVerify(t *testing.T) {
 	require.NoError(t, validateGrafanaURL("http://grafana.local", true))
 	require.NoError(t, validateGrafanaURL("https://grafana.local", true))
 	require.Error(t, validateGrafanaURL("ftp://grafana.local", true))
-}
-
-func TestGrafanaDriver_MintCredential_SAZeroID(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		json.NewEncoder(w).Encode(map[string]interface{}{"id": 0})
-	}))
-	defer server.Close()
-
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type: credential.SourceTypeGrafana,
-			Config: map[string]string{
-				"grafana_url": server.URL,
-				"admin_token": "glsa_admin",
-			},
-		},
-		httpClient: server.Client(),
-	}
-
-	spec := &credential.CredSpec{
-		Name:   "test-zero-id",
-		Type:   credential.TypeAPIKey,
-		Config: map[string]string{},
-	}
-
-	_, _, _, _, err := driver.MintCredential(context.Background(), spec)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "ID 0")
-}
-
-func TestGrafanaDriver_AuthorizationHeader(t *testing.T) {
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "Bearer glsa_my_admin_token", r.Header.Get("Authorization"))
-		assert.Equal(t, "application/json", r.Header.Get("Accept"))
-
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, `{"totalCount":0,"serviceAccounts":[]}`)
-	}))
-	defer server.Close()
-
-	driver := &GrafanaDriver{
-		credSource: &credential.CredSource{
-			Type: credential.SourceTypeGrafana,
-			Config: map[string]string{
-				"grafana_url": server.URL,
-				"admin_token": "glsa_my_admin_token",
-			},
-		},
-		httpClient: server.Client(),
-	}
-
-	_, _, err := driver.doGrafanaRequest(context.Background(), http.MethodGet, "/api/serviceaccounts/search", nil, "")
-	require.NoError(t, err)
-}
-
-func TestParseGrafanaLeaseID(t *testing.T) {
-	tests := []struct {
-		leaseID   string
-		wantSAID  string
-		wantOrgID string
-	}{
-		{"1337", "1337", ""},
-		{"42:1337", "1337", "42"},
-		{"org:with:colon:99", "99", "org:with:colon"},
-	}
-	for _, tc := range tests {
-		saID, orgID := parseGrafanaLeaseID(tc.leaseID)
-		assert.Equal(t, tc.wantSAID, saID, "leaseID=%q saID", tc.leaseID)
-		assert.Equal(t, tc.wantOrgID, orgID, "leaseID=%q orgID", tc.leaseID)
-	}
 }

--- a/credential/types/api_key.go
+++ b/credential/types/api_key.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/stephnangue/warden/credential"
 )
@@ -60,7 +61,7 @@ func NewAPIKeyCredType() *APIKeyCredType {
 			// credential the type calls revocable, so a key minted for a caller
 			// outlived the session it was minted for and sat at the upstream until
 			// its own expiry — which an elastic spec may set to 30d, and which a
-			// grafana service-account token does not have at all.
+			// grafana spec may set to as long as the operator likes.
 			Revocable: true,
 		},
 	}
@@ -120,18 +121,19 @@ func (t *APIKeyCredType) ConfigSchema() []*credential.FieldValidator {
 			Describe("JSON role descriptors scoping the key's privileges (elastic)").
 			Example(`{"reader":{"indices":[{"names":["logs-*"],"privileges":["read"]}]}}`),
 
-		credential.StringField("role").
-			OneOf("Viewer", "Editor", "Admin").
-			Describe("Service-account role (grafana)").
-			Example("Viewer"),
+		credential.StringField("service_account_id").
+			Custom(validateGrafanaServiceAccountID).
+			Describe("Provisioned service account to mint tokens on (grafana); overrides the source's default").
+			Example("42"),
 
 		credential.StringField("name_prefix").
-			Describe("Prefix for the generated service-account name (grafana)").
-			Example("warden"),
+			Custom(validateGrafanaNamePrefix).
+			Describe("Prefix for the generated token name (grafana); must itself start with 'warden-'").
+			Example("warden-team-a-"),
 
-		credential.StringField("org_id").
-			Describe("Organization the service account is created in (grafana)").
-			Example("1"),
+		credential.StringField("token_expiry").
+			Describe("Lifetime of the minted service-account token (grafana; default 1h)").
+			Example("1h"),
 
 		credential.StringField("key_type").
 			OneOf("ingest", "configuration").
@@ -302,9 +304,37 @@ func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType str
 				return fmt.Errorf("'role_descriptors' is not valid JSON")
 			}
 		}
-	case credential.SourceTypeGrafana, credential.SourceTypeHoneycomb:
+	case credential.SourceTypeGrafana:
+		// As above: the token is created upstream per mint and the spec holds no
+		// key. What it holds is which provisioned service account to mint on, and
+		// the shape of the token.
+		//
+		// This arm is where grafana's spec validation has to live. The driver's
+		// VerifySpec runs only inside the store's test-mint block, which is skipped
+		// for a chained spec — so a check placed there would be dead on exactly the
+		// keyless path. This runs for every spec.
+		//
+		// service_account_id is validated by the schema when present. It cannot be
+		// required here: it may come from the source instead, and this method is
+		// handed the source's type but never its config. The store checks that.
+		if raw, present := config["token_expiry"]; present {
+			if err := validateGrafanaTokenExpiry(raw); err != nil {
+				return fmt.Errorf("'token_expiry': %w", err)
+			}
+		}
+		// ValidateSchema ignores keys it does not declare, so a removed field is
+		// not a refused one: left alone, role would be accepted here and then
+		// masked on read as an unrecognised key, showing an operator their role
+		// displayed as a secret and telling them nothing.
+		if _, present := config["role"]; present {
+			return fmt.Errorf("'role' is not settable: a minted token carries the role of the service account it is issued on, which you set in Grafana when provisioning that account. Point service_account_id at an account with the role you want")
+		}
+		if _, present := config["org_id"]; present {
+			return fmt.Errorf("'org_id' is not settable: a service account belongs to one organization, so naming the account in service_account_id already says which. Use one source per organization")
+		}
+	case credential.SourceTypeHoneycomb:
 		// As above: the key is created upstream per mint and the spec holds no
-		// key. Their mint parameters are validated by their own drivers.
+		// key. Its mint parameters are validated by its own driver.
 	default:
 		// apikey source: the api_key lives inline in the spec, unless it is sourced from
 		// another cred spec via credential chaining (secret_spec) — the two are mutually
@@ -354,6 +384,65 @@ func validateElasticTimeValue(v string) error {
 	}
 	return fmt.Errorf("is not an Elasticsearch time value (an integer and one of %s), got: %s",
 		strings.Join(elasticTimeUnits, ", "), v)
+}
+
+// validateGrafanaTokenExpiry checks the lifetime a grafana spec asks for.
+//
+// The lower bound is the point of it. The driver passes this to Grafana as an
+// integer number of seconds, and Grafana reads 0 as "this token never expires" —
+// so anything under a second truncates into a permanent token carrying the
+// provisioned account's role. Warden would not catch it either: a zero lease TTL
+// reads as a static credential and is registered as nonexpiring.
+//
+// credential.GetDuration swallows a parse error and returns the default, so an
+// unchecked "60" here would mint a 1h token while the spec says otherwise. Unlike
+// elastic's expiration this is a Go duration — the driver parses it with
+// time.ParseDuration, so that is what validates it.
+func validateGrafanaTokenExpiry(v string) error {
+	if v == "" {
+		return fmt.Errorf("must not be empty; omit it to take the 1h default, or give a lifetime such as 30m")
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return fmt.Errorf("is not a duration (an integer and a unit, such as 30m or 24h), got: %s", v)
+	}
+	if d < time.Second {
+		return fmt.Errorf("must be at least 1s, got: %s; Grafana reads a shorter lifetime as a token that never expires", v)
+	}
+	return nil
+}
+
+// validateGrafanaNamePrefix keeps a spec's token names inside the namespace the
+// driver's sweep recognises.
+//
+// The sweep covers a whole service account, which several specs may share with
+// the account's own operator, so it reclaims only names that announce themselves
+// as Warden's. A spec free to pick any prefix could therefore mint tokens the
+// sweep will never look at, and nothing else would ever remove them. Requiring
+// the prefix to extend the default keeps per-spec naming useful
+// ("warden-team-a-") without letting a spec opt out of being cleaned up.
+func validateGrafanaNamePrefix(v string) error {
+	const wardenPrefix = "warden-"
+	if !strings.HasPrefix(v, wardenPrefix) {
+		return fmt.Errorf("must start with %q so the driver's sweep recognises the tokens it names (it reclaims only Warden's own), got: %s",
+			wardenPrefix, v)
+	}
+	return nil
+}
+
+// validateGrafanaServiceAccountID checks an account id is what Grafana issues: a
+// positive integer. The driver interpolates it into a request path, where a value
+// that is not a number is answered with an opaque 404 at mint time.
+//
+// Deliberately duplicated from the driver rather than shared: credential/types
+// does not import credential/drivers, and one small predicate is a better price
+// than that edge.
+func validateGrafanaServiceAccountID(v string) error {
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil || n <= 0 {
+		return fmt.Errorf("must be a positive integer (the numeric id Grafana gives the account), got: %s", v)
+	}
+	return nil
 }
 
 // RequiresSpecRotation returns false — API keys live in source config, not spec.

--- a/credential/types/api_key.go
+++ b/credential/types/api_key.go
@@ -261,6 +261,14 @@ func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType str
 			return fmt.Errorf("for an elastic source, set %s on the source (the chained api key authenticates the source's own Security API calls), not on the spec",
 				credential.ConfigSecretSpec)
 		}
+		// Grafana chains for the same reason and at the same level: the fetched
+		// secret is the privileged token its own token-management calls are made
+		// with, and every spec on it mints a fresh token rather than serving a
+		// stored one.
+		if sourceType == credential.SourceTypeGrafana {
+			return fmt.Errorf("for a grafana source, set %s on the source (the chained token authenticates the source's own service-account calls), not on the spec",
+				credential.ConfigSecretSpec)
+		}
 		return fmt.Errorf("secret_spec (credential chaining) is not supported with a %s source", sourceType)
 	}
 

--- a/credential/types/api_key_test.go
+++ b/credential/types/api_key_test.go
@@ -209,13 +209,104 @@ func TestAPIKeyCredType_ValidateConfig(t *testing.T) {
 		},
 		{
 			name:       "grafana source - no api_key required",
-			config:     map[string]string{"role": "Viewer"},
+			config:     map[string]string{"service_account_id": "42"},
 			sourceType: credential.SourceTypeGrafana,
 			wantErr:    false,
 		},
 		{
+			name: "grafana source - full mint config",
+			config: map[string]string{
+				"service_account_id": "42",
+				"token_expiry":       "30m",
+				"name_prefix":        "warden-team-a-",
+			},
+			sourceType: credential.SourceTypeGrafana,
+			wantErr:    false,
+		},
+		{
+			// The sweep reclaims only names carrying the default prefix, so a
+			// prefix outside it mints tokens nothing ever removes.
+			name:       "grafana source - a name_prefix outside the swept namespace is refused",
+			config:     map[string]string{"service_account_id": "42", "name_prefix": "acme-"},
+			sourceType: credential.SourceTypeGrafana,
+			wantErr:    true,
+			errMsg:     "must start with",
+		},
+		{
+			// The id may come from the source instead, which this method cannot
+			// see — so presence is the store's check, shape is this one's.
+			name:       "grafana source - a silent spec is fine here",
+			config:     map[string]string{},
+			sourceType: credential.SourceTypeGrafana,
+			wantErr:    false,
+		},
+		{
+			name:       "grafana source - non-numeric service_account_id",
+			config:     map[string]string{"service_account_id": "my-account"},
+			sourceType: credential.SourceTypeGrafana,
+			wantErr:    true,
+			errMsg:     "positive integer",
+		},
+		{
+			// Warden mints on an account the operator provisioned, and that
+			// account's role is the credential's privilege. Removing the field from
+			// the schema would only make it unrecognised — and therefore masked on
+			// read — so it is refused by name.
+			name:       "grafana source - role is refused with guidance",
+			config:     map[string]string{"service_account_id": "42", "role": "Admin"},
+			sourceType: credential.SourceTypeGrafana,
+			wantErr:    true,
+			errMsg:     "'role' is not settable",
+		},
+		{
+			name:       "grafana source - org_id is refused with guidance",
+			config:     map[string]string{"service_account_id": "42", "org_id": "1"},
+			sourceType: credential.SourceTypeGrafana,
+			wantErr:    true,
+			errMsg:     "'org_id' is not settable",
+		},
+		{
+			// GetDuration swallows a parse error and hands back the default, so an
+			// unchecked "60" mints a 1h token while the spec says otherwise.
+			name:       "grafana source - unitless token_expiry is refused",
+			config:     map[string]string{"service_account_id": "42", "token_expiry": "60"},
+			sourceType: credential.SourceTypeGrafana,
+			wantErr:    true,
+			errMsg:     "is not a duration",
+		},
+		{
+			// Grafana reads secondsToLive=0 as "never expires".
+			name:       "grafana source - zero token_expiry is refused",
+			config:     map[string]string{"service_account_id": "42", "token_expiry": "0s"},
+			sourceType: credential.SourceTypeGrafana,
+			wantErr:    true,
+			errMsg:     "must be at least 1s",
+		},
+		{
+			name:       "grafana source - sub-second token_expiry is refused",
+			config:     map[string]string{"service_account_id": "42", "token_expiry": "500ms"},
+			sourceType: credential.SourceTypeGrafana,
+			wantErr:    true,
+			errMsg:     "must be at least 1s",
+		},
+		{
+			name:       "grafana source - empty token_expiry is refused",
+			config:     map[string]string{"service_account_id": "42", "token_expiry": ""},
+			sourceType: credential.SourceTypeGrafana,
+			wantErr:    true,
+			errMsg:     "must not be empty",
+		},
+		{
 			name:       "honeycomb source - no api_key required",
 			config:     map[string]string{"key_type": "ingest"},
+			sourceType: credential.SourceTypeHoneycomb,
+			wantErr:    false,
+		},
+		{
+			// The grafana arm was split out of the shared one; honeycomb keeps its
+			// own mint parameters and must not pick up grafana's checks.
+			name:       "honeycomb source - unaffected by the grafana arm split",
+			config:     map[string]string{"key_type": "configuration", "key_name_prefix": "warden"},
 			sourceType: credential.SourceTypeHoneycomb,
 			wantErr:    false,
 		},
@@ -600,6 +691,46 @@ func TestAPIKeyCredType_KnownAdjunctFieldsAreDeclared(t *testing.T) {
 
 	for _, field := range ct.KnownAdjunctFields() {
 		assert.True(t, declared[field], "adjunct %q must be declared in ConfigSchema", field)
+	}
+}
+
+// A mint parameter reads back in the clear only because it is declared. Left out
+// of the schema, grafana's token_expiry was displayed to an operator as a secret.
+func TestAPIKeyCredType_SensitiveConfigFieldsFor_GrafanaMintParams(t *testing.T) {
+	ct := NewAPIKeyCredType()
+
+	fields := ct.SensitiveConfigFieldsFor(map[string]string{
+		"service_account_id": "42",
+		"name_prefix":        "warden-team-a-",
+		"token_expiry":       "1h",
+	})
+
+	for _, key := range []string{"service_account_id", "name_prefix", "token_expiry"} {
+		assert.NotContains(t, fields, key, "%s shapes the mint and is not a secret", key)
+	}
+}
+
+func TestValidateGrafanaTokenExpiry(t *testing.T) {
+	for _, v := range []string{"1s", "30m", "1h", "24h", "90s500ms"} {
+		t.Run("valid/"+v, func(t *testing.T) {
+			assert.NoError(t, validateGrafanaTokenExpiry(v))
+		})
+	}
+	// "" is the key present and empty, "60" is the unitless trap GetDuration would
+	// swallow, and anything under a second becomes a token Grafana never expires.
+	for _, v := range []string{"", "60", "1hour", "0s", "0", "500ms", "-1h"} {
+		t.Run("invalid/"+v, func(t *testing.T) {
+			assert.Error(t, validateGrafanaTokenExpiry(v))
+		})
+	}
+}
+
+func TestValidateGrafanaServiceAccountID(t *testing.T) {
+	for _, v := range []string{"1", "42", "999999"} {
+		assert.NoError(t, validateGrafanaServiceAccountID(v), "id %q", v)
+	}
+	for _, v := range []string{"", "0", "-1", "abc", "4.2", "../42"} {
+		assert.Error(t, validateGrafanaServiceAccountID(v), "id %q must be refused", v)
 	}
 }
 

--- a/credential/types/api_key_test.go
+++ b/credential/types/api_key_test.go
@@ -297,6 +297,15 @@ func TestAPIKeyCredType_ValidateConfig(t *testing.T) {
 			errMsg:     "must not be empty",
 		},
 		{
+			// grafana chains at the source, not the spec: the fetched token
+			// authenticates the source's own service-account calls.
+			name:       "grafana source - spec-level secret_spec points at the source",
+			config:     map[string]string{credential.ConfigSecretSpec: "grafana-admin-token"},
+			sourceType: credential.SourceTypeGrafana,
+			wantErr:    true,
+			errMsg:     "set secret_spec on the source",
+		},
+		{
 			name:       "honeycomb source - no api_key required",
 			config:     map[string]string{"key_type": "ingest"},
 			sourceType: credential.SourceTypeHoneycomb,


### PR DESCRIPTION
> Stacked on #574. Review that one first; this diff is against it.

## Why

A grafana source held a standing service-account token to manage tokens on the account it mints against. That is exactly the kind of secret credential chaining exists to remove — elastic, ovh, ibm, scaleway, gitlab, github, oauth2 and token_exchange already fetch their source credential per request and store nothing.

## What

A source can now name a cred spec that yields the privileged token (`secret_spec`), which Warden mints **as the calling agent** at use time and keeps nowhere. The two are mutually exclusive: keeping the token beside the reference would leave a source that reads as keyless while storing the very secret chaining removes.

Chaining is a **source** concern here, as it is for elastic — the fetched token authenticates the driver's own service-account calls, not the credential being served — so a spec-level reference is refused with guidance by both the `api_key` type and the config store, the latter holding when the type registry is unavailable and `credType` is nil.

The service account is still named per spec. Chaining supplies the token that *manages* tokens, not the account they are minted on — the one thing a reader might reasonably expect it to cover, so it is refused explicitly and tested.

## The part worth reviewing carefully

**A chained source cannot revoke.** Revocation runs at lease expiry, where there is no caller to walk the chain as. So `Revoke` warns and returns rather than feeding the daily irrevocable-lease loop a request that can never succeed. The minted token still expires on its own, and the sweep reclaims it from the account's token list on a later mint.

That leaves a window nothing closes: a lease ending **early** — revoked by an operator, or clamped below `token_expiry` — leaves a live token until it expires, and the sweep only reclaims what Grafana already reports as expired. So a chained spec's `token_expiry` is capped (24h), refused both at the write that introduces it and again at mint. The inline path revokes precisely and keeps its full range.

The ceiling is applied in the store as well as the driver because only the store can see both the spec's lifetime and whether its source is chained — the credential type is handed the source's *type* but never its config.

## Known limitation

Editing an inline source into a chained one while leases are outstanding silently turns those leases unrevokable, because `Revoke` decides from current config rather than from the lease. Refusing that needs the expiration manager's outstanding-lease set, which is a larger change than this PR.

## Verification

`go build ./... && go vet ./...`, full `go test ./...`, `-race` on the driver, and the full e2e suite (20 packages) green. End-to-end coverage of both paths is #576.
