### PR TITLE
chore: ignore local working files kept in the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,15 @@ e2e/.certs/
 e2e/.logs/
 e2e/.pids/
 e2e/.root_token
+# Local working files: agent configuration, scratch analyses, and a throwaway
+# compose stack. They live in the repo root for convenience but belong to one
+# machine, not to the project.
+.claude/
+dirk-*.md
+eu-ai-act-analysis.md
+per-user-oauth-cert-dex/
+
+# The e2e findings log. It records production gaps the e2e suites surface, and
+# is kept alongside the run rather than committed: entries are resolved by
+# fixing the gap, not by editing the list in a review.
+e2e/FINDINGS.md


### PR DESCRIPTION
Agent configuration, scratch analyses and a throwaway compose stack sit in the working tree for convenience but belong to one machine, not to the project.

Untracked, they were one stray `git add -A` away from a commit — which is exactly how they reached one during a rebase on a branch in flight. Ignoring them removes the hazard rather than relying on care.

- `.claude/`
- `dirk-*.md`
- `eu-ai-act-analysis.md`
- `per-user-oauth-cert-dex/`
- `e2e/FINDINGS.md` — the e2e findings log, kept alongside the run rather than committed: entries are resolved by fixing the gap, not by editing the list in a review.

Independent of the grafana stack (#574 → #575 → #576); it just happens to be the same working tree.
