### PR TITLE
test(e2e): drive the grafana source driver end to end, both paths

### DIFF
--- a/e2e/fullchain/grafana_chaining_test.go
+++ b/e2e/fullchain/grafana_chaining_test.go
@@ -1,0 +1,338 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// A grafana source chains the privileged token that authenticates its own
+// service-account calls. Grafana's token API has no assertion grant to federate
+// against, so as with elastic and ibm, keyless here means removing the token from
+// Warden rather than exchanging an identity for one.
+//
+// Chaining is a SOURCE concern for this driver, and only that. There is one mint
+// path and no second reading of the fetched material — every spec issues a fresh
+// token rather than serving a stored one — so a spec-level reference means
+// nothing and is refused, with the guidance to move it to the source.
+//
+// What chaining does NOT supply is the account. The fetched token is the one that
+// manages tokens; the account they are minted on is still the operator's, still
+// named by the spec or its source, and still required — which the last row here
+// pins, because it is the one thing a reader might expect chaining to cover.
+//
+// The inline half of this driver is next door in grafana_source_test.go.
+
+const (
+	// Written to secret/data/e2e/grafana-admin-token by setup.sh, under the key
+	// the driver looks for by convention.
+	grafanaChainedAdminToken = "glsa_e2e-grafana-not-a-real-admin-token"
+
+	// Test-local, the source included, for the reason the other chained suites
+	// give: a killed run skips t.Cleanup, and a spec left hanging off a shared
+	// source would block that source from being deleted, failing the next run's
+	// setup before it reaches the cleanup that would have cleared it.
+	grafanaSecretSpec     = "fc-gf-token-from-vault"
+	grafanaChainSource    = "fc-gf-keyless-src"
+	grafanaChainSpec      = "fc-gf-chain-cred"
+	grafanaChainAgentRole = "fc-gf-chain-agent"
+)
+
+// setupGrafanaChain stands up one chain: a referenced spec over the Vault secret,
+// a source holding no token that names it, an ordinary spec naming the account,
+// and a role selecting that spec.
+//
+// secretField may be empty, which exercises the conventional-name fallback — the
+// driver reads admin_token, then api_key, then token, but only when no field was
+// resolved.
+func setupGrafanaChain(t *testing.T, subj scalewaySubject, secretField string, stub *grafanaStub) {
+	t.Helper()
+
+	// The referenced spec is minted as the calling agent, and both subjects derive
+	// that agent from an inbound JWT — agent_identity forwards it, warden_identity
+	// signs an assertion from the principal it established. This mount's default
+	// agent leg is a client certificate, which carries neither.
+	useJWTAgentLeg(t, grafanaEnv)
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+grafanaChainAgentRole, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+grafanaChainSpec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+grafanaChainSource, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+grafanaSecretSpec, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	grafanaMustWrite(t, "POST", "sys/cred/specs/"+grafanaSecretSpec, fmt.Sprintf(`{
+		"type":"key_value","source":%q,"config":{
+			"mint_method":"kv2_read","kv2_mount":"secret",
+			"secret_path":"e2e/grafana-admin-token","subject_token_source":%q}}`,
+		subj.source, subj.name),
+		"create the referenced secret spec "+grafanaSecretSpec)
+
+	// No admin_token: validation refuses a source that keeps one while naming a
+	// chain. tls_skip_verify because the stub listens on http, the same allowance
+	// every other stubbed source in this suite takes.
+	sourceCfg := fmt.Sprintf(`"grafana_url":%q,"tls_skip_verify":"true","secret_spec":%q`,
+		stub.URL, grafanaSecretSpec)
+	if secretField != "" {
+		sourceCfg += fmt.Sprintf(`,"secret_field":%q`, secretField)
+	}
+	grafanaMustWrite(t, "POST", "sys/cred/sources/"+grafanaChainSource,
+		fmt.Sprintf(`{"type":"grafana","config":{%s}}`, sourceCfg),
+		"create the keyless grafana source")
+
+	// Ordinary but for the account: it inherits the chain from its source and
+	// carries no chaining config of its own, which is what source-level chaining
+	// means.
+	grafanaMustWrite(t, "POST", "sys/cred/specs/"+grafanaChainSpec, fmt.Sprintf(
+		`{"type":"api_key","source":%q,"config":{"service_account_id":%q,"token_expiry":"1h"}}`,
+		grafanaChainSource, grafanaAccountViewer),
+		"create the chained grafana spec")
+
+	grafanaMustWrite(t, "POST", "auth/jwt/role/"+grafanaChainAgentRole, fmt.Sprintf(`{
+		"token_policies":[%q],"cred_spec_name":%q,
+		"user_claim":"sub","token_ttl":3600}`,
+		grafanaEnv.Policy(), grafanaChainSpec),
+		"create the chained agent role")
+}
+
+// TestGrafanaChaining_SourceFetchesTheTokenPerRequest is the whole feature in one
+// row: the source stores no Grafana secret, the referenced spec yields one, and
+// the token the gateway injects is the one Grafana issued for exactly that
+// privileged token.
+//
+// Both ways of naming the secret are driven — by secret_field, and by the
+// conventional key the driver falls back to when no field is set — because the
+// fallback only applies when nothing resolved, and a resolver that fell back on
+// an empty result would silently authenticate with some other value.
+func TestGrafanaChaining_SourceFetchesTheTokenPerRequest(t *testing.T) {
+	ensureEnv(t)
+
+	fields := []struct {
+		name  string
+		field string
+	}{
+		{"named_by_secret_field", "admin_token"},
+		{"conventional_name", ""},
+	}
+
+	for _, subj := range scalewaySubjects {
+		for _, f := range fields {
+			t.Run(subj.name+"/"+f.name, func(t *testing.T) {
+				stub := startGrafanaStub(t)
+				setupGrafanaChain(t, subj, f.field, stub)
+				stub.reset()
+				upstream.Reset()
+
+				status, body, _ := h.ChainRequest(t, leaderPort, grafanaEnv, h.ChainOpts{
+					AgentToken: h.GetDefaultJWT(t),
+					Bearer:     h.FullChainUserJWT(t),
+					Role:       grafanaChainAgentRole,
+					Path:       h.ProbePath("grafana-chained-" + f.name),
+				})
+				if status != 200 {
+					t.Fatalf("status %d, body %s", status, string(body))
+				}
+
+				// The stub derives what it issues from the token it was handed, so
+				// this header is the end-to-end proof that the FETCHED token
+				// performed the create — not an inline one a routing regression fell
+				// back to.
+				h.AssertChain(t, upstream, status, body, h.ChainWant{
+					Status:        200,
+					Injected:      map[string]string{"Authorization": "Bearer " + grafanaMintedFor(grafanaChainedAdminToken)},
+					Absent:        h.AlwaysAbsent(),
+					UpstreamCalls: 1,
+				})
+
+				// And Grafana's own record agrees, which distinguishes a genuine
+				// chain from a header that merely looks right.
+				presented := stub.observed()
+				if len(presented) == 0 {
+					t.Fatal("the Grafana stub saw no token creation at all")
+				}
+				for _, token := range presented {
+					if token != grafanaChainedAdminToken {
+						t.Errorf("the create authenticated with %q, want the chained privileged token", token)
+					}
+				}
+
+				// Chaining supplies the token that manages tokens, not the account.
+				for _, c := range stub.createdTokens() {
+					if c.AccountID != grafanaAccountViewer {
+						t.Errorf("the token was created on account %q, want the account the spec names (%q)",
+							c.AccountID, grafanaAccountViewer)
+					}
+				}
+				if deleted := stub.deletedAccounts(); len(deleted) != 0 {
+					t.Errorf("Grafana was asked to delete service account(s) %v", deleted)
+				}
+			})
+		}
+	}
+}
+
+// TestGrafanaChaining_ExpiredTokensAreReclaimed is the sweep on the path where it
+// is the only reclamation there is.
+//
+// A chained source cannot revoke — there is no caller at lease expiry to fetch
+// the privileged token as — so nothing but this removes what it mints. It also
+// cannot be observed the way the inline row's sweep partly could: a chained spec
+// is never test-minted at create, so the only sweep that ever runs is the one a
+// real request triggers, authenticating with the token that request fetched.
+func TestGrafanaChaining_ExpiredTokensAreReclaimed(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startGrafanaStub(t)
+	setupGrafanaChain(t, scalewaySubjects[0], "admin_token", stub)
+
+	stub.primeTokens(grafanaAccountViewer,
+		grafanaStubToken{ID: 8001, Name: "warden-" + grafanaChainSpec + "-1-aaaaaaaa", HasExpired: true},
+		grafanaStubToken{ID: 8002, Name: "warden-" + grafanaChainSpec + "-2-bbbbbbbb", HasExpired: false},
+		grafanaStubToken{ID: 8003, Name: "ci-pipeline-token", HasExpired: true},
+	)
+	stub.reset()
+	upstream.Reset()
+
+	status, body, _ := h.ChainRequest(t, leaderPort, grafanaEnv, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Bearer:     h.FullChainUserJWT(t),
+		Role:       grafanaChainAgentRole,
+		Path:       h.ProbePath("grafana-chained-sweep"),
+	})
+	if status != 200 {
+		t.Fatalf("status %d, body %s", status, string(body))
+	}
+
+	stub.awaitDeleted(t, "8001", 60*time.Second)
+	stub.awaitQuiescent(t, 3*time.Second)
+
+	// The token this very request minted is in the listing too, and live. A sweep
+	// that read hasExpired the wrong way round would take it.
+	var minted string
+	for _, c := range stub.createdTokens() {
+		minted = c.MintedID
+	}
+	for _, id := range stub.deletedTokens() {
+		switch id {
+		case "8002":
+			t.Errorf("the sweep deleted a token that has not expired")
+		case "8003":
+			t.Errorf("the sweep deleted a token this account's operator issued and Warden did not")
+		case minted:
+			t.Errorf("the sweep deleted the credential this request had just minted")
+		}
+	}
+}
+
+// TestGrafanaChaining_PlacementAndShapeAreEnforced drives the refusals. A
+// reference on the spec would describe a secret the spec never spends, and a
+// source keeping a token beside a chain reads as keyless while storing the very
+// secret chaining removes.
+func TestGrafanaChaining_PlacementAndShapeAreEnforced(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startGrafanaStub(t)
+	setupGrafanaChain(t, scalewaySubjects[0], "admin_token", stub)
+
+	t.Run("a spec may not carry a reference of its own", func(t *testing.T) {
+		grafanaMustRefuse(t, "sys/cred/specs/fc-gf-spec-chained",
+			fmt.Sprintf(`{"type":"api_key","source":%q,"config":{"service_account_id":%q,"secret_spec":%q}}`,
+				grafanaChainSource, grafanaAccountViewer, grafanaSecretSpec),
+			"set secret_spec on the source",
+			"a spec naming its own reference")
+	})
+
+	t.Run("a chained source may not also store a privileged token", func(t *testing.T) {
+		grafanaMustRefuse(t, "sys/cred/sources/fc-gf-half-keyless",
+			fmt.Sprintf(`{"type":"grafana","config":{"grafana_url":%q,"tls_skip_verify":"true","secret_spec":%q,"admin_token":"still-here"}}`,
+				stub.URL, grafanaSecretSpec),
+			"admin_token",
+			"a source keeping an inline token beside a reference")
+	})
+
+	// A chained source holds no secret of its own, so there is nothing here to
+	// rotate — that passes to whoever owns the referenced spec.
+	t.Run("a chained source may not carry a rotation period", func(t *testing.T) {
+		grafanaMustRefuse(t, "sys/cred/sources/fc-gf-rotating",
+			fmt.Sprintf(`{"type":"grafana","rotation_period":3600,"config":{"grafana_url":%q,"tls_skip_verify":"true","secret_spec":%q}}`,
+				stub.URL, grafanaSecretSpec),
+			"rotation_period",
+			"a chained source asking to rotate")
+	})
+
+	// The one an operator is most likely to expect chaining to have covered.
+	t.Run("a chained spec still has to name an account", func(t *testing.T) {
+		grafanaMustRefuse(t, "sys/cred/specs/fc-gf-chain-no-account",
+			fmt.Sprintf(`{"type":"api_key","source":%q,"config":{"token_expiry":"1h"}}`, grafanaChainSource),
+			"service_account_id is required",
+			"a chained spec naming no account")
+	})
+}
+
+// TestGrafanaChaining_InlineSourceStillNeedsAToken pins the other half of the
+// dropped Required(): a source naming no chain must still be refused without a
+// token, rather than being accepted and failing at the first mint.
+func TestGrafanaChaining_InlineSourceStillNeedsAToken(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startGrafanaStub(t)
+	grafanaMustRefuse(t, "sys/cred/sources/fc-gf-no-token",
+		fmt.Sprintf(`{"type":"grafana","config":{"grafana_url":%q,"tls_skip_verify":"true"}}`, stub.URL),
+		"admin_token",
+		"a source with neither a token nor a reference")
+}
+
+// TestGrafanaChaining_IncompleteMaterialIsRefusedBeforeAnyGrafanaCall points
+// secret_field at a key the payload does not have.
+//
+// What it asserts is where the failure lands. The resolver refuses on the
+// material alone, before authenticating, so Grafana is never called: an
+// incomplete secret must not be spent as a credential to find out it was
+// incomplete. That is also what separates this from a stale-secret refusal, which
+// would have reached Grafana and been told no — and which the minting layer would
+// then retry, having evicted a perfectly good cached secret.
+//
+// It is discriminating for a second reason: the payload DOES carry admin_token,
+// the very key the conventional fallback reads. A resolver that fell back after a
+// field resolved to nothing would authenticate successfully here and this row
+// would go green while secret_field silently meant nothing.
+func TestGrafanaChaining_IncompleteMaterialIsRefusedBeforeAnyGrafanaCall(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startGrafanaStub(t)
+	setupGrafanaChain(t, scalewaySubjects[0], "no_such_field", stub)
+	stub.reset()
+	upstream.Reset()
+
+	status, body, _ := h.ChainRequest(t, leaderPort, grafanaEnv, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Bearer:     h.FullChainUserJWT(t),
+		Role:       grafanaChainAgentRole,
+		Path:       h.ProbePath("grafana-chained-incomplete"),
+	})
+	if status == 200 {
+		t.Fatalf("the request succeeded on material the field names nothing in: %s", string(body))
+	}
+	// Named specifically: any other 500 would pass a bare status check while
+	// meaning something entirely different.
+	if !strings.Contains(string(body), "chained secret material is incomplete") {
+		t.Errorf("the refusal did not name the incomplete material: %s", string(body))
+	}
+
+	if creates := stub.createdTokens(); len(creates) != 0 {
+		t.Errorf("Grafana was asked to create %d token(s) with material the driver could not resolve: %+v",
+			len(creates), creates)
+	}
+	// And nothing reached the upstream either, since there was no credential to
+	// inject.
+	if n := len(upstream.Requests()); n != 0 {
+		t.Errorf("the upstream saw %d request(s), want 0", n)
+	}
+}

--- a/e2e/fullchain/grafana_source_test.go
+++ b/e2e/fullchain/grafana_source_test.go
@@ -1,0 +1,487 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// The grafana source driver on its inline path: a source holding its own
+// privileged token, issuing a token per request on an account an operator
+// provisioned.
+//
+// Nothing drove this code end to end before — grafana appeared nowhere in this
+// suite, which is what e2e/FINDINGS.md records. What these rows pin is the shape
+// of the driver rather than any one call: Warden mints a credential ON an
+// identity, it does not create the identity. A row asserting only that a token
+// came back would pass just as well against the driver that created a fresh
+// service account per request, so each one below names the account too.
+
+// grafanaStaticKey backs the mount itself, which serves an ordinary static
+// credential. The rows here bind their own specs by role, so this is only what
+// makes the mount stand up.
+const grafanaStaticKey = "glsa_fc-grafana-not-a-real-token"
+
+var grafanaEnv = h.ProviderEnv{
+	Mount:      "fc-grafana",
+	Type:       "grafana",
+	URLKey:     "grafana_url",
+	CredType:   "api_key",
+	CredConfig: map[string]string{"api_key": grafanaStaticKey},
+}
+
+const (
+	// The privileged token an inline source holds: able to manage tokens on the
+	// provisioned account, and nothing this suite does may create an account
+	// with it.
+	grafanaInlineAdminToken = "glsa_fc-inline-not-a-real-admin-token"
+
+	// Everything is test-local, the source included. A killed run skips
+	// t.Cleanup, and a spec left hanging off a shared source would block that
+	// source from being deleted, failing the next run's setup before it reaches
+	// the cleanup that would have cleared it.
+	grafanaInlineSource    = "fc-gf-inline-src"
+	grafanaInlineSpec      = "fc-gf-inline-cred"
+	grafanaInlineAgentRole = "fc-gf-inline-agent"
+
+	grafanaRevokeSource    = "fc-gf-revoke-src"
+	grafanaRevokeSpec      = "fc-gf-revoke-cred"
+	grafanaRevokeAgentRole = "fc-gf-revoke-agent"
+
+	grafanaSweepSource    = "fc-gf-sweep-src"
+	grafanaSweepSpec      = "fc-gf-sweep-cred"
+	grafanaSweepAgentRole = "fc-gf-sweep-agent"
+
+	// The prefix a spec sets on the names of the tokens it mints. The sweep
+	// matches Warden's own default prefix, so this stays under it.
+	grafanaSpecNamePrefix = "warden-"
+)
+
+func grafanaMustWrite(t *testing.T, method, path, body, what string) {
+	t.Helper()
+	switch status, resp := h.APIRequest(t, method, path, leaderPort, body); status {
+	case 200, 201, 204:
+	default:
+		t.Fatalf("%s (status %d): %s", what, status, resp)
+	}
+}
+
+// grafanaMustRefuse asserts a write is rejected and that the reason names what
+// the operator has to change. "not 200" would also pass for a 500, which would
+// mean something else entirely.
+func grafanaMustRefuse(t *testing.T, path, body, wantIn, what string) {
+	t.Helper()
+	status, resp := h.APIRequest(t, "POST", path, leaderPort, body)
+	if status < 400 || status >= 500 {
+		t.Fatalf("%s: status %d, want a 4xx refusal (body: %s)", what, status, resp)
+	}
+	if !strings.Contains(string(resp), wantIn) {
+		t.Errorf("%s: refusal did not mention %q: %s", what, wantIn, resp)
+	}
+	t.Cleanup(func() { h.APIRequest(t, "DELETE", path, leaderPort, "") })
+}
+
+// setupGrafanaInlineSource stands up a source holding its own privileged token, a
+// spec naming the account to mint on, and a role selecting it.
+//
+// sourceAccount goes on the source as its default; specAccount on the spec. Either
+// may be empty, which is how the rows below tell the two apart.
+func setupGrafanaInlineSource(t *testing.T, stub *grafanaStub, source, spec, role string, tokenTTL int, sourceAccount, specAccount, specExtra string) {
+	t.Helper()
+
+	useJWTAgentLeg(t, grafanaEnv)
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "auth/jwt/role/"+role, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/specs/"+spec, leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+source, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	sourceCfg := fmt.Sprintf(`"grafana_url":%q,"tls_skip_verify":"true","admin_token":%q`,
+		stub.URL, grafanaInlineAdminToken)
+	if sourceAccount != "" {
+		sourceCfg += fmt.Sprintf(`,"service_account_id":%q`, sourceAccount)
+	}
+	grafanaMustWrite(t, "POST", "sys/cred/sources/"+source,
+		fmt.Sprintf(`{"type":"grafana","config":{%s}}`, sourceCfg),
+		"create the inline grafana source "+source)
+
+	specCfg := fmt.Sprintf(`"name_prefix":%q`, grafanaSpecNamePrefix)
+	if specAccount != "" {
+		specCfg += fmt.Sprintf(`,"service_account_id":%q`, specAccount)
+	}
+	specCfg += specExtra
+	grafanaMustWrite(t, "POST", "sys/cred/specs/"+spec,
+		fmt.Sprintf(`{"type":"api_key","source":%q,"config":{%s}}`, source, specCfg),
+		"create the inline grafana spec "+spec)
+
+	if role != "" {
+		grafanaMustWrite(t, "POST", "auth/jwt/role/"+role, fmt.Sprintf(`{
+			"token_policies":[%q],"cred_spec_name":%q,
+			"user_claim":"sub","token_ttl":%d}`,
+			grafanaEnv.Policy(), spec, tokenTTL),
+			"create the inline agent role "+role)
+	}
+}
+
+// TestGrafanaSource_MintIssuesATokenOnTheProvisionedAccount drives the inline
+// path end to end, and is the row the whole redesign turns on.
+//
+// It asserts three things a "a token came back" check would miss: that the token
+// was created ON the account the spec names, that no account was created or
+// deleted along the way, and that the spec's mint parameters reached Grafana. The
+// driver as it stood would fail every one of them — it created a fresh service
+// account per request with a role the spec chose.
+func TestGrafanaSource_MintIssuesATokenOnTheProvisionedAccount(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startGrafanaStub(t)
+	setupGrafanaInlineSource(t, stub, grafanaInlineSource, grafanaInlineSpec, grafanaInlineAgentRole,
+		3600, "", grafanaAccountViewer, `,"token_expiry":"30m"`)
+
+	// Standing the spec up already cost Grafana a create and a delete: spec
+	// validation test-mints and then releases the lease. Start counting here.
+	stub.reset()
+	upstream.Reset()
+
+	status, body, _ := h.ChainRequest(t, leaderPort, grafanaEnv, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Bearer:     h.FullChainUserJWT(t),
+		Role:       grafanaInlineAgentRole,
+		Path:       h.ProbePath("grafana-inline-mint"),
+	})
+	if status != 200 {
+		t.Fatalf("status %d, body %s", status, string(body))
+	}
+
+	// The stub derives what it issues from the token that authenticated the
+	// create, so this header names the source's own privileged token specifically.
+	h.AssertChain(t, upstream, status, body, h.ChainWant{
+		Status:        200,
+		Injected:      map[string]string{"Authorization": "Bearer " + grafanaMintedFor(grafanaInlineAdminToken)},
+		Absent:        h.AlwaysAbsent(),
+		UpstreamCalls: 1,
+	})
+
+	creates := stub.createdTokens()
+	if len(creates) != 1 {
+		t.Fatalf("Grafana saw %d token creations, want exactly 1: %+v", len(creates), creates)
+	}
+	got := creates[0]
+
+	if got.Privileged != grafanaInlineAdminToken {
+		t.Errorf("the create authenticated with %q, want the source's own privileged token", got.Privileged)
+	}
+	if got.AccountID != grafanaAccountViewer {
+		t.Errorf("the token was created on account %q, want the account the spec names (%q)",
+			got.AccountID, grafanaAccountViewer)
+	}
+	if ttl, _ := got.Body["secondsToLive"].(float64); ttl != 1800 {
+		t.Errorf("secondsToLive reached Grafana as %v, want the spec's 30m as 1800", got.Body["secondsToLive"])
+	}
+	// The name is what tells one lease from another in Grafana's own view, where
+	// every token on the account acts as the same identity.
+	name, _ := got.Body["name"].(string)
+	if !strings.HasPrefix(name, grafanaSpecNamePrefix+grafanaInlineSpec+"-") {
+		t.Errorf("token name %q does not carry the spec's prefix and name", name)
+	}
+
+	// The account is the operator's. Nothing here may create or remove one.
+	if deleted := stub.deletedAccounts(); len(deleted) != 0 {
+		t.Errorf("Grafana was asked to delete service account(s) %v; Warden must only ever delete tokens", deleted)
+	}
+}
+
+// TestGrafanaSource_SpecAccountWinsOverTheSourceDefault is what spec-level
+// placement buys: one source — one Grafana, one privileged token — serving two
+// privilege levels, because the account's role is the credential's privilege.
+//
+// Both halves matter. A driver reading only the source default would fail the
+// first; one reading only the spec would fail the second.
+func TestGrafanaSource_SpecAccountWinsOverTheSourceDefault(t *testing.T) {
+	ensureEnv(t)
+
+	t.Run("the spec's account wins", func(t *testing.T) {
+		stub := startGrafanaStub(t)
+		setupGrafanaInlineSource(t, stub, grafanaInlineSource+"-a", grafanaInlineSpec+"-a",
+			grafanaInlineAgentRole+"-a", 3600, grafanaAccountViewer, grafanaAccountEditor, "")
+		stub.reset()
+		upstream.Reset()
+
+		status, body, _ := h.ChainRequest(t, leaderPort, grafanaEnv, h.ChainOpts{
+			AgentToken: h.GetDefaultJWT(t),
+			Bearer:     h.FullChainUserJWT(t),
+			Role:       grafanaInlineAgentRole + "-a",
+			Path:       h.ProbePath("grafana-account-spec-wins"),
+		})
+		if status != 200 {
+			t.Fatalf("status %d, body %s", status, string(body))
+		}
+		assertGrafanaMintedOn(t, stub, grafanaAccountEditor)
+	})
+
+	t.Run("the source default covers a silent spec", func(t *testing.T) {
+		stub := startGrafanaStub(t)
+		setupGrafanaInlineSource(t, stub, grafanaInlineSource+"-b", grafanaInlineSpec+"-b",
+			grafanaInlineAgentRole+"-b", 3600, grafanaAccountEditor, "", "")
+		stub.reset()
+		upstream.Reset()
+
+		status, body, _ := h.ChainRequest(t, leaderPort, grafanaEnv, h.ChainOpts{
+			AgentToken: h.GetDefaultJWT(t),
+			Bearer:     h.FullChainUserJWT(t),
+			Role:       grafanaInlineAgentRole + "-b",
+			Path:       h.ProbePath("grafana-account-source-default"),
+		})
+		if status != 200 {
+			t.Fatalf("status %d, body %s", status, string(body))
+		}
+		assertGrafanaMintedOn(t, stub, grafanaAccountEditor)
+	})
+}
+
+func assertGrafanaMintedOn(t *testing.T, stub *grafanaStub, wantAccount string) {
+	t.Helper()
+	creates := stub.createdTokens()
+	if len(creates) != 1 {
+		t.Fatalf("Grafana saw %d token creations, want exactly 1: %+v", len(creates), creates)
+	}
+	if creates[0].AccountID != wantAccount {
+		t.Errorf("the token was created on account %q, want %q", creates[0].AccountID, wantAccount)
+	}
+}
+
+// TestGrafanaSource_MintedTokenIsDeletedWhenTheSessionEnds pins revocation, which
+// the redesign made precise: the lease names one token, so revoking removes that
+// token and leaves the account and everything else on it alone.
+//
+// A minted token is registered for expiry against the SESSION's lifetime, not its
+// own — so a role with a short token_ttl brings the revocation forward to where a
+// test can watch it. The token here asks for an hour; what ends it is the agent's
+// token running out five seconds later.
+func TestGrafanaSource_MintedTokenIsDeletedWhenTheSessionEnds(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startGrafanaStub(t)
+	setupGrafanaInlineSource(t, stub, grafanaRevokeSource, grafanaRevokeSpec, grafanaRevokeAgentRole,
+		5, "", grafanaAccountViewer, "")
+
+	stub.reset()
+	upstream.Reset()
+
+	status, body, _ := h.ChainRequest(t, leaderPort, grafanaEnv, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Bearer:     h.FullChainUserJWT(t),
+		Role:       grafanaRevokeAgentRole,
+		Path:       h.ProbePath("grafana-inline-revoke"),
+	})
+	if status != 200 {
+		t.Fatalf("status %d, body %s", status, string(body))
+	}
+	creates := stub.createdTokens()
+	if len(creates) != 1 {
+		t.Fatalf("Grafana saw %d token creations, want exactly 1", len(creates))
+	}
+	minted := creates[0].MintedID
+
+	// Nothing to synchronise on but the effect: revocation runs on the expiration
+	// manager's own timer once the session's five seconds are up.
+	stub.awaitDeleted(t, minted, 60*time.Second)
+
+	for _, id := range stub.deletedTokens() {
+		if id != minted {
+			t.Errorf("Grafana was asked to delete token %q, which this row never minted", id)
+		}
+	}
+	if deleted := stub.deletedAccounts(); len(deleted) != 0 {
+		t.Errorf("revocation deleted service account(s) %v; it must only remove the one token", deleted)
+	}
+}
+
+// TestGrafanaSource_ExpiredTokensAreReclaimed drives the sweep.
+//
+// Grafana does not remove a token when it expires — it stays listed on the
+// account, inert but accumulating — and a revoke that failed for good, or a node
+// that died between mint and register, leaves one behind. What the sweep is
+// allowed to match is the whole of its safety: the account is the operator's and
+// may hold tokens Warden never issued, so a live token and a hand-issued expired
+// one are primed alongside, and this row asserts both survived.
+func TestGrafanaSource_ExpiredTokensAreReclaimed(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startGrafanaStub(t)
+	setupGrafanaInlineSource(t, stub, grafanaSweepSource, grafanaSweepSpec, grafanaSweepAgentRole,
+		3600, "", grafanaAccountViewer, "")
+
+	// Primed AFTER setup, deliberately. Creating the spec test-mints through a
+	// throwaway driver the store builds and discards, and that mint sweeps too —
+	// so priming earlier would let this row pass on a sweep the request path never
+	// ran. The registry driver serving the request below has swept nothing yet.
+	stub.primeTokens(grafanaAccountViewer,
+		grafanaStubToken{ID: 9001, Name: "warden-" + grafanaSweepSpec + "-1-aaaaaaaa", HasExpired: true},
+		grafanaStubToken{ID: 9002, Name: "warden-" + grafanaSweepSpec + "-2-bbbbbbbb", HasExpired: false},
+		grafanaStubToken{ID: 9003, Name: "ci-pipeline-token", HasExpired: true},
+	)
+	stub.reset()
+	upstream.Reset()
+
+	status, body, _ := h.ChainRequest(t, leaderPort, grafanaEnv, h.ChainOpts{
+		AgentToken: h.GetDefaultJWT(t),
+		Bearer:     h.FullChainUserJWT(t),
+		Role:       grafanaSweepAgentRole,
+		Path:       h.ProbePath("grafana-inline-sweep"),
+	})
+	if status != 200 {
+		t.Fatalf("status %d, body %s", status, string(body))
+	}
+
+	stub.awaitDeleted(t, "9001", 60*time.Second)
+
+	// The sweep walks the listing in order, so 9003 would be deleted after 9001 if
+	// the filter were wrong. Let the sweep finish before concluding it left them.
+	stub.awaitQuiescent(t, 3*time.Second)
+
+	for _, id := range stub.deletedTokens() {
+		switch id {
+		case "9002":
+			t.Errorf("the sweep deleted a token that has not expired")
+		case "9003":
+			t.Errorf("the sweep deleted %q, a token this account's operator issued and Warden did not", "ci-pipeline-token")
+		}
+	}
+	if deleted := stub.deletedAccounts(); len(deleted) != 0 {
+		t.Errorf("the sweep deleted service account(s) %v; it may only remove tokens", deleted)
+	}
+}
+
+// TestGrafanaSource_SpecShapeIsEnforced drives the refusals that moved into the
+// credential type, which is the layer that runs for every spec — including a
+// chained one, which the store never test-mints or verifies.
+func TestGrafanaSource_SpecShapeIsEnforced(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startGrafanaStub(t)
+	setupGrafanaInlineSource(t, stub, grafanaInlineSource+"-shape", grafanaInlineSpec+"-shape",
+		"", 0, "", grafanaAccountViewer, "")
+	source := grafanaInlineSource + "-shape"
+
+	spec := func(config string) string {
+		return fmt.Sprintf(`{"type":"api_key","source":%q,"config":{%s}}`, source, config)
+	}
+
+	// The privilege boundary this redesign moved. Asking for a role would be
+	// asking Warden to create an identity, which it no longer does.
+	t.Run("a spec may not choose a role", func(t *testing.T) {
+		grafanaMustRefuse(t, "sys/cred/specs/fc-gf-role",
+			spec(`"service_account_id":"42","role":"Admin"`),
+			"'role' is not settable",
+			"a spec asking for a role")
+	})
+
+	// The account says which organization; a second answer could only disagree.
+	t.Run("a spec may not name an organization", func(t *testing.T) {
+		grafanaMustRefuse(t, "sys/cred/specs/fc-gf-org",
+			spec(`"service_account_id":"42","org_id":"1"`),
+			"'org_id' is not settable",
+			"a spec naming an org")
+	})
+
+	// Grafana reads a truncated-to-zero lifetime as "never expires", and a zero
+	// lease TTL reads to Warden as a static credential.
+	for _, expiry := range []string{"0s", "500ms"} {
+		t.Run("a sub-second lifetime is refused: "+expiry, func(t *testing.T) {
+			grafanaMustRefuse(t, "sys/cred/specs/fc-gf-tiny-"+expiry,
+				spec(fmt.Sprintf(`"service_account_id":"42","token_expiry":%q`, expiry)),
+				"at least 1s",
+				"a spec asking for "+expiry)
+		})
+	}
+
+	// GetDuration swallows a parse error and returns the default, so an unchecked
+	// value here would mint an hour while the spec said something else.
+	t.Run("a unitless lifetime is refused", func(t *testing.T) {
+		grafanaMustRefuse(t, "sys/cred/specs/fc-gf-unitless",
+			spec(`"service_account_id":"42","token_expiry":"60"`),
+			"not a duration",
+			"a spec asking for a unitless lifetime")
+	})
+
+	t.Run("a non-numeric account is refused", func(t *testing.T) {
+		grafanaMustRefuse(t, "sys/cred/specs/fc-gf-badaccount",
+			spec(`"service_account_id":"my-account"`),
+			"positive integer",
+			"a spec naming a non-numeric account")
+	})
+}
+
+// TestGrafanaSource_SpecMustNameAnAccount pins the check that can only live in
+// the store: the credential type is handed the source's TYPE but never its
+// config, so it cannot see whether a default exists to fall back to.
+func TestGrafanaSource_SpecMustNameAnAccount(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startGrafanaStub(t)
+	const source = "fc-gf-bare-src"
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "sys/cred/specs/fc-gf-no-account", leaderPort, "")
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+source, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	grafanaMustWrite(t, "POST", "sys/cred/sources/"+source, fmt.Sprintf(
+		`{"type":"grafana","config":{"grafana_url":%q,"tls_skip_verify":"true","admin_token":%q}}`,
+		stub.URL, grafanaInlineAdminToken),
+		"create a grafana source with no default account")
+
+	grafanaMustRefuse(t, "sys/cred/specs/fc-gf-no-account",
+		fmt.Sprintf(`{"type":"api_key","source":%q,"config":{"token_expiry":"1h"}}`, source),
+		"service_account_id is required",
+		"a spec on a source that names no account either")
+}
+
+// TestGrafanaSource_VerificationRejectsAnAccountThatCannotServe covers what
+// VerifySpec adds over the test mint that runs just before it: an account id
+// naming nothing, and one the operator has disabled — whose tokens would mint
+// happily and then fail to authenticate.
+func TestGrafanaSource_VerificationRejectsAnAccountThatCannotServe(t *testing.T) {
+	ensureEnv(t)
+
+	stub := startGrafanaStub(t)
+	const source = "fc-gf-verify-src"
+
+	clear := func() {
+		h.APIRequest(t, "DELETE", "sys/cred/sources/"+source, leaderPort, "")
+	}
+	clear()
+	t.Cleanup(clear)
+
+	grafanaMustWrite(t, "POST", "sys/cred/sources/"+source, fmt.Sprintf(
+		`{"type":"grafana","config":{"grafana_url":%q,"tls_skip_verify":"true","admin_token":%q}}`,
+		stub.URL, grafanaInlineAdminToken),
+		"create the verifying grafana source")
+
+	t.Run("an account that does not exist", func(t *testing.T) {
+		grafanaMustRefuse(t, "sys/cred/specs/fc-gf-missing-account",
+			fmt.Sprintf(`{"type":"api_key","source":%q,"config":{"service_account_id":%q}}`,
+				source, grafanaAccountUnknown),
+			grafanaAccountUnknown,
+			"a spec naming an account Grafana does not have")
+	})
+
+	t.Run("an account the operator disabled", func(t *testing.T) {
+		grafanaMustRefuse(t, "sys/cred/specs/fc-gf-disabled-account",
+			fmt.Sprintf(`{"type":"api_key","source":%q,"config":{"service_account_id":%q}}`,
+				source, grafanaAccountDisabled),
+			"disabled",
+			"a spec naming a disabled account")
+	})
+}

--- a/e2e/fullchain/grafana_stub_test.go
+++ b/e2e/fullchain/grafana_stub_test.go
@@ -1,0 +1,405 @@
+//go:build e2e
+
+package fullchain
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// A stand-in Grafana, shared by the inline and chained grafana suites so the two
+// cannot drift apart in what they think a Grafana does.
+//
+// It answers the four calls the driver makes and records what it was asked,
+// because most of what these rows assert is not the response — it is which
+// credential authenticated the call, which account the token was created on, and
+// what was deleted.
+//
+// Every status and body here was checked against Grafana's own documentation and
+// source rather than assumed, because a stub that is wrong in the same direction
+// as the driver turns a broken path into a green row:
+//
+//   - POST   /api/serviceaccounts/{id}/tokens      200 {"id":N,"name":...,"key":...}
+//     400 ErrDuplicateToken on a repeated name (errutil.BadRequest)
+//     404 ErrServiceAccountNotFound for an unknown account
+//   - DELETE /api/serviceaccounts/{id}/tokens/{tid} 200 {"message":"API key deleted"}
+//     404 ErrServiceAccountTokenNotFound when it is already gone
+//   - GET    /api/serviceaccounts/{id}/tokens       200, a FLAT array carrying hasExpired
+//   - GET    /api/serviceaccounts/{id}              200 {...,"role":...,"isDisabled":...}
+
+// grafanaMintedFor derives the token the stub issues from the privileged token
+// that authenticated the create. Deriving rather than returning a constant is
+// what carries "which secret was spent" all the way to the header the gateway
+// injects — a fixed value would look identical whichever token performed the call.
+func grafanaMintedFor(privileged string) string {
+	return "glsa_minted-for-" + privileged
+}
+
+const (
+	// The accounts the stub is provisioned with, as an operator would have
+	// created them in Grafana. Warden never creates one, so a row asking for an
+	// account outside this set is asking for a 404.
+	grafanaAccountViewer   = "42"
+	grafanaAccountEditor   = "57"
+	grafanaAccountDisabled = "99"
+	grafanaAccountUnknown  = "12345"
+)
+
+// grafanaTokenCreate is one recorded token creation.
+type grafanaTokenCreate struct {
+	// Privileged is the credential that authenticated the create — the answer to
+	// "which secret was spent".
+	Privileged string
+	// AccountID is the account the token was created on, which is the whole
+	// point of the redesign: a spec names it, Warden does not invent one.
+	AccountID string
+	// Body is the create request verbatim, so a row can assert the mint
+	// parameters an operator set actually reached Grafana.
+	Body map[string]interface{}
+	// MintedID is the token id the stub issued.
+	MintedID string
+	// TokenName is the name it was created under, which is what the sweep's
+	// prefix filter reads.
+	TokenName string
+}
+
+// grafanaStubToken is one token as the listing reports it.
+type grafanaStubToken struct {
+	ID         int64  `json:"id"`
+	Name       string `json:"name"`
+	HasExpired bool   `json:"hasExpired"`
+}
+
+// grafanaStub records what the driver asked of it. Every field is read under the
+// mutex: the sweep runs on a goroutine of its own and revocation on the
+// expiration manager's timer, so a row polling for their effects races the
+// handler serving them.
+type grafanaStub struct {
+	*httptest.Server
+
+	mu      sync.Mutex
+	creates []grafanaTokenCreate
+	// deleted records every token id the driver asked to remove, whether by
+	// revoking a lease or by sweeping an expired one.
+	deleted []string
+	// accountsDeleted records any attempt to delete an ACCOUNT. It must stay
+	// empty: the account is the operator's, and a driver that removed one would
+	// be taking away every other token on it.
+	accountsDeleted []string
+	// listed is what the token listing reports, per account. Primed by a row
+	// that wants the sweep to find something.
+	listed map[string][]grafanaStubToken
+	// issued names every token name seen, so a repeat draws Grafana's real
+	// duplicate refusal rather than quietly succeeding.
+	issued  map[string]bool
+	nextID  int64
+	accepts map[string]bool
+}
+
+func (s *grafanaStub) recordCreate(c grafanaTokenCreate) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.creates = append(s.creates, c)
+	// A real Grafana lists the token it just issued, so the sweep's listing
+	// contains live Warden-named tokens as well as expired ones. Without this the
+	// stub could never catch a sweep that deleted a credential still in use.
+	s.listed[c.AccountID] = append(s.listed[c.AccountID], grafanaStubToken{
+		ID: mustAtoi(c.MintedID), Name: c.TokenName, HasExpired: false,
+	})
+}
+
+func (s *grafanaStub) createdTokens() []grafanaTokenCreate {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]grafanaTokenCreate(nil), s.creates...)
+}
+
+// observed returns the privileged tokens that authenticated a create, oldest first.
+func (s *grafanaStub) observed() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	tokens := make([]string, 0, len(s.creates))
+	for _, c := range s.creates {
+		tokens = append(tokens, c.Privileged)
+	}
+	return tokens
+}
+
+func (s *grafanaStub) deletedTokens() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.deleted...)
+}
+
+func (s *grafanaStub) deletedAccounts() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.accountsDeleted...)
+}
+
+// reset clears the record. Standing a source and spec up already costs Grafana a
+// create and a delete — spec validation test-mints and then releases the lease —
+// so a row that means to count its own traffic starts from here.
+func (s *grafanaStub) reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.creates = nil
+	s.deleted = nil
+	s.accountsDeleted = nil
+}
+
+// primeTokens makes the listing on an account report these tokens, as though
+// earlier mints had left them there.
+func (s *grafanaStub) primeTokens(accountID string, tokens ...grafanaStubToken) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listed[accountID] = tokens
+}
+
+func (s *grafanaStub) sawDeleted(id string) bool {
+	for _, got := range s.deletedTokens() {
+		if got == id {
+			return true
+		}
+	}
+	return false
+}
+
+// awaitDeleted waits for a token id to be deleted, and says what it did see when
+// it is not. Both the revocation and the sweep run off this goroutine, so there
+// is nothing to synchronise on but the effect itself.
+func (s *grafanaStub) awaitDeleted(t *testing.T, id string, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if s.sawDeleted(id) {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("token %q was never deleted within %s; Grafana was asked to delete %v",
+		id, within, s.deletedTokens())
+}
+
+// awaitQuiescent waits until no delete has been recorded for a settle period.
+//
+// The sweep walks the account's listing in order, so a row that concludes "it
+// left the others alone" the instant its first expected delete lands is reading
+// a half-finished sweep: a wrongly-filtered delete issued later would arrive
+// after the assertions and never be seen.
+func (s *grafanaStub) awaitQuiescent(t *testing.T, settle time.Duration) {
+	t.Helper()
+	last := len(s.deletedTokens())
+	deadline := time.Now().Add(settle + 10*time.Second)
+	stableSince := time.Now()
+	for time.Now().Before(deadline) {
+		time.Sleep(200 * time.Millisecond)
+		if n := len(s.deletedTokens()); n != last {
+			last, stableSince = n, time.Now()
+			continue
+		}
+		if time.Since(stableSince) >= settle {
+			return
+		}
+	}
+	t.Fatalf("deletes never settled; Grafana was asked to delete %v", s.deletedTokens())
+}
+
+// grafanaAccountPath splits "/api/serviceaccounts/{id}[/tokens[/{tid}]]".
+func grafanaAccountPath(path string) (accountID, rest string) {
+	trimmed := strings.TrimPrefix(path, "/api/serviceaccounts/")
+	accountID, rest, _ = strings.Cut(trimmed, "/")
+	return accountID, rest
+}
+
+func startGrafanaStub(t *testing.T) *grafanaStub {
+	t.Helper()
+
+	stub := &grafanaStub{
+		listed: map[string][]grafanaStubToken{},
+		issued: map[string]bool{},
+		accepts: map[string]bool{
+			grafanaAccountViewer:   true,
+			grafanaAccountEditor:   true,
+			grafanaAccountDisabled: true,
+		},
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/serviceaccounts/", func(w http.ResponseWriter, r *http.Request) {
+		privileged, ok := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if !ok || privileged == "" {
+			grafanaErr(w, http.StatusUnauthorized, "auth.unauthorized", "Unauthorized")
+			return
+		}
+
+		accountID, rest := grafanaAccountPath(r.URL.Path)
+
+		stub.mu.Lock()
+		known := stub.accepts[accountID]
+		stub.mu.Unlock()
+		if !known {
+			// Grafana answers a call naming an account it does not have with
+			// ErrServiceAccountNotFound, an errutil.NotFound.
+			grafanaErr(w, http.StatusNotFound, "serviceaccounts.ErrNotFound", "service account not found")
+			return
+		}
+
+		switch {
+		// Nothing in the driver may create or delete an ACCOUNT. Both are
+		// refused loudly rather than merely unrouted, so a regression that tried
+		// shows up as a failing row and not a 404 someone reads as a stub gap.
+		case rest == "" && r.Method == http.MethodDelete:
+			stub.mu.Lock()
+			stub.accountsDeleted = append(stub.accountsDeleted, accountID)
+			stub.mu.Unlock()
+			grafanaErr(w, http.StatusForbidden, "e2e.AccountDeleteForbidden",
+				"this stub refuses to delete a service account: it belongs to the operator")
+
+		case rest == "" && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":         mustAtoi(accountID),
+				"name":       "warden-e2e-" + accountID,
+				"login":      "sa-warden-e2e-" + accountID,
+				"orgId":      1,
+				"isDisabled": accountID == grafanaAccountDisabled,
+				"role":       grafanaRoleOf(accountID),
+			})
+
+		case rest == "tokens" && r.Method == http.MethodPost:
+			var body map[string]interface{}
+			if r.Body != nil {
+				_ = json.NewDecoder(r.Body).Decode(&body)
+			}
+			name, _ := body["name"].(string)
+
+			// Grafana reads secondsToLive 0, null or absent as "this token never
+			// expires". Refusing it here means a regression that let one through
+			// fails a row instead of quietly issuing a permanent credential.
+			ttl, present := body["secondsToLive"].(float64)
+			if !present || ttl < 1 {
+				grafanaErr(w, http.StatusBadRequest, "e2e.NeverExpires",
+					fmt.Sprintf("refusing to create a token that never expires (secondsToLive=%v)", body["secondsToLive"]))
+				return
+			}
+
+			stub.mu.Lock()
+			if stub.issued[name] {
+				stub.mu.Unlock()
+				// ErrDuplicateToken is an errutil.BadRequest, so 400.
+				grafanaErr(w, http.StatusBadRequest, "serviceaccounts.ErrTokenAlreadyExists",
+					fmt.Sprintf("service account token with name %s already exists in the organization", name))
+				return
+			}
+			stub.issued[name] = true
+			stub.nextID++
+			id := stub.nextID
+			stub.mu.Unlock()
+
+			stub.recordCreate(grafanaTokenCreate{
+				Privileged: privileged,
+				AccountID:  accountID,
+				Body:       body,
+				MintedID:   strconv.FormatInt(id, 10),
+				TokenName:  name,
+			})
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"id":   id,
+				"name": name,
+				"key":  grafanaMintedFor(privileged),
+			})
+
+		case rest == "tokens" && r.Method == http.MethodGet:
+			stub.mu.Lock()
+			tokens := append([]grafanaStubToken(nil), stub.listed[accountID]...)
+			stub.mu.Unlock()
+			if tokens == nil {
+				tokens = []grafanaStubToken{}
+			}
+			// A flat array, not a paginated object.
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(tokens)
+
+		case strings.HasPrefix(rest, "tokens/") && r.Method == http.MethodDelete:
+			tokenID := strings.TrimPrefix(rest, "tokens/")
+
+			stub.mu.Lock()
+			remaining := stub.listed[accountID][:0:0]
+			found := false
+			for _, tok := range stub.listed[accountID] {
+				if strconv.FormatInt(tok.ID, 10) == tokenID {
+					found = true
+					continue
+				}
+				remaining = append(remaining, tok)
+			}
+			stub.listed[accountID] = remaining
+			already := stub.wasDeletedLocked(tokenID)
+			stub.deleted = append(stub.deleted, tokenID)
+			stub.mu.Unlock()
+
+			// Grafana's store checks RowsAffected and returns
+			// ErrServiceAccountTokenNotFound — an errutil.NotFound — which
+			// ErrOrFallback re-raises as 404 rather than its 500 fallback. The
+			// driver treats that as success, and this is where that is proved.
+			if already && !found {
+				grafanaErr(w, http.StatusNotFound, "serviceaccounts.ErrTokenNotFound",
+					"service account token with id "+tokenID+" not found")
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"message": "API key deleted"})
+
+		default:
+			grafanaErr(w, http.StatusNotFound, "e2e.NoRoute", "no route for "+r.Method+" "+r.URL.Path)
+		}
+	})
+
+	stub.Server = httptest.NewServer(mux)
+	t.Cleanup(stub.Close)
+	return stub
+}
+
+// wasDeletedLocked reports whether a token id has already been deleted. Callers
+// hold the mutex.
+func (s *grafanaStub) wasDeletedLocked(id string) bool {
+	for _, got := range s.deleted {
+		if got == id {
+			return true
+		}
+	}
+	return false
+}
+
+// grafanaErr answers the way Grafana does, with a messageId beside the message.
+func grafanaErr(w http.ResponseWriter, status int, messageID, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"messageId": messageID,
+		"message":   message,
+	})
+}
+
+func grafanaRoleOf(accountID string) string {
+	if accountID == grafanaAccountEditor {
+		return "Editor"
+	}
+	return "Viewer"
+}
+
+func mustAtoi(s string) int64 {
+	n, _ := strconv.ParseInt(s, 10, 64)
+	return n
+}

--- a/e2e/fullchain/main_test.go
+++ b/e2e/fullchain/main_test.go
@@ -52,7 +52,7 @@ import (
 var allEnvs = []h.ProviderEnv{
 	openaiEnv, anthropicEnv, newrelicEnv, elasticEnv, githubEnv,
 	splunkEnv, datadogEnv, restEnv, dynatraceEnv, dynatraceOAuthEnv, mcpEnv, mcpGitHubEnv,
-	mcpAWSEnv, mcpAWSWrongCredEnv, atlassianEnv, honeycombEnv,
+	mcpAWSEnv, mcpAWSWrongCredEnv, atlassianEnv, honeycombEnv, grafanaEnv,
 	prometheusEnv, prometheusBasicEnv,
 	scalewayEnv, cloudflareEnv,
 	vaultEnv,

--- a/e2e/setup.sh
+++ b/e2e/setup.sh
@@ -431,6 +431,13 @@ vault_api POST "secret/data/e2e/elastic-cluster-pair" \
 vault_api POST "secret/data/e2e/elastic-cluster-odd" \
   '{"data":{"key":"e2e-es-cluster-not-a-real-secret","key_id":"e2e-es-cluster-id","unrelated_field":"must-not-be-vended"}}'
 
+# The privileged token a keyless grafana source fetches instead of storing. Under
+# its conventional name, so the chaining rows can drive both the secret_field path
+# and the fallback the driver takes when no field is set. Assembled rather than
+# written out, for the reason the elastic fixtures above give.
+vault_api POST "secret/data/e2e/grafana-admin-token" \
+  "{\"data\":{\"admin_token\":\"glsa_$(printf 'e2e-grafana-not-a-real-admin-token')\"}}"
+
 # Create policy for Warden-minted service tokens (read-only secrets access)
 echo "  Creating Vault policies..."
 vault_api PUT "sys/policies/acl/e2e-secrets-reader" \


### PR DESCRIPTION
> The last of the grafana stack: #574 (provisioned account) and #579 (keyless) are merged; this is the end-to-end coverage for both.

## Why

Grafana appeared nowhere in this suite — `e2e/FINDINGS.md` listed it among the providers reachable only through the shared Bearer extractor — so neither the mount nor either path of its source driver had ever been driven end to end.

## The stub

Every status and body it returns was checked against Grafana's own docs **and source**, because a stub that is wrong in the same direction as the driver turns a broken path into a green row. It:

- refuses a duplicate token name with the real **400** (`ErrDuplicateToken` is an `errutil.BadRequest`);
- answers **404** on a second delete — the status the driver treats as success, which reaches the wire only because `ErrOrFallback` re-raises an `errutil.NotFound` with its own status instead of its 500 fallback;
- refuses `secondsToLive` below 1, which Grafana would read as a token that never expires;
- **refuses to delete a service account at all**, recording the attempt, so a regression that tried fails a row rather than passing as an unrouted 404;
- and **lists the tokens it issues**, as Grafana does, so a sweep taking a live one cannot go unnoticed.

As the elastic stub does, it derives the token it issues from the privileged token that authenticated the create. That carries "which secret was spent" all the way to the header the gateway injects, and it is what makes the chained rows proof of a chain rather than of a header that merely looks right.

## The rows

They assert the *shape* of the driver, not just that a token came back — a weaker row would pass equally well against the design this stack replaced. So each one names the account: the token is created **on the account the spec names**, no account is created or removed, the spec's account beats the source default and the default covers a silent spec, revocation removes one token and nothing else, and the sweep reclaims an expired Warden-named token while leaving a live one and one the account's operator issued by hand.

Both sweep rows drive a real request. The inline one primes **after** setup on purpose: creating a spec test-mints through a driver the store builds and discards, and that mint sweeps too — so priming earlier would let the row pass on a sweep the request path never ran. The chained row has no such ambiguity, since a chained spec is never test-minted, which is why it is the one that matters.

The chained rows drive both subjects and both ways of naming the secret. The incomplete-material row is discriminating for a reason worth stating: the payload **does** carry `admin_token`, so a resolver that fell back to a conventional name after `secret_field` resolved to nothing would authenticate and go green.

## Verification

`make test-e2e` — all 20 packages green, including the 25 new grafana rows.
