### PR TITLE
feat(grafana): fetch the privileged token per request instead of storing one

### DIFF
--- a/core/credential_config_store.go
+++ b/core/credential_config_store.go
@@ -1119,10 +1119,26 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 	// config, so it validates the value's shape and cannot check that a value
 	// exists at all. Checked here rather than left to mint time because a spec
 	// naming no account fails every request it ever serves.
-	if source.Type == credential.SourceTypeGrafana &&
-		credential.GetString(spec.Config, "service_account_id", "") == "" &&
-		credential.GetString(source.Config, "service_account_id", "") == "" {
-		return logical.ErrBadRequestf("service_account_id is required for a grafana spec: set it on the spec, or on the source as a default; Warden mints tokens on an account you provision in Grafana, it does not create one")
+	if source.Type == credential.SourceTypeGrafana {
+		if credential.GetString(spec.Config, "service_account_id", "") == "" &&
+			credential.GetString(source.Config, "service_account_id", "") == "" {
+			return logical.ErrBadRequestf("service_account_id is required for a grafana spec: set it on the spec, or on the source as a default; Warden mints tokens on an account you provision in Grafana, it does not create one")
+		}
+		// A chained grafana source cannot revoke — there is no caller at lease
+		// expiry to fetch its token as — so a token it mints stays live until its
+		// own expiry however the lease ended. The driver refuses an over-long one
+		// at mint; this is the same rule where an operator can act on it, at the
+		// write that introduces it. Only this layer can apply it: the credential
+		// type is handed the source's TYPE but never its config, so it cannot tell
+		// a chained source from an inline one.
+		if source.Config[credential.ConfigSecretSpec] != "" {
+			if raw := credential.GetString(spec.Config, "token_expiry", ""); raw != "" {
+				if d, err := time.ParseDuration(raw); err == nil && d > drivers.GrafanaChainedMaxTokenExpiry {
+					return logical.ErrBadRequestf("'token_expiry' %s exceeds the %s ceiling for a chained grafana source: revocation cannot run without a caller to fetch the token as, so a minted token stays live until it expires",
+						raw, drivers.GrafanaChainedMaxTokenExpiry)
+				}
+			}
+		}
 	}
 
 	// Credential chaining: when this spec (spec-level, wins) or its source
@@ -1183,6 +1199,11 @@ func (s *CredentialConfigStore) validateSpec(ctx context.Context, spec *credenti
 				// this is the layer that holds when the type registry is unavailable
 				// and credType is nil — the same reason the ovh arm below exists.
 				return logical.ErrBadRequestf("for an elastic source, set secret_spec on the source (the chained api key authenticates the source's own Security API calls), not on the spec")
+			case credential.SourceTypeGrafana:
+				// Same shape as elastic: the fetched token authenticates the source's
+				// own service-account calls, and every spec on it mints a fresh token
+				// rather than serving a stored one.
+				return logical.ErrBadRequestf("for a grafana source, set secret_spec on the source (the chained token authenticates the source's own service-account calls), not on the spec")
 			}
 		}
 		// An oauth2 source that chains its client credential resolves the pair per mint,

--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -2935,3 +2935,123 @@ func TestCredentialConfigStore_UpdateSource_GrafanaDefaultAccountIsLoadBearing(t
 		assert.NotContains(t, err.Error(), "gf-explicit")
 	})
 }
+
+// A grafana source chains the privileged token that authenticates its own
+// service-account calls, so the reference belongs on the source — the same shape
+// as elastic above, and refused at this layer for the same reason: the api_key
+// type says it first, and this is what holds when the type registry is
+// unavailable and credType is nil.
+func TestCredentialConfigStore_ValidateSpec_GrafanaChainsAtTheSource(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "grafana-admin-token", Type: "vault_token", Source: "src",
+		Config: map[string]string{
+			"subject_token_source": "warden_identity",
+			"assertion_audience":   "test-aud",
+		},
+	}))
+
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "grafana-chained", Type: credential.SourceTypeGrafana,
+		Config: map[string]string{
+			credential.ConfigSecretSpec: "grafana-admin-token",
+			"service_account_id":        "42",
+		},
+	}))
+
+	t.Run("a spec on a chained source needs no reference of its own", func(t *testing.T) {
+		require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "grafana-chained-spec", Type: credential.TypeAPIKey, Source: "grafana-chained",
+			Config: map[string]string{"token_expiry": "1h"},
+		}))
+	})
+
+	t.Run("a spec-level reference is refused with guidance", func(t *testing.T) {
+		err := store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "grafana-spec-level", Type: credential.TypeAPIKey, Source: "grafana-chained",
+			Config: map[string]string{credential.ConfigSecretSpec: "grafana-admin-token"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "set secret_spec on the source")
+	})
+
+	// A chained source holds no privileged token to rotate; the referenced spec's
+	// owner rotates it at the source of truth.
+	t.Run("rotation_period on a chained source is refused", func(t *testing.T) {
+		err := store.CreateSource(ctx, &credential.CredSource{
+			Name: "grafana-chained-rotating", Type: credential.SourceTypeGrafana,
+			RotationPeriod: time.Hour,
+			Config:         map[string]string{credential.ConfigSecretSpec: "grafana-admin-token"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rotation_period does not apply to a chained source")
+	})
+
+	// The account still has to be named: chaining supplies the token that manages
+	// tokens, not the account they are minted on.
+	t.Run("a chained source still needs a service account", func(t *testing.T) {
+		require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+			Name: "grafana-chained-bare", Type: credential.SourceTypeGrafana,
+			Config: map[string]string{credential.ConfigSecretSpec: "grafana-admin-token"},
+		}))
+		err := store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "grafana-no-account", Type: credential.TypeAPIKey, Source: "grafana-chained-bare",
+			Config: map[string]string{},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "service_account_id is required")
+	})
+}
+
+// A chained grafana source cannot revoke, so a token it mints stays live until
+// its own expiry however the lease ended. The driver refuses an over-long one at
+// mint; this is the same rule at the write that introduces it, and only this
+// layer can apply it — the credential type is handed the source's TYPE but never
+// its config, so it cannot tell a chained source from an inline one.
+func TestCredentialConfigStore_ValidateSpec_GrafanaChainedTokenExpiryIsCapped(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{Name: "src", Type: "local"}))
+	require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+		Name: "gf-token", Type: "vault_token", Source: "src",
+		Config: map[string]string{
+			"subject_token_source": "warden_identity",
+			"assertion_audience":   "test-aud",
+		},
+	}))
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "gf-chained", Type: credential.SourceTypeGrafana,
+		Config: map[string]string{
+			credential.ConfigSecretSpec: "gf-token",
+			"service_account_id":        "42",
+		},
+	}))
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "gf-inline", Type: credential.SourceTypeGrafana,
+		Config: map[string]string{"admin_token": "glsa_x", "service_account_id": "42"},
+	}))
+
+	spec := func(name, source, expiry string) *credential.CredSpec {
+		return &credential.CredSpec{
+			Name: name, Type: credential.TypeAPIKey, Source: source,
+			MinTTL: 5 * time.Minute, MaxTTL: time.Hour,
+			Config: map[string]string{"token_expiry": expiry},
+		}
+	}
+
+	t.Run("an over-long lifetime on a chained source is refused", func(t *testing.T) {
+		err := store.CreateSpec(ctx, spec("gf-long", "gf-chained", "720h"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "ceiling for a chained grafana source")
+	})
+
+	t.Run("the same lifetime is fine inline, where revocation is precise", func(t *testing.T) {
+		require.NoError(t, store.CreateSpec(ctx, spec("gf-long-inline", "gf-inline", "720h")))
+	})
+
+	t.Run("a lifetime within the ceiling is accepted", func(t *testing.T) {
+		require.NoError(t, store.CreateSpec(ctx, spec("gf-short", "gf-chained", "1h")))
+	})
+}

--- a/credential/drivers/grafana_driver.go
+++ b/credential/drivers/grafana_driver.go
@@ -40,9 +40,25 @@ const (
 	grafanaSweepTimeout       = 2 * time.Minute
 )
 
+// GrafanaChainedMaxTokenExpiry bounds how long a token minted from a chained
+// source may live.
+//
+// Exported because the config store applies the same rule at spec-write time,
+// where an operator can act on it — it is the only layer that can see both the
+// spec's lifetime and whether its source is chained.
+//
+// Such a source cannot revoke: revocation runs at lease expiry, where there is no
+// caller to fetch the chained token as. So a minted token stays valid until its
+// own expiry however the lease ended — and a lease can end early, well before
+// token_expiry, leaving a live credential nothing will take back until the sweep
+// sees Grafana report it expired. That window is the exposure, and an operator
+// asking for 720h would be asking for a month of it.
+const GrafanaChainedMaxTokenExpiry = 24 * time.Hour
+
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*GrafanaDriver)(nil)
 var _ credential.SpecVerifier = (*GrafanaDriver)(nil)
+var _ credential.ChainedSecretMinter = (*GrafanaDriver)(nil)
 var _ credential.RotationConfigValidator = (*GrafanaDriverFactory)(nil)
 
 // GrafanaDriver mints tokens on a service account an operator provisioned.
@@ -58,6 +74,13 @@ var _ credential.RotationConfigValidator = (*GrafanaDriverFactory)(nil)
 // spec cannot ask for privilege the operator did not already grant. MintCredential
 // creates one token on the named account; Revoke deletes that one token, leaving
 // the account and every other token on it untouched.
+//
+// Held inline, the privileged token authenticates every call. Chained
+// (secret_spec), it is fetched per mint from a referenced spec as the calling
+// agent and kept nowhere — which leaves nothing to revoke with once the request
+// is over, since revocation runs at lease expiry where there is no caller to walk
+// the chain as. The minted token still expires on its own, and the sweep reclaims
+// what it leaves behind.
 type GrafanaDriver struct {
 	credSource *credential.CredSource
 	logger     *logger.GatedLogger
@@ -81,6 +104,9 @@ func (f *GrafanaDriverFactory) Type() string {
 
 // ValidateConfig validates Grafana source configuration using declarative schema.
 func (f *GrafanaDriverFactory) ValidateConfig(config map[string]string) error {
+	if err := validateGrafanaChainedConfig(config); err != nil {
+		return err
+	}
 	return credential.ValidateSchema(config,
 		credential.StringField("grafana_url").
 			Required().
@@ -90,9 +116,11 @@ func (f *GrafanaDriverFactory) ValidateConfig(config map[string]string) error {
 			Describe("Grafana API base URL").
 			Example("https://mystack.grafana.net"),
 
+		// Required only when the source holds its own token; a chained source is
+		// refused one outright. validateGrafanaChainedConfig enforces both halves of
+		// that, since the schema can express neither.
 		credential.StringField("admin_token").
-			Required().
-			Describe("Service-account token able to manage tokens on the provisioned account"),
+			Describe("Service-account token able to manage tokens on the provisioned account; required unless secret_spec is set"),
 
 		credential.StringField("service_account_id").
 			Custom(validateGrafanaServiceAccountID).
@@ -105,7 +133,42 @@ func (f *GrafanaDriverFactory) ValidateConfig(config map[string]string) error {
 
 		credential.BoolField("tls_skip_verify").
 			Describe("Skip TLS certificate verification (development only)"),
+
+		credential.StringField(credential.ConfigSecretSpec).
+			Describe("Cred spec yielding the privileged token, instead of storing one here").
+			Example("grafana-admin-token"),
+
+		credential.StringField(credential.ConfigSecretField).
+			Describe("Field of the referenced credential holding the privileged token").
+			Example("admin_token"),
+
+		credential.DurationField(credential.ConfigSecretCacheTTL).
+			Describe("How long to reuse the fetched token before re-fetching (default: no caching)").
+			Example("30m"),
 	)
+}
+
+// validateGrafanaChainedConfig holds a source to exactly one way of getting its
+// privileged token.
+//
+// A chained source keeps none of its own: keeping one would leave a source that
+// reads as keyless while storing the very secret chaining removes, and there is
+// nothing here that could use it — the fetched token authenticates every call, and
+// the paths that run without a caller are disabled rather than falling back to it.
+func validateGrafanaChainedConfig(config map[string]string) error {
+	if credential.GetString(config, credential.ConfigSecretSpec, "") == "" {
+		// The schema cannot express "required unless another key is set", so the
+		// non-chained requirement lands here alongside its opposite.
+		if credential.GetString(config, "admin_token", "") == "" {
+			return fmt.Errorf("admin_token is required unless %s is set", credential.ConfigSecretSpec)
+		}
+		return nil
+	}
+	if credential.GetString(config, "admin_token", "") != "" {
+		return fmt.Errorf("admin_token must be omitted when %s is set; the referenced spec supplies the privileged token",
+			credential.ConfigSecretSpec)
+	}
+	return nil
 }
 
 // SensitiveConfigFields returns source config keys that should be masked.
@@ -169,6 +232,12 @@ func (d *GrafanaDriver) warn(msg string, fields ...logger.TypedField) {
 	}
 }
 
+// isChained reports whether this source fetches its privileged token per mint
+// rather than holding one.
+func (d *GrafanaDriver) isChained() bool {
+	return credential.GetString(d.credSource.Config, credential.ConfigSecretSpec, "") != ""
+}
+
 // resolveGrafanaServiceAccountID returns the account a spec mints against: its own
 // service_account_id, or the source's default.
 //
@@ -196,6 +265,62 @@ func (d *GrafanaDriver) resolveGrafanaServiceAccountID(spec *credential.CredSpec
 // itself, and that id is what the lease carries: revocation deletes the one token,
 // not the account it hangs off.
 func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// A chained spec mints through MintFromSecret, which the minting layer routes
+	// it to. Arriving here means that routing was bypassed, so fail rather than
+	// fall through to an inline token this source does not have.
+	if d.isChained() || spec.Config[credential.ConfigSecretSpec] != "" {
+		return nil, nil, 0, "", fmt.Errorf("grafana: %s is set (credential chaining); this spec mints from fetched secret material, not directly",
+			credential.ConfigSecretSpec)
+	}
+	return d.mintToken(ctx, d.getAdminToken(), spec, false)
+}
+
+// MintFromSecret mints from a privileged token fetched through credential
+// chaining, for a source that stores none of its own.
+func (d *GrafanaDriver) MintFromSecret(ctx context.Context, spec *credential.CredSpec, material credential.SecretMaterial) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	token, err := resolveChainedGrafanaToken(material)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+	return d.mintToken(ctx, token, spec, true)
+}
+
+// resolveChainedGrafanaToken reads the privileged token out of fetched secret
+// material.
+//
+// Grafana has one wire shape for this — an opaque bearer token — so unlike elastic
+// there is nothing here to disambiguate; the only question is which key of the
+// payload holds it.
+func resolveChainedGrafanaToken(material credential.SecretMaterial) (string, error) {
+	token := material.Secret()
+
+	// Fall back to conventional names ONLY when no field was resolved. A field that
+	// resolved to nothing is a misconfigured secret_field — say so, rather than
+	// silently authenticating with some other value from the payload.
+	if token == "" && material.Field == "" {
+		for _, key := range []string{"admin_token", "api_key", "token"} {
+			if token = material.Data[key]; token != "" {
+				break
+			}
+		}
+	}
+	if token == "" {
+		if material.Field != "" {
+			return "", fmt.Errorf("grafana: %s %q is empty or absent in the fetched secret material: %w",
+				credential.ConfigSecretField, material.Field, credential.ErrChainedSecretIncomplete)
+		}
+		return "", fmt.Errorf("grafana: no privileged token in fetched secret material (set %s, or store it under 'admin_token', 'api_key' or 'token'): %w",
+			credential.ConfigSecretField, credential.ErrChainedSecretIncomplete)
+	}
+	return token, nil
+}
+
+// mintToken creates one token on the spec's account.
+//
+// chained says where the privileged token it authenticates with came from, which
+// decides only how an authentication refusal is reported: a fetched token can be
+// stale and worth re-fetching, an inline one cannot.
+func (d *GrafanaDriver) mintToken(ctx context.Context, adminToken string, spec *credential.CredSpec, chained bool) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	saID, err := d.resolveGrafanaServiceAccountID(spec)
 	if err != nil {
 		return nil, nil, 0, "", err
@@ -233,6 +358,16 @@ func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.Cre
 		return nil, nil, 0, "", fmt.Errorf("token_expiry %s is under one second, which Grafana would read as a token that never expires; give a lifetime of 1s or more", tokenExpiry)
 	}
 
+	// A chained source cannot revoke, so a token it mints stays live until its own
+	// expiry — including when the lease ends early, which the sweep cannot help
+	// with because it only reclaims tokens Grafana already reports as expired.
+	// That window is the whole exposure, so it is bounded here rather than left to
+	// whatever an operator typed.
+	if chained && tokenExpiry > GrafanaChainedMaxTokenExpiry {
+		return nil, nil, 0, "", fmt.Errorf("token_expiry %s exceeds the %s ceiling for a chained source: revocation cannot run without a caller to fetch the token as, so a minted token stays live until it expires",
+			tokenExpiry, GrafanaChainedMaxTokenExpiry)
+	}
+
 	// Token names are unique per service account, and every spec now mints against
 	// an account it may share — so the name carries a random suffix as well as a
 	// timestamp. Two mints of the same spec in the same millisecond would otherwise
@@ -253,8 +388,16 @@ func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.Cre
 	// that refusal and report a failed mint while the token the first attempt
 	// created stands — unknown to Warden, and unrevokable until it expires.
 	path := fmt.Sprintf("/api/serviceaccounts/%s/tokens", url.PathEscape(saID))
-	respBody, _, err := d.doGrafanaRequestWith(ctx, http.MethodPost, path, body, grafanaCreateRetryConfig)
+	respBody, status, err := d.doGrafanaRequestWith(ctx, adminToken, http.MethodPost, path, body, grafanaCreateRetryConfig)
 	if err != nil {
+		// On the chained path a refusal to authenticate marks the fetched token as
+		// stale, so the minting layer evicts what it cached and retries once with a
+		// fresh read. An inline source has nothing to evict, and saying so would only
+		// send it round a loop that cannot change the outcome.
+		if chained && (status == http.StatusUnauthorized || status == http.StatusForbidden) {
+			return nil, nil, 0, "", fmt.Errorf("grafana: the server rejected the chained privileged token: %w (%w)",
+				credential.ErrChainedSecretRejected, err)
+		}
 		return nil, nil, 0, "", fmt.Errorf("failed to create token on service account %s: %w", saID, err)
 	}
 
@@ -305,7 +448,7 @@ func (d *GrafanaDriver) MintCredential(ctx context.Context, spec *credential.Cre
 		)
 	}
 
-	d.startSweep(saID)
+	d.startSweep(adminToken, saID)
 
 	return rawData, metadata, leaseTTL, leaseID, nil
 }
@@ -322,11 +465,24 @@ func (d *GrafanaDriver) Revoke(ctx context.Context, leaseID string) error {
 		return err
 	}
 
+	// A chained source holds no token to authorise the delete, and revocation runs
+	// at lease expiry, where there is no caller to walk the chain as. That will
+	// never change, so returning an error would only send the expiration manager
+	// into backoff and then a daily retry, forever, for a request that cannot
+	// succeed. The minted token carries its own expiry — which is why a mint is
+	// refused a lifetime Grafana would round to "never" — and a later mint's sweep
+	// reclaims it.
+	if d.isChained() {
+		d.warn("cannot revoke a token minted from a chained privileged token; it expires on its own and is swept on a later mint",
+			logger.String("lease", leaseID))
+		return nil
+	}
+
 	// 200 = deleted, 404 = already gone — both are success. Returning an error for a
 	// token that is no longer there would send the expiration manager into backoff
 	// and then a daily retry, forever, for a request that can never succeed.
 	path := fmt.Sprintf("/api/serviceaccounts/%s/tokens/%s", url.PathEscape(saID), url.PathEscape(tokenID))
-	if _, _, err := d.doGrafanaRequest(ctx, http.MethodDelete, path, nil, 200, 204, 404); err != nil {
+	if _, _, err := d.doGrafanaRequest(ctx, d.getAdminToken(), http.MethodDelete, path, nil, 200, 204, 404); err != nil {
 		return fmt.Errorf("failed to delete token %s: %w", leaseID, err)
 	}
 
@@ -366,8 +522,16 @@ func (d *GrafanaDriver) VerifySpec(ctx context.Context, spec *credential.CredSpe
 		return err
 	}
 
+	// A chained source holds no token to probe with — it is fetched per mint, as
+	// the caller, and there is no caller here. Belt and braces: the store does not
+	// call this for a chained spec at all, which is why the account id above is
+	// checked by the store rather than relied on here.
+	if d.isChained() {
+		return nil
+	}
+
 	path := fmt.Sprintf("/api/serviceaccounts/%s", url.PathEscape(saID))
-	respBody, status, err := d.doGrafanaRequest(ctx, http.MethodGet, path, nil)
+	respBody, status, err := d.doGrafanaRequest(ctx, d.getAdminToken(), http.MethodGet, path, nil)
 	if err != nil {
 		// Reading an account takes a scope that minting a token on it does not, so a
 		// deliberately write-scoped privileged token is a legitimate configuration.
@@ -423,17 +587,21 @@ var grafanaCreateRetryConfig = httputil.HTTPRetryConfig{
 // doGrafanaRequest executes an authenticated HTTP request to the Grafana API with
 // the default retry policy. Optional okStatuses override the default 2xx success
 // check (e.g. pass 200, 204, 404 to treat an already-deleted token as success).
-func (d *GrafanaDriver) doGrafanaRequest(ctx context.Context, method, path string, body []byte, okStatuses ...int) ([]byte, int, error) {
-	return d.doGrafanaRequestWith(ctx, method, path, body, defaultGrafanaRetryConfig, okStatuses...)
+func (d *GrafanaDriver) doGrafanaRequest(ctx context.Context, adminToken, method, path string, body []byte, okStatuses ...int) ([]byte, int, error) {
+	return d.doGrafanaRequestWith(ctx, adminToken, method, path, body, defaultGrafanaRetryConfig, okStatuses...)
 }
 
 // doGrafanaRequestWith is doGrafanaRequest with an explicit retry policy.
-func (d *GrafanaDriver) doGrafanaRequestWith(ctx context.Context, method, path string, body []byte, retry httputil.HTTPRetryConfig, okStatuses ...int) ([]byte, int, error) {
+//
+// The privileged token is passed in rather than read from config: a chained
+// source holds none, and the one it authenticates with belongs to the request
+// that fetched it.
+func (d *GrafanaDriver) doGrafanaRequestWith(ctx context.Context, adminToken, method, path string, body []byte, retry httputil.HTTPRetryConfig, okStatuses ...int) ([]byte, int, error) {
 	apiURL := d.getGrafanaURL() + path
 
 	headers := map[string]string{
 		"Accept":        "application/json",
-		"Authorization": "Bearer " + d.getAdminToken(),
+		"Authorization": "Bearer " + adminToken,
 	}
 	if body != nil {
 		headers["Content-Type"] = "application/json"
@@ -471,7 +639,7 @@ func (d *GrafanaDriver) doGrafanaRequestWith(ctx context.Context, method, path s
 // It runs detached, on its own context: a sweep is a list plus a delete per
 // reclaimed token, and run inline on the caller's context it would add that to the
 // tail of a live request, or be cancelled the moment the mint returns.
-func (d *GrafanaDriver) startSweep(saID string) {
+func (d *GrafanaDriver) startSweep(adminToken, saID string) {
 	// Claimed under the lock rather than with a check-then-set pair: concurrent
 	// mints on one account are the normal case, and a gap between them lets every
 	// one of them launch a sweep.
@@ -492,7 +660,7 @@ func (d *GrafanaDriver) startSweep(saID string) {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), grafanaSweepTimeout)
 		defer cancel()
-		if !d.sweepExpiredTokens(ctx, saID) {
+		if !d.sweepExpiredTokens(ctx, adminToken, saID) {
 			// Bring the next attempt forward. The interval above exists to stop a
 			// busy spec sweeping on every request, not to sit out an outage.
 			d.sweepMu.Lock()
@@ -514,9 +682,9 @@ func (d *GrafanaDriver) startSweep(saID string) {
 // token would be destroying objects this source does not own.
 // It reports whether the listing succeeded. A sweep that could not even read the
 // account has not done its job, and the caller brings the next attempt forward.
-func (d *GrafanaDriver) sweepExpiredTokens(ctx context.Context, saID string) bool {
+func (d *GrafanaDriver) sweepExpiredTokens(ctx context.Context, adminToken, saID string) bool {
 	path := fmt.Sprintf("/api/serviceaccounts/%s/tokens", url.PathEscape(saID))
-	respBody, _, err := d.doGrafanaRequest(ctx, http.MethodGet, path, nil)
+	respBody, _, err := d.doGrafanaRequest(ctx, adminToken, http.MethodGet, path, nil)
 	if err != nil {
 		d.warn("could not list service account tokens to reclaim expired ones",
 			logger.String("service_account_id", saID),
@@ -542,7 +710,7 @@ func (d *GrafanaDriver) sweepExpiredTokens(ctx context.Context, saID string) boo
 			continue
 		}
 		delPath := fmt.Sprintf("/api/serviceaccounts/%s/tokens/%d", url.PathEscape(saID), token.ID)
-		if _, _, err := d.doGrafanaRequest(ctx, http.MethodDelete, delPath, nil, 200, 204, 404); err != nil {
+		if _, _, err := d.doGrafanaRequest(ctx, adminToken, http.MethodDelete, delPath, nil, 200, 204, 404); err != nil {
 			// Another node sweeping the same account is expected and harmless; a
 			// real failure just leaves the token for the next sweep.
 			d.warn("could not reclaim an expired token",

--- a/credential/drivers/grafana_driver_test.go
+++ b/credential/drivers/grafana_driver_test.go
@@ -361,9 +361,10 @@ func TestGrafanaDriver_MintCredential_TokenNamesAreUnique(t *testing.T) {
 		mu.Unlock()
 
 		if duplicate {
-			// What Grafana does with a name already on the account.
+			// What Grafana does with a name already on the account: ErrDuplicateToken,
+			// an errutil.BadRequest, so 400 and never retryable.
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte(`{"message":"service account token with given name already exists"}`))
+			w.Write([]byte(`{"messageId":"serviceaccounts.ErrTokenAlreadyExists","message":"service account token with name busy already exists in the organization"}`))
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -550,13 +551,13 @@ func TestGrafanaDriver_SweepRetriesSoonerAfterAFailedListing(t *testing.T) {
 	defer server.Close()
 
 	driver := grafanaTestDriver(server, nil)
-	require.False(t, driver.sweepExpiredTokens(context.Background(), "42"),
+	require.False(t, driver.sweepExpiredTokens(context.Background(), "glsa_admin", "42"),
 		"a listing that failed must not report success")
 
 	// Now through startSweep, which is what owns the backoff. It stamps the full
 	// interval up front to stop a stampede, then brings it back in when the sweep
 	// reports failure — so the value read here is the driver's, not this test's.
-	driver.startSweep("42")
+	driver.startSweep("glsa_admin", "42")
 
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
@@ -765,7 +766,7 @@ func TestGrafanaDriver_SweepExpiredTokens(t *testing.T) {
 	defer server.Close()
 
 	driver := grafanaTestDriver(server, nil)
-	driver.sweepExpiredTokens(context.Background(), "42")
+	driver.sweepExpiredTokens(context.Background(), "glsa_admin", "42")
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -781,7 +782,7 @@ func TestGrafanaDriver_SweepExpiredTokens_ListFailureIsHarmless(t *testing.T) {
 
 	driver := grafanaTestDriver(server, nil)
 	assert.NotPanics(t, func() {
-		driver.sweepExpiredTokens(context.Background(), "42")
+		driver.sweepExpiredTokens(context.Background(), "glsa_admin", "42")
 	}, "a driver without a logger must not panic on the warn path")
 }
 
@@ -803,9 +804,9 @@ func TestGrafanaDriver_SweepRateLimitIsPerAccount(t *testing.T) {
 	defer server.Close()
 
 	driver := grafanaTestDriver(server, nil)
-	driver.startSweep("42")
-	driver.startSweep("57")
-	driver.startSweep("42") // inside the interval; must not sweep again
+	driver.startSweep("glsa_admin", "42")
+	driver.startSweep("glsa_admin", "57")
+	driver.startSweep("glsa_admin", "42") // inside the interval; must not sweep again
 
 	for i := 0; i < 2; i++ {
 		select {
@@ -837,6 +838,251 @@ func TestIsGrafanaWardenTokenName(t *testing.T) {
 	assert.False(t, isGrafanaWardenTokenName("my-warden-token"))
 }
 
+// --- Credential chaining (keyless source) ---
+
+func TestGrafanaDriverFactory_ValidateConfig_Chained(t *testing.T) {
+	factory := &GrafanaDriverFactory{}
+
+	tests := []struct {
+		name    string
+		config  map[string]string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "secret_spec without admin_token",
+			config: map[string]string{
+				"grafana_url":               "https://mystack.grafana.net",
+				credential.ConfigSecretSpec: "grafana-admin-token",
+			},
+		},
+		{
+			name: "secret_spec with the modifiers",
+			config: map[string]string{
+				"grafana_url":                   "https://mystack.grafana.net",
+				"service_account_id":            "42",
+				credential.ConfigSecretSpec:     "grafana-admin-token",
+				credential.ConfigSecretField:    "admin_token",
+				credential.ConfigSecretCacheTTL: "30m",
+			},
+		},
+		{
+			// Keeping the token would leave a source that reads as keyless while
+			// storing the very secret chaining removes.
+			name: "admin_token alongside secret_spec is refused",
+			config: map[string]string{
+				"grafana_url":               "https://mystack.grafana.net",
+				"admin_token":               "glsa_still_here",
+				credential.ConfigSecretSpec: "grafana-admin-token",
+			},
+			wantErr: true,
+			errMsg:  "admin_token must be omitted",
+		},
+		{
+			name:    "neither admin_token nor secret_spec is refused",
+			config:  map[string]string{"grafana_url": "https://mystack.grafana.net"},
+			wantErr: true,
+			errMsg:  "admin_token is required unless",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := factory.ValidateConfig(tt.config)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestResolveChainedGrafanaToken(t *testing.T) {
+	tests := []struct {
+		name     string
+		material credential.SecretMaterial
+		want     string
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name:     "secret_field names the token",
+			material: credential.SecretMaterial{Data: map[string]string{"admin_token": "glsa_a", "other": "x"}, Field: "admin_token"},
+			want:     "glsa_a",
+		},
+		{
+			name:     "conventional name admin_token",
+			material: credential.SecretMaterial{Data: map[string]string{"admin_token": "glsa_b"}},
+			want:     "glsa_b",
+		},
+		{
+			name:     "conventional name api_key",
+			material: credential.SecretMaterial{Data: map[string]string{"api_key": "glsa_c"}},
+			want:     "glsa_c",
+		},
+		{
+			name:     "conventional name token",
+			material: credential.SecretMaterial{Data: map[string]string{"token": "glsa_d"}},
+			want:     "glsa_d",
+		},
+		{
+			// A field that resolved to nothing is a misconfigured secret_field. Say
+			// so, rather than silently authenticating with some other value from the
+			// payload — admin_token is present here and must NOT be used.
+			name:     "a resolved-to-nothing secret_field does not fall back",
+			material: credential.SecretMaterial{Data: map[string]string{"admin_token": "glsa_e"}, Field: "wrong_name"},
+			wantErr:  true,
+			errMsg:   "is empty or absent",
+		},
+		{
+			name:     "no token at all",
+			material: credential.SecretMaterial{Data: map[string]string{"unrelated": "x"}},
+			wantErr:  true,
+			errMsg:   "no privileged token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveChainedGrafanaToken(tt.material)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, credential.ErrChainedSecretIncomplete)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGrafanaDriver_MintFromSecret(t *testing.T) {
+	var gotAuth, gotPath string
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			gotAuth, gotPath = r.Header.Get("Authorization"), r.URL.Path
+			w.WriteHeader(http.StatusOK)
+			json.NewEncoder(w).Encode(map[string]interface{}{"id": 31, "key": "glsa_minted"})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[]`)
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{
+		"admin_token":               "", // a chained source holds none
+		credential.ConfigSecretSpec: "grafana-admin-token",
+	})
+
+	rawData, metadata, ttl, leaseID, err := driver.MintFromSecret(context.Background(),
+		grafanaSpec("kv", map[string]string{"service_account_id": "42"}),
+		credential.SecretMaterial{Data: map[string]string{"admin_token": "glsa_chained_admin"}})
+	require.NoError(t, err)
+
+	assert.Equal(t, "glsa_minted", rawData["api_key"])
+	assert.Equal(t, time.Hour, ttl)
+	assert.Equal(t, "42:31", leaseID)
+	assert.Equal(t, "42", metadata["service_account_id"])
+	assert.Equal(t, "/api/serviceaccounts/42/tokens", gotPath)
+	assert.Equal(t, "Bearer glsa_chained_admin", gotAuth,
+		"the chained token must authenticate, not a stored one")
+}
+
+// Routing a chained spec is the minting layer's job. Arriving at MintCredential
+// means it was bypassed, and falling through would authenticate with an empty
+// token.
+func TestGrafanaDriver_MintCredential_RefusesChainedSource(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("nothing should reach Grafana")
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{
+		"admin_token":               "",
+		credential.ConfigSecretSpec: "grafana-admin-token",
+	})
+
+	_, _, _, _, err := driver.MintCredential(context.Background(),
+		grafanaSpec("x", map[string]string{"service_account_id": "42"}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential chaining")
+}
+
+// A fetched token can be stale and worth re-fetching; an inline one cannot, and
+// saying so would send it round a loop that cannot change the outcome.
+func TestGrafanaDriver_ChainedRejectionMarksSecretStale(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"message":"Unauthorized"}`))
+	}))
+	defer server.Close()
+
+	spec := grafanaSpec("x", map[string]string{"service_account_id": "42"})
+
+	chained := grafanaTestDriver(server, map[string]string{
+		"admin_token":               "",
+		credential.ConfigSecretSpec: "grafana-admin-token",
+	})
+	_, _, _, _, err := chained.MintFromSecret(context.Background(), spec,
+		credential.SecretMaterial{Data: map[string]string{"admin_token": "glsa_stale"}})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, credential.ErrChainedSecretRejected)
+
+	inline := grafanaTestDriver(server, nil)
+	_, _, _, _, err = inline.MintCredential(context.Background(), spec)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, credential.ErrChainedSecretRejected,
+		"an inline source has nothing to evict")
+}
+
+// Revocation runs at lease expiry, where a chained source has no caller to fetch
+// its privileged token as. An error there would only feed the daily irrevocable
+// loop.
+func TestGrafanaDriver_Revoke_ChainedIsNoOp(t *testing.T) {
+	var called atomic.Int32
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{
+		"admin_token":               "",
+		credential.ConfigSecretSpec: "grafana-admin-token",
+	})
+
+	require.NoError(t, driver.Revoke(context.Background(), "42:7"))
+	assert.Equal(t, int32(0), called.Load(), "nothing should reach Grafana")
+
+	// A malformed lease is still refused: that check does not depend on a token.
+	require.Error(t, driver.Revoke(context.Background(), "42"))
+}
+
+func TestGrafanaDriver_VerifySpec_ChainedIsNoOp(t *testing.T) {
+	var called atomic.Int32
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	driver := grafanaTestDriver(server, map[string]string{
+		"admin_token":               "",
+		credential.ConfigSecretSpec: "grafana-admin-token",
+	})
+
+	require.NoError(t, driver.VerifySpec(context.Background(),
+		grafanaSpec("x", map[string]string{"service_account_id": "42"})))
+	assert.Equal(t, int32(0), called.Load())
+}
+
 // --- Helpers ---
 
 func TestValidateGrafanaServiceAccountID(t *testing.T) {
@@ -858,7 +1104,7 @@ func TestGrafanaDriver_AuthorizationHeader(t *testing.T) {
 	defer server.Close()
 
 	driver := grafanaTestDriver(server, map[string]string{"admin_token": "glsa_my_admin_token"})
-	_, _, err := driver.doGrafanaRequest(context.Background(), http.MethodGet, "/api/serviceaccounts/42", nil)
+	_, _, err := driver.doGrafanaRequest(context.Background(), driver.getAdminToken(), http.MethodGet, "/api/serviceaccounts/42", nil)
 	require.NoError(t, err)
 }
 
@@ -893,4 +1139,36 @@ func TestValidateGrafanaURL_TLSSkipVerify(t *testing.T) {
 	require.NoError(t, validateGrafanaURL("http://grafana.local", true))
 	require.NoError(t, validateGrafanaURL("https://grafana.local", true))
 	require.Error(t, validateGrafanaURL("ftp://grafana.local", true))
+}
+
+// A chained source cannot revoke, so a token it mints stays live until its own
+// expiry however the lease ended. That window is bounded; the inline path, which
+// revokes precisely, is not.
+func TestGrafanaDriver_ChainedTokenExpiryIsCapped(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(map[string]interface{}{"id": 4, "key": "glsa_x"})
+	}))
+	defer server.Close()
+
+	spec := grafanaSpec("long", map[string]string{
+		"service_account_id": "42",
+		"token_expiry":       "720h",
+	})
+
+	chained := grafanaTestDriver(server, map[string]string{
+		"admin_token":               "",
+		credential.ConfigSecretSpec: "grafana-admin-token",
+	})
+	_, _, _, _, err := chained.MintFromSecret(context.Background(), spec,
+		credential.SecretMaterial{Data: map[string]string{"admin_token": "glsa_chained"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ceiling for a chained source")
+
+	// The same lifetime is fine inline, where revocation removes the token
+	// precisely when the lease ends.
+	inline := grafanaTestDriver(server, nil)
+	_, _, ttl, _, err := inline.MintCredential(context.Background(), spec)
+	require.NoError(t, err)
+	assert.Equal(t, 720*time.Hour, ttl)
 }

--- a/credential/types/api_key.go
+++ b/credential/types/api_key.go
@@ -261,6 +261,14 @@ func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType str
 			return fmt.Errorf("for an elastic source, set %s on the source (the chained api key authenticates the source's own Security API calls), not on the spec",
 				credential.ConfigSecretSpec)
 		}
+		// Grafana chains for the same reason and at the same level: the fetched
+		// secret is the privileged token its own token-management calls are made
+		// with, and every spec on it mints a fresh token rather than serving a
+		// stored one.
+		if sourceType == credential.SourceTypeGrafana {
+			return fmt.Errorf("for a grafana source, set %s on the source (the chained token authenticates the source's own service-account calls), not on the spec",
+				credential.ConfigSecretSpec)
+		}
 		return fmt.Errorf("secret_spec (credential chaining) is not supported with a %s source", sourceType)
 	}
 

--- a/credential/types/api_key_test.go
+++ b/credential/types/api_key_test.go
@@ -297,6 +297,15 @@ func TestAPIKeyCredType_ValidateConfig(t *testing.T) {
 			errMsg:     "must not be empty",
 		},
 		{
+			// grafana chains at the source, not the spec: the fetched token
+			// authenticates the source's own service-account calls.
+			name:       "grafana source - spec-level secret_spec points at the source",
+			config:     map[string]string{credential.ConfigSecretSpec: "grafana-admin-token"},
+			sourceType: credential.SourceTypeGrafana,
+			wantErr:    true,
+			errMsg:     "set secret_spec on the source",
+		},
+		{
 			name:       "honeycomb source - no api_key required",
 			config:     map[string]string{"key_type": "ingest"},
 			sourceType: credential.SourceTypeHoneycomb,


### PR DESCRIPTION
> Stacked on #574. Review that one first; this diff is against it.

## Why

A grafana source held a standing service-account token to manage tokens on the account it mints against. That is exactly the kind of secret credential chaining exists to remove — elastic, ovh, ibm, scaleway, gitlab, github, oauth2 and token_exchange already fetch their source credential per request and store nothing.

## What

A source can now name a cred spec that yields the privileged token (`secret_spec`), which Warden mints **as the calling agent** at use time and keeps nowhere. The two are mutually exclusive: keeping the token beside the reference would leave a source that reads as keyless while storing the very secret chaining removes.

Chaining is a **source** concern here, as it is for elastic — the fetched token authenticates the driver's own service-account calls, not the credential being served — so a spec-level reference is refused with guidance by both the `api_key` type and the config store, the latter holding when the type registry is unavailable and `credType` is nil.

The service account is still named per spec. Chaining supplies the token that *manages* tokens, not the account they are minted on — the one thing a reader might reasonably expect it to cover, so it is refused explicitly and tested.

## The part worth reviewing carefully

**A chained source cannot revoke.** Revocation runs at lease expiry, where there is no caller to walk the chain as. So `Revoke` warns and returns rather than feeding the daily irrevocable-lease loop a request that can never succeed. The minted token still expires on its own, and the sweep reclaims it from the account's token list on a later mint.

That leaves a window nothing closes: a lease ending **early** — revoked by an operator, or clamped below `token_expiry` — leaves a live token until it expires, and the sweep only reclaims what Grafana already reports as expired. So a chained spec's `token_expiry` is capped (24h), refused both at the write that introduces it and again at mint. The inline path revokes precisely and keeps its full range.

The ceiling is applied in the store as well as the driver because only the store can see both the spec's lifetime and whether its source is chained — the credential type is handed the source's *type* but never its config.

## Known limitation

Editing an inline source into a chained one while leases are outstanding silently turns those leases unrevokable, because `Revoke` decides from current config rather than from the lease. Refusing that needs the expiration manager's outstanding-lease set, which is a larger change than this PR.

## Verification

`go build ./... && go vet ./...`, full `go test ./...`, `-race` on the driver, and the full e2e suite (20 packages) green. End-to-end coverage of both paths is #576.
