### PR TITLE
feat(policy): add MCP policy type with its own grammar, storage and API

### DIFF
--- a/api/sys_policies.go
+++ b/api/sys_policies.go
@@ -7,23 +7,40 @@ import (
 	"net/http"
 )
 
+// Policy type identifiers accepted by the typed policy methods. They are the
+// path segment under sys/policies/.
+const (
+	PolicyTypeCBP = "cbp"
+	PolicyTypeMCP = "mcp"
+)
+
 // PolicyOutput represents policy information
 type PolicyOutput struct {
 	Name   string `json:"name"`
 	Policy string `json:"policy"`
 }
 
-// PutPolicy creates or updates a policy
+// PutPolicy creates or updates a capability-based policy
 func (c *Sys) PutPolicy(name string, policy string) error {
 	return c.PutPolicyWithContext(context.Background(), name, policy)
 }
 
-// PutPolicyWithContext creates or updates a policy with context
+// PutPolicyWithContext creates or updates a capability-based policy with context
 func (c *Sys) PutPolicyWithContext(ctx context.Context, name string, policy string) error {
+	return c.PutPolicyOfTypeWithContext(ctx, PolicyTypeCBP, name, policy)
+}
+
+// PutPolicyOfType creates or updates a policy of the given type
+func (c *Sys) PutPolicyOfType(policyType, name, policy string) error {
+	return c.PutPolicyOfTypeWithContext(context.Background(), policyType, name, policy)
+}
+
+// PutPolicyOfTypeWithContext creates or updates a policy of the given type with context
+func (c *Sys) PutPolicyOfTypeWithContext(ctx context.Context, policyType, name, policy string) error {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/policies/cbp/%s", name))
+	r := c.c.NewRequest(http.MethodPost, fmt.Sprintf("/v1/sys/policies/%s/%s", policyType, name))
 
 	input := map[string]interface{}{
 		"policy": policy,
@@ -42,17 +59,27 @@ func (c *Sys) PutPolicyWithContext(ctx context.Context, name string, policy stri
 	return nil
 }
 
-// GetPolicy retrieves a policy
+// GetPolicy retrieves a capability-based policy
 func (c *Sys) GetPolicy(name string) (*PolicyOutput, error) {
 	return c.GetPolicyWithContext(context.Background(), name)
 }
 
-// GetPolicyWithContext retrieves a policy with context
+// GetPolicyWithContext retrieves a capability-based policy with context
 func (c *Sys) GetPolicyWithContext(ctx context.Context, name string) (*PolicyOutput, error) {
+	return c.GetPolicyOfTypeWithContext(ctx, PolicyTypeCBP, name)
+}
+
+// GetPolicyOfType retrieves a policy of the given type
+func (c *Sys) GetPolicyOfType(policyType, name string) (*PolicyOutput, error) {
+	return c.GetPolicyOfTypeWithContext(context.Background(), policyType, name)
+}
+
+// GetPolicyOfTypeWithContext retrieves a policy of the given type with context
+func (c *Sys) GetPolicyOfTypeWithContext(ctx context.Context, policyType, name string) (*PolicyOutput, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/policies/cbp/%s", name))
+	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/policies/%s/%s", policyType, name))
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {
@@ -79,17 +106,27 @@ func (c *Sys) GetPolicyWithContext(ctx context.Context, name string) (*PolicyOut
 	return output, nil
 }
 
-// ListPolicies lists all policies
+// ListPolicies lists all capability-based policies
 func (c *Sys) ListPolicies() ([]string, error) {
 	return c.ListPoliciesWithContext(context.Background())
 }
 
-// ListPoliciesWithContext lists policies with context
+// ListPoliciesWithContext lists capability-based policies with context
 func (c *Sys) ListPoliciesWithContext(ctx context.Context) ([]string, error) {
+	return c.ListPoliciesOfTypeWithContext(ctx, PolicyTypeCBP)
+}
+
+// ListPoliciesOfType lists all policies of the given type
+func (c *Sys) ListPoliciesOfType(policyType string) ([]string, error) {
+	return c.ListPoliciesOfTypeWithContext(context.Background(), policyType)
+}
+
+// ListPoliciesOfTypeWithContext lists policies of the given type with context
+func (c *Sys) ListPoliciesOfTypeWithContext(ctx context.Context, policyType string) ([]string, error) {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodGet, "/v1/sys/policies/cbp")
+	r := c.c.NewRequest(http.MethodGet, fmt.Sprintf("/v1/sys/policies/%s", policyType))
 	r.Params.Set("warden-list", "true")
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
@@ -121,17 +158,27 @@ func (c *Sys) ListPoliciesWithContext(ctx context.Context) ([]string, error) {
 	return keys, nil
 }
 
-// DeletePolicy deletes a policy
+// DeletePolicy deletes a capability-based policy
 func (c *Sys) DeletePolicy(name string) error {
 	return c.DeletePolicyWithContext(context.Background(), name)
 }
 
-// DeletePolicyWithContext deletes a policy with context
+// DeletePolicyWithContext deletes a capability-based policy with context
 func (c *Sys) DeletePolicyWithContext(ctx context.Context, name string) error {
+	return c.DeletePolicyOfTypeWithContext(ctx, PolicyTypeCBP, name)
+}
+
+// DeletePolicyOfType deletes a policy of the given type
+func (c *Sys) DeletePolicyOfType(policyType, name string) error {
+	return c.DeletePolicyOfTypeWithContext(context.Background(), policyType, name)
+}
+
+// DeletePolicyOfTypeWithContext deletes a policy of the given type with context
+func (c *Sys) DeletePolicyOfTypeWithContext(ctx context.Context, policyType, name string) error {
 	ctx, cancelFunc := c.c.withConfiguredTimeout(ctx)
 	defer cancelFunc()
 
-	r := c.c.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/sys/policies/cbp/%s", name))
+	r := c.c.NewRequest(http.MethodDelete, fmt.Sprintf("/v1/sys/policies/%s/%s", policyType, name))
 
 	resp, err := c.c.rawRequestWithContext(ctx, r)
 	if err != nil {

--- a/cmd/policies/delete.go
+++ b/cmd/policies/delete.go
@@ -21,7 +21,7 @@ var (
 		Long: `
 Usage: warden policy delete <name> [flags]
 
-  Deletes a capability-based policy.
+  Deletes a policy. Use -type to select which kind: "cbp" (default) or "mcp".
 
   WARNING: This is a destructive operation and cannot be undone!
 
@@ -30,9 +30,13 @@ Usage: warden policy delete <name> [flags]
 
   Examples:
 
-    Delete a policy (with confirmation):
+    Delete a capability-based policy (with confirmation):
 
       $ warden policy delete my-policy
+
+    Delete an MCP policy:
+
+      $ warden policy delete -type mcp github-tools
 
     Delete a policy (skip confirmation):
 
@@ -45,11 +49,17 @@ Usage: warden policy delete <name> [flags]
 
 func init() {
 	DeleteCmd.Flags().BoolVarP(&deleteForce, "force", "f", false, "Skip confirmation prompt")
+	addTypeFlag(DeleteCmd)
 }
 
 func runDelete(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	if err := helpers.ValidatePath(name); err != nil {
+		return err
+	}
+
+	pType, err := resolvePolicyType()
+	if err != nil {
 		return err
 	}
 
@@ -59,12 +69,12 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	if helpers.ResolveDryRun() {
-		return helpers.DryRun(c, "DELETE", "sys/policies/{name}", nil)
+		return helpers.DryRun(c, "DELETE", "sys/policies/"+pType+"/{name}", nil)
 	}
 
 	// Confirmation prompt (unless -force is used)
 	if !deleteForce {
-		fmt.Printf("Are you sure you want to delete policy '%s'? (yes/no): ", name)
+		fmt.Printf("Are you sure you want to delete %s policy '%s'? (yes/no): ", pType, name)
 
 		reader := bufio.NewReader(os.Stdin)
 		response, err := reader.ReadString('\n')
@@ -80,12 +90,12 @@ func runDelete(cmd *cobra.Command, args []string) error {
 	}
 
 	// Delete the policy
-	err = c.Sys().DeletePolicy(name)
+	err = c.Sys().DeletePolicyOfType(pType, name)
 	if err != nil {
 		return fmt.Errorf("error deleting policy: %w", err)
 	}
 
-	return helpers.RenderMap(map[string]any{"name": name, "deleted": true}, func() {
-		fmt.Printf("Success! Deleted policy: %s\n", name)
+	return helpers.RenderMap(map[string]any{"name": name, "type": pType, "deleted": true}, func() {
+		fmt.Printf("Success! Deleted %s policy: %s\n", pType, name)
 	})
 }

--- a/cmd/policies/list.go
+++ b/cmd/policies/list.go
@@ -2,6 +2,7 @@ package policies
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/stephnangue/warden/cmd/helpers"
@@ -13,39 +14,53 @@ var ListCmd = &cobra.Command{
 	SilenceErrors: true,
 	Short:         "List all policies",
 	Long: `
-Usage: warden policy list
+Usage: warden policy list [flags]
 
-  Lists all capability-based policies in the current namespace.
+  Lists policies in the current namespace. Use -type to select which kind:
+  "cbp" (default) or "mcp".
 
-  Example:
+  Examples:
 
-    List all policies:
+    List capability-based policies:
 
       $ warden policy list
+
+    List MCP policies:
+
+      $ warden policy list -type mcp
 `,
 	Args: cobra.NoArgs,
 	RunE: runList,
 }
 
+func init() {
+	addTypeFlag(ListCmd)
+}
+
 func runList(cmd *cobra.Command, args []string) error {
+	pType, err := resolvePolicyType()
+	if err != nil {
+		return err
+	}
+
 	c, err := helpers.Client()
 	if err != nil {
 		return err
 	}
 
-	policies, err := c.Sys().ListPolicies()
+	policies, err := c.Sys().ListPoliciesOfType(pType)
 	if err != nil {
 		return fmt.Errorf("error listing policies: %w", err)
 	}
 
 	if len(policies) == 0 {
 		return helpers.RenderStrings(nil, func() {
-			fmt.Println("No policies found")
+			fmt.Printf("No %s policies found\n", pType)
 		})
 	}
 
 	return helpers.RenderStrings(policies, func() {
-		fmt.Println("Policies")
+		fmt.Printf("%s policies\n", strings.ToUpper(pType))
 		for _, policy := range policies {
 			fmt.Printf("  %s\n", policy)
 		}

--- a/cmd/policies/policy_type.go
+++ b/cmd/policies/policy_type.go
@@ -1,0 +1,32 @@
+package policies
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/stephnangue/warden/api"
+	"github.com/stephnangue/warden/cmd/helpers"
+)
+
+// policyType holds the value of the shared -type flag. Every policy
+// subcommand binds the same variable; only one of them runs per invocation.
+var policyType string
+
+// addTypeFlag registers the shared -type flag on a policy subcommand.
+func addTypeFlag(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&policyType, "type", api.PolicyTypeCBP,
+		"Policy type: cbp (capability-based) or mcp (MCP tool contract)")
+}
+
+// resolvePolicyType validates the -type flag and returns the path segment the
+// API expects. Validating here rather than at the server keeps a typo from
+// looking like a missing policy.
+func resolvePolicyType() (string, error) {
+	switch policyType {
+	case api.PolicyTypeCBP, api.PolicyTypeMCP:
+		return policyType, nil
+	default:
+		return "", fmt.Errorf("invalid policy type %q, want %q or %q: %w",
+			policyType, api.PolicyTypeCBP, api.PolicyTypeMCP, helpers.ErrInvalidInput)
+	}
+}

--- a/cmd/policies/read.go
+++ b/cmd/policies/read.go
@@ -13,18 +13,27 @@ var ReadCmd = &cobra.Command{
 	SilenceErrors: true,
 	Short:         "Read a policy",
 	Long: `
-Usage: warden policy read <name>
+Usage: warden policy read <name> [flags]
 
-  Reads a capability-based policy and prints its contents.
+  Reads a policy and prints its contents. Use -type to select which kind:
+  "cbp" (default) or "mcp".
 
-  Example:
+  Examples:
 
-    Read a policy:
+    Read a capability-based policy:
 
       $ warden policy read my-policy
+
+    Read an MCP policy:
+
+      $ warden policy read -type mcp github-tools
 `,
 	Args: cobra.ExactArgs(1),
 	RunE: runRead,
+}
+
+func init() {
+	addTypeFlag(ReadCmd)
 }
 
 func runRead(cmd *cobra.Command, args []string) error {
@@ -33,22 +42,28 @@ func runRead(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	pType, err := resolvePolicyType()
+	if err != nil {
+		return err
+	}
+
 	c, err := helpers.Client()
 	if err != nil {
 		return err
 	}
 
-	policy, err := c.Sys().GetPolicy(name)
+	policy, err := c.Sys().GetPolicyOfType(pType, name)
 	if err != nil {
 		return fmt.Errorf("error reading policy: %w", err)
 	}
 
 	if policy == nil {
-		return fmt.Errorf("policy %q not found: %w", name, helpers.ErrNotFound)
+		return fmt.Errorf("%s policy %q not found: %w", pType, name, helpers.ErrNotFound)
 	}
 
 	data := map[string]any{
 		"name":   name,
+		"type":   pType,
 		"policy": policy.Policy,
 	}
 

--- a/cmd/policies/write.go
+++ b/cmd/policies/write.go
@@ -15,14 +15,19 @@ var WriteCmd = &cobra.Command{
 	SilenceErrors: true,
 	Short:         "Write a policy",
 	Long: `
-Usage: warden policy write <name> <policy_file>
+Usage: warden policy write <name> <policy_file> [flags]
 
-  Writes a capability-based policy. The policy can be read from a file
-  or from stdin by using "-" as the filename.
+  Writes a policy. The policy can be read from a file or from stdin by using
+  "-" as the filename. Use -type to choose which kind of policy to write:
+  "cbp" (default) grants capabilities on paths, "mcp" constrains the JSON-RPC
+  methods, tools, resources and prompts reachable on a path.
+
+  Policy names are unique across types: a name already used by a policy of the
+  other type is rejected.
 
   Examples:
 
-    Write a policy from stdin:
+    Write a capability-based policy from stdin:
 
       $ warden policy write my-policy - <<EOF
       path "secret/data/myapp/*" {
@@ -34,6 +39,24 @@ Usage: warden policy write <name> <policy_file>
       }
       EOF
 
+    Write an MCP policy from stdin. Rules are grouped by what they govern,
+    and each family block names what it allows and denies:
+
+      $ warden policy write -type mcp github-tools - <<EOF
+      path "mcp/gateway/github/*" {
+        methods {
+          allowed = ["tools/list", "tools/call"]
+        }
+
+        tools {
+          allowed = ["get_repository", "list_issues"]
+          denied  = ["delete_*", "force_*"]
+        }
+
+        condition = "call.args.?env.orValue('') != 'prod'"
+      }
+      EOF
+
     Write a policy from a file:
 
       $ warden policy write my-policy ./policy.hcl
@@ -42,10 +65,19 @@ Usage: warden policy write <name> <policy_file>
 	RunE: runWrite,
 }
 
+func init() {
+	addTypeFlag(WriteCmd)
+}
+
 func runWrite(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	policyPath := args[1]
 	if err := helpers.ValidatePath(name); err != nil {
+		return err
+	}
+
+	pType, err := resolvePolicyType()
+	if err != nil {
 		return err
 	}
 
@@ -79,16 +111,16 @@ func runWrite(cmd *cobra.Command, args []string) error {
 
 	if helpers.ResolveDryRun() {
 		payload := map[string]any{"policy": policyContent}
-		return helpers.DryRun(c, "PUT", "sys/policies/{name}", payload)
+		return helpers.DryRun(c, "PUT", "sys/policies/"+pType+"/{name}", payload)
 	}
 
 	// Write the policy
-	err = c.Sys().PutPolicy(name, policyContent)
+	err = c.Sys().PutPolicyOfType(pType, name, policyContent)
 	if err != nil {
 		return fmt.Errorf("error writing policy: %w", err)
 	}
 
-	return helpers.RenderMap(map[string]any{"name": name, "written": true}, func() {
-		fmt.Printf("Success! Uploaded policy: %s\n", name)
+	return helpers.RenderMap(map[string]any{"name": name, "type": pType, "written": true}, func() {
+		fmt.Printf("Success! Uploaded %s policy: %s\n", pType, name)
 	})
 }

--- a/core/namespace_store.go
+++ b/core/namespace_store.go
@@ -993,15 +993,19 @@ func (ns *NamespaceStore) clearNamespaceResources(nsCtx context.Context, namespa
 		}
 	}
 
-	// clear CBP policies
-	policiesToClear, err := ns.core.policyStore.ListPolicies(nsCtx, PolicyTypeCBP, false)
-	if err != nil {
-		return fmt.Errorf("failed to retrieve namespace policies: %w", err)
-	}
-	for _, policy := range policiesToClear {
-		err := ns.core.policyStore.deletePolicyForce(nsCtx, policy, PolicyTypeCBP)
+	// Clear policies of every type. Each type lives in its own storage view and
+	// the deletion job never clears the namespace prefix wholesale, so a type
+	// missing from this loop is orphaned in storage forever.
+	for _, policyType := range []PolicyType{PolicyTypeCBP, PolicyTypeMCP} {
+		policiesToClear, err := ns.core.policyStore.ListPolicies(nsCtx, policyType, false)
 		if err != nil {
-			return fmt.Errorf("failed to delete policy: %w", err)
+			return fmt.Errorf("failed to retrieve namespace %s policies: %w", policyType, err)
+		}
+		for _, policy := range policiesToClear {
+			err := ns.core.policyStore.deletePolicyForce(nsCtx, policy, policyType)
+			if err != nil {
+				return fmt.Errorf("failed to delete %s policy: %w", policyType, err)
+			}
 		}
 	}
 

--- a/core/policy.go
+++ b/core/policy.go
@@ -44,15 +44,23 @@ const (
 
 type PolicyType uint32
 
-// CPB is meant for Capability-Based Policy
+// CBP is meant for Capability-Based Policy. MCP policies are purely
+// restrictive: they grant nothing on their own and are ANDed with the CBP
+// decision at request time.
+//
+// These values are persisted verbatim in PolicyEntry.Type, so the ordering is
+// storage-stable: append new types at the end, never reorder or reuse a value.
 const (
 	PolicyTypeCBP PolicyType = iota
+	PolicyTypeMCP
 )
 
 func (p PolicyType) String() string {
 	switch p {
 	case PolicyTypeCBP:
 		return "cbp"
+	case PolicyTypeMCP:
+		return "mcp"
 	}
 
 	return ""
@@ -394,31 +402,13 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 			}
 		}
 
-		// Strip a leading '/' as paths in Vault start after the / in the API path
-		if len(pc.Path) > 0 && pc.Path[0] == '/' {
-			pc.Path = pc.Path[1:]
+		normPath, isPrefix, hasSegmentWildcards, err := normalizePathPattern(result.namespace, pc.Path)
+		if err != nil {
+			return err
 		}
-
-		// Ensure we are using the full request path internally
-		pc.Path = result.namespace.Path + pc.Path
-
-		if strings.Contains(pc.Path, "+*") {
-			return fmt.Errorf("path %q: invalid use of wildcards ('+*' is forbidden)", pc.Path)
-		}
-
-		if pc.Path == "+" || strings.Count(pc.Path, "/+") > 0 || strings.HasPrefix(pc.Path, "+/") {
-			pc.HasSegmentWildcards = true
-		}
-
-		if strings.HasSuffix(pc.Path, "*") {
-			// If there are segment wildcards, don't actually strip the
-			// trailing asterisk, but don't want to hit the default case
-			if !pc.HasSegmentWildcards {
-				// Strip the glob character if found
-				pc.Path = strings.TrimSuffix(pc.Path, "*")
-				pc.IsPrefix = true
-			}
-		}
+		pc.Path = normPath
+		pc.IsPrefix = isPrefix
+		pc.HasSegmentWildcards = hasSegmentWildcards
 
 		// Initialize the map
 		pc.Permissions.CapabilitiesBitmap = 0
@@ -513,6 +503,45 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 
 	result.Paths = paths
 	return nil
+}
+
+// normalizePathPattern canonicalises a `path "..."` stanza key into the form
+// the policy indexes are keyed on: leading slash stripped, namespace path
+// prefixed, segment wildcards and trailing-glob prefixes detected.
+//
+// Both the CBP and the MCP parser call this. Sharing it is what guarantees the
+// two indexes can never disagree on a path key — a divergence there would make
+// MCP stanzas silently miss the requests they were written for.
+func normalizePathPattern(ns *namespace.Namespace, key string) (path string, isPrefix, hasSegmentWildcards bool, err error) {
+	path = key
+
+	// Strip a leading '/' as paths start after the / in the API path
+	if len(path) > 0 && path[0] == '/' {
+		path = path[1:]
+	}
+
+	// Ensure we are using the full request path internally
+	path = ns.Path + path
+
+	if strings.Contains(path, "+*") {
+		return "", false, false, fmt.Errorf("path %q: invalid use of wildcards ('+*' is forbidden)", path)
+	}
+
+	if path == "+" || strings.Count(path, "/+") > 0 || strings.HasPrefix(path, "+/") {
+		hasSegmentWildcards = true
+	}
+
+	if strings.HasSuffix(path, "*") {
+		// If there are segment wildcards, don't actually strip the trailing
+		// asterisk, but don't want to hit the default case
+		if !hasSegmentWildcards {
+			// Strip the glob character if found
+			path = strings.TrimSuffix(path, "*")
+			isPrefix = true
+		}
+	}
+
+	return path, isPrefix, hasSegmentWildcards, nil
 }
 
 // canonicaliseMCPRules converts a parsed mcp { } HCL block into the

--- a/core/policy_cas_test.go
+++ b/core/policy_cas_test.go
@@ -25,7 +25,7 @@ func writePolicy(t *testing.T, backend *SystemBackend, ctx context.Context, name
 		raw[k] = v
 	}
 	schema := backend.pathPolicies()[0].Fields
-	resp, err := backend.handlePolicyUpdate(ctx,
+	resp, err := backend.handlePolicyUpdate(PolicyTypeCBP)(ctx,
 		createTestRequest(logical.UpdateOperation, "policies/cbp/"+name, raw),
 		createFieldData(schema, raw))
 	require.NoError(t, err)
@@ -43,7 +43,7 @@ func createPolicy(t *testing.T, backend *SystemBackend, ctx context.Context, nam
 		raw[k] = v
 	}
 	schema := backend.pathPolicies()[0].Fields
-	resp, err := backend.handlePolicyCreate(ctx,
+	resp, err := backend.handlePolicyCreate(PolicyTypeCBP)(ctx,
 		createTestRequest(logical.CreateOperation, "policies/cbp/"+name, raw),
 		createFieldData(schema, raw))
 	require.NoError(t, err)
@@ -54,7 +54,7 @@ func readPolicyVersion(t *testing.T, backend *SystemBackend, ctx context.Context
 	t.Helper()
 	raw := map[string]interface{}{"name": name}
 	schema := backend.pathPolicies()[0].Fields
-	resp, err := backend.handlePolicyRead(ctx,
+	resp, err := backend.handlePolicyRead(PolicyTypeCBP)(ctx,
 		createTestRequest(logical.ReadOperation, "policies/cbp/"+name, raw),
 		createFieldData(schema, raw))
 	require.NoError(t, err)

--- a/core/policy_cbp_test.go
+++ b/core/policy_cbp_test.go
@@ -79,7 +79,7 @@ func TestCBP_CompiledConditionSharedAcrossCallers(t *testing.T) {
 
 	// Both assemblies drew on the same parsed policy, which is what holds the
 	// compiled CEL program — so the condition was compiled once, not per call.
-	cached, ok := ps.tokenPoliciesLRU.Get(ps.cacheKey(namespace.RootNamespace, "cond"))
+	cached, ok := ps.tokenPoliciesLRU.Get(ps.cacheKey(namespace.RootNamespace, "cond", PolicyTypeCBP))
 	require.True(t, ok, "the parsed policy must stay cached")
 	require.Len(t, cached.Paths, 1)
 	assert.NotEmpty(t, cached.Paths[0].Permissions.Conditions,
@@ -1168,7 +1168,7 @@ func TestCBP_ReusesCachedParse(t *testing.T) {
 
 	// Seed the LRU directly so GetPolicy returns this cached *Policy on the
 	// cache-hit path (storage is never consulted).
-	idx := ps.cacheKey(namespace.RootNamespace, "diverged")
+	idx := ps.cacheKey(namespace.RootNamespace, "diverged", PolicyTypeCBP)
 	ps.tokenPoliciesLRU.Add(idx, cached)
 
 	cbp, err := ps.CBP(ctx, map[string][]string{namespace.RootNamespaceID: {"diverged"}})
@@ -1315,7 +1315,7 @@ func TestCBP_ExpiredPathIsDropped(t *testing.T) {
 			Expiration:   time.Now().Add(50 * time.Millisecond),
 		}},
 	}
-	ps.tokenPoliciesLRU.Add(ps.cacheKey(namespace.RootNamespace, "expiring"), p)
+	ps.tokenPoliciesLRU.Add(ps.cacheKey(namespace.RootNamespace, "expiring", PolicyTypeCBP), p)
 
 	names := map[string][]string{namespace.RootNamespaceID: {"expiring"}}
 	first, err := ps.CBP(ctx, names)

--- a/core/policy_mcp_parse.go
+++ b/core/policy_mcp_parse.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-secure-stdlib/parseutil"
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/gohcl"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	hcljson "github.com/hashicorp/hcl/v2/json"
+
+	"github.com/stephnangue/warden/internal/namespace"
+)
+
+// The MCP policy grammar is parsed with HCL v2 rather than the v1 parser the
+// CBP grammar inherited. Two properties matter here and neither is available
+// in v1: unsupported attributes and blocks are rejected by default, and a
+// repeated block is a hard error instead of a silent field-wise merge.
+//
+// Both matter asymmetrically for a restrictive policy. A typo in `allowed`
+// merely denies more than intended — noisy but safe. A typo in `denied` would
+// leave the deny list empty and silently widen the policy, which is the one
+// failure mode this grammar must not have.
+//
+// The parsers stay independent, but the canonical path key does not: both call
+// normalizePathPattern, so the CBP and MCP indexes cannot disagree on which
+// requests a stanza covers.
+
+// mcpPolicyDoc is the decode shape of a whole MCP policy document.
+type mcpPolicyDoc struct {
+	Name  string             `hcl:"name,optional"`
+	Paths []mcpPolicyPathHCL `hcl:"path,block"`
+}
+
+// mcpPolicyPathHCL is one `path "..." { }` stanza of an MCP policy. There is no
+// capabilities key: an MCP policy grants nothing, it only narrows what a
+// capability-based grant already allows.
+type mcpPolicyPathHCL struct {
+	Path string `hcl:"path,label"`
+
+	Comment    string `hcl:"comment,optional"`
+	Expiration string `hcl:"expiration,optional"`
+
+	Methods   *mcpFamilyHCL `hcl:"methods,block"`
+	Tools     *mcpFamilyHCL `hcl:"tools,block"`
+	Resources *mcpFamilyHCL `hcl:"resources,block"`
+	Prompts   *mcpFamilyHCL `hcl:"prompts,block"`
+
+	// Condition is the per-call CEL expression. It spans every family and is
+	// evaluated once per call, so it belongs to the stanza rather than to any
+	// one family block.
+	Condition string `hcl:"condition,optional"`
+}
+
+// mcpFamilyHCL is one family block: methods, tools, resources or prompts.
+type mcpFamilyHCL struct {
+	Allowed []string `hcl:"allowed,optional"`
+	Denied  []string `hcl:"denied,optional"`
+}
+
+// lists returns the (allowed, denied) pair for a family block, tolerating a
+// nil receiver so an omitted block reads the same as an empty one.
+func (f *mcpFamilyHCL) lists() (allowed, denied []string) {
+	if f == nil {
+		return nil, nil
+	}
+	return f.Allowed, f.Denied
+}
+
+// flatten converts a stanza's family blocks into the flat rule shape that
+// canonicaliseMCPRules validates, so wildcard checking, lowercasing and CEL
+// compilation live in one place no matter how the document spells them.
+func (s *mcpPolicyPathHCL) flatten() *MCPRulesHCL {
+	h := &MCPRulesHCL{Condition: s.Condition}
+	h.AllowedMethods, h.DeniedMethods = s.Methods.lists()
+	h.AllowedTools, h.DeniedTools = s.Tools.lists()
+	h.AllowedResources, h.DeniedResources = s.Resources.lists()
+	h.AllowedPrompts, h.DeniedPrompts = s.Prompts.lists()
+	return h
+}
+
+// ParseMCPPolicy parses an MCP policy document into an intermediary Policy.
+//
+// An MCP policy is keyed by request path exactly as a CBP policy is, but each
+// stanza groups its rules by the thing being governed — methods, tools,
+// resources, prompts — and carries no capabilities. The result is purely
+// restrictive: it grants nothing on its own, and its rules are ANDed with the
+// CBP decision at request time.
+func ParseMCPPolicy(ns *namespace.Namespace, rules string) (*Policy, error) {
+	body, err := parseMCPBody([]byte(rules))
+	if err != nil {
+		return nil, err
+	}
+
+	var doc mcpPolicyDoc
+	if diags := gohcl.DecodeBody(body, nil, &doc); diags.HasErrors() {
+		return nil, fmt.Errorf("failed to parse policy: %s", diags.Error())
+	}
+
+	p := &Policy{
+		Name:      doc.Name,
+		Raw:       rules,
+		Type:      PolicyTypeMCP,
+		namespace: ns,
+	}
+
+	paths := make([]*PathRules, 0, len(doc.Paths))
+	for i := range doc.Paths {
+		stanza := &doc.Paths[i]
+
+		var expiration time.Time
+		if stanza.Expiration != "" {
+			exp, err := parseutil.ParseAbsoluteTime(stanza.Expiration)
+			if err != nil {
+				return nil, fmt.Errorf("path %q: invalid expiration time: %w", stanza.Path, err)
+			}
+
+			// An expired stanza is dropped at parse, mechanically the same
+			// treatment a CBP path stanza gets — but not the same direction.
+			// Dropping an expired CBP stanza removes a grant, which fails
+			// closed; dropping an expired MCP stanza removes a restriction.
+			// A lapsed tool contract must therefore stop traffic rather than
+			// free it, which is what the absence deny-by-default provides: no
+			// stanza in scope for an MCP-shaped request is a denial. Until that
+			// rule is in place, an expired stanza leaves its path ungoverned.
+			if time.Now().After(exp) {
+				continue
+			}
+			expiration = exp
+		}
+
+		normPath, isPrefix, hasSegmentWildcards, err := normalizePathPattern(ns, stanza.Path)
+		if err != nil {
+			return nil, err
+		}
+
+		rules, err := canonicaliseMCPRules(stanza.flatten())
+		if err != nil {
+			return nil, fmt.Errorf("path %q: %w", stanza.Path, err)
+		}
+
+		paths = append(paths, &PathRules{
+			Path:                normPath,
+			IsPrefix:            isPrefix,
+			HasSegmentWildcards: hasSegmentWildcards,
+			Expiration:          expiration,
+			Permissions: &CBPPermissions{
+				MCP: []*CBPMCPRules{rules},
+			},
+		})
+	}
+
+	p.Paths = paths
+	return p, nil
+}
+
+// parseMCPBody parses a policy document as either native HCL or JSON, matching
+// the "HCL or JSON format" contract the policy API advertises. The format is
+// sniffed the same way the CBP parser sniffs it: a leading '{' means JSON.
+func parseMCPBody(src []byte) (hcl.Body, error) {
+	if strings.HasPrefix(strings.TrimSpace(string(src)), "{") {
+		file, diags := hcljson.Parse(src, "policy.json")
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("failed to parse policy: %s", diags.Error())
+		}
+		return file.Body, nil
+	}
+
+	file, diags := hclsyntax.ParseConfig(src, "policy.hcl", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("failed to parse policy: %s", diags.Error())
+	}
+	return file.Body, nil
+}

--- a/core/policy_mcp_parse_test.go
+++ b/core/policy_mcp_parse_test.go
@@ -1,0 +1,265 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/internal/namespace"
+)
+
+// testParseMCPPolicy parses an MCP policy document for testing.
+func testParseMCPPolicy(t testing.TB, rules string) *Policy {
+	t.Helper()
+	policy, err := ParseMCPPolicy(namespace.RootNamespace, rules)
+	require.NoError(t, err)
+	return policy
+}
+
+func TestParseMCPPolicy_AllFields(t *testing.T) {
+	p := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+    methods {
+      allowed = ["tools/list", "tools/call"]
+      denied  = ["tools/dangerous"]
+    }
+
+    tools {
+      allowed = ["get_repository", "list_issues"]
+      denied  = ["delete_*"]
+    }
+
+    resources {
+      allowed = ["github://repo/*"]
+      denied  = ["github://secrets/*"]
+    }
+
+    prompts {
+      allowed = ["*"]
+      denied  = ["sudo_*"]
+    }
+
+    condition = "call.args.?env.orValue('') != 'prod'"
+}
+`)
+
+	assert.Equal(t, PolicyTypeMCP, p.Type)
+	require.Len(t, p.Paths, 1)
+
+	pr := p.Paths[0]
+	assert.Equal(t, "mcp/gateway/", pr.Path)
+	assert.True(t, pr.IsPrefix)
+	assert.False(t, pr.HasSegmentWildcards)
+
+	// An MCP stanza grants nothing: the capability bitmap stays zero.
+	assert.Zero(t, pr.Permissions.CapabilitiesBitmap)
+	assert.Empty(t, pr.Permissions.Conditions, "path-level conditions are a CBP concept")
+
+	require.Len(t, pr.Permissions.MCP, 1)
+	set := pr.Permissions.MCP[0]
+	assert.Equal(t, []string{"tools/list", "tools/call"}, set.AllowedMethods)
+	assert.Equal(t, []string{"tools/dangerous"}, set.DeniedMethods)
+	assert.Equal(t, []string{"get_repository", "list_issues"}, set.AllowedTools)
+	assert.Equal(t, []string{"delete_*"}, set.DeniedTools)
+	assert.Equal(t, []string{"github://repo/*"}, set.AllowedResources)
+	assert.Equal(t, []string{"github://secrets/*"}, set.DeniedResources)
+	assert.Equal(t, []string{"*"}, set.AllowedPrompts)
+	assert.Equal(t, []string{"sudo_*"}, set.DeniedPrompts)
+	require.NotNil(t, set.Condition, "the per-call condition compiles against the MCP env")
+}
+
+func TestParseMCPPolicy_LowercasesEntries(t *testing.T) {
+	p := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+    methods { allowed = ["Tools/CALL"] }
+    tools   { allowed = ["Get_Repository"] }
+}
+`)
+	set := p.Paths[0].Permissions.MCP[0]
+	assert.Equal(t, []string{"tools/call"}, set.AllowedMethods)
+	assert.Equal(t, []string{"get_repository"}, set.AllowedTools)
+}
+
+func TestParseMCPPolicy_EmptyStanzaIsValid(t *testing.T) {
+	// An empty stanza is a deliberate lock-down: with no allow lists, the
+	// shipped deny-by-default gates refuse every non-lifecycle call.
+	p := testParseMCPPolicy(t, `path "mcp/gateway/*" {}`)
+	require.Len(t, p.Paths, 1)
+	require.Len(t, p.Paths[0].Permissions.MCP, 1)
+	assert.Empty(t, p.Paths[0].Permissions.MCP[0].AllowedMethods)
+}
+
+// TestParseMCPPolicy_EmptyBlockMatchesOmittedBlock pins that writing a family
+// block with nothing in it says the same thing as leaving it out: both leave
+// the family's lists nil, which denies everything in that family.
+func TestParseMCPPolicy_EmptyBlockMatchesOmittedBlock(t *testing.T) {
+	withEmpty := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+    methods { allowed = ["tools/list"] }
+    tools {}
+}
+`)
+	omitted := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+    methods { allowed = ["tools/list"] }
+}
+`)
+	assert.Equal(t,
+		omitted.Paths[0].Permissions.MCP[0],
+		withEmpty.Paths[0].Permissions.MCP[0])
+}
+
+func TestParseMCPPolicy_RejectsCBPKeys(t *testing.T) {
+	for _, key := range []string{
+		`capabilities = ["update"]`,
+		`pagination_limit = 10`,
+		`allowed_params = { region = ["eu-west-1"] }`,
+	} {
+		_, err := ParseMCPPolicy(namespace.RootNamespace,
+			fmt.Sprintf("path \"mcp/gateway/*\" {\n  %s\n}\n", key))
+		require.Error(t, err, "MCP policies must reject the CBP key %q", key)
+	}
+}
+
+// TestParseMCPPolicy_RejectsMisspelledFamilyKey is the reason this grammar is
+// parsed with HCL v2. A typo in `denied` would leave the deny list empty and
+// silently widen the policy; the v1 decoder ignores unknown keys, so the
+// mistake would never surface.
+func TestParseMCPPolicy_RejectsMisspelledFamilyKey(t *testing.T) {
+	_, err := ParseMCPPolicy(namespace.RootNamespace, `
+path "mcp/gateway/*" {
+    tools {
+      allowed = ["get_repository"]
+      deined  = ["delete_repository"]
+    }
+}
+`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deined", "the diagnostic must name the offending key")
+}
+
+func TestParseMCPPolicy_RejectsUnknownFamilyBlock(t *testing.T) {
+	_, err := ParseMCPPolicy(namespace.RootNamespace, `
+path "mcp/gateway/*" {
+    toolz { allowed = ["get_repository"] }
+}
+`)
+	require.Error(t, err)
+}
+
+// TestParseMCPPolicy_RejectsDuplicateFamilyBlock pins the other v2 property:
+// a repeated block is an error rather than a silent field-wise merge, so an
+// operator cannot lose half a rule set without being told.
+func TestParseMCPPolicy_RejectsDuplicateFamilyBlock(t *testing.T) {
+	_, err := ParseMCPPolicy(namespace.RootNamespace, `
+path "mcp/gateway/*" {
+    tools { denied = ["alpha"] }
+    tools { denied = ["beta"] }
+}
+`)
+	require.Error(t, err)
+}
+
+func TestParseMCPPolicy_RejectsBadPatterns(t *testing.T) {
+	// Leading and internal wildcards are rejected; only a trailing * is a glob.
+	for _, pattern := range []string{`"*_repo"`, `"get_*_repo"`} {
+		_, err := ParseMCPPolicy(namespace.RootNamespace,
+			fmt.Sprintf("path \"mcp/gateway/*\" {\n  tools { allowed = [%s] }\n}\n", pattern))
+		require.Error(t, err, "pattern %s must be rejected", pattern)
+	}
+}
+
+// TestParseMCPPolicy_JSONDocument covers the "HCL or JSON format" contract the
+// policy API advertises, which the v2 parser serves from its own json package.
+func TestParseMCPPolicy_JSONDocument(t *testing.T) {
+	p := testParseMCPPolicy(t, `{
+  "path": {
+    "mcp/gateway/*": {
+      "methods": { "allowed": ["tools/list"] },
+      "tools":   { "allowed": ["get_repository"] }
+    }
+  }
+}`)
+	require.Len(t, p.Paths, 1)
+	set := p.Paths[0].Permissions.MCP[0]
+	assert.Equal(t, []string{"tools/list"}, set.AllowedMethods)
+	assert.Equal(t, []string{"get_repository"}, set.AllowedTools)
+}
+
+// TestParseMCPPolicy_JSONRejectsMisspelledKey pins that the strictness which
+// justifies the v2 parser survives the JSON path too — a document submitted as
+// JSON must not be able to smuggle in a silently-ignored `deined`.
+func TestParseMCPPolicy_JSONRejectsMisspelledKey(t *testing.T) {
+	_, err := ParseMCPPolicy(namespace.RootNamespace, `{
+  "path": {
+    "mcp/gateway/*": {
+      "tools": { "allowed": ["get_repository"], "deined": ["delete_repository"] }
+    }
+  }
+}`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deined")
+}
+
+func TestParseMCPPolicy_ExpiredStanzaSkipped(t *testing.T) {
+	past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	p := testParseMCPPolicy(t, fmt.Sprintf(`
+path "mcp/gateway/*" {
+    expiration = %q
+    methods { allowed = ["tools/list"] }
+}
+`, past))
+	// Dropped at parse, mechanically as in CBP. The direction differs though:
+	// this removes a restriction rather than a grant, so a lapsed contract is
+	// only safe once absence of a matching stanza denies MCP-shaped requests.
+	assert.Empty(t, p.Paths, "an expired stanza is dropped at parse")
+}
+
+func TestParseMCPPolicy_FutureExpirationKept(t *testing.T) {
+	future := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	p := testParseMCPPolicy(t, fmt.Sprintf(`
+path "mcp/gateway/*" {
+    expiration = %q
+    methods { allowed = ["tools/list"] }
+}
+`, future))
+	require.Len(t, p.Paths, 1)
+	assert.False(t, p.Paths[0].Expiration.IsZero())
+}
+
+// TestPathNormalizationParity is the guard against the two policy indexes
+// disagreeing on a path key. A divergence here would make MCP stanzas silently
+// miss the requests they were written for, so both parsers must agree exactly.
+func TestPathNormalizationParity(t *testing.T) {
+	for _, key := range []string{
+		"mcp/gateway/*",
+		"/mcp/gateway/*",
+		"mcp/gateway",
+		"mcp/role/+/gateway*",
+		"+/gateway",
+	} {
+		t.Run(key, func(t *testing.T) {
+			cbp := testParsePolicy(t, fmt.Sprintf("path %q {\n  capabilities = [\"update\"]\n}\n", key))
+			mcp := testParseMCPPolicy(t, fmt.Sprintf("path %q {\n  methods { allowed = [\"tools/list\"] }\n}\n", key))
+
+			require.Len(t, cbp.Paths, 1)
+			require.Len(t, mcp.Paths, 1)
+			assert.Equal(t, cbp.Paths[0].Path, mcp.Paths[0].Path)
+			assert.Equal(t, cbp.Paths[0].IsPrefix, mcp.Paths[0].IsPrefix)
+			assert.Equal(t, cbp.Paths[0].HasSegmentWildcards, mcp.Paths[0].HasSegmentWildcards)
+		})
+	}
+}
+
+func TestPathNormalizationParity_RejectsSameBadWildcard(t *testing.T) {
+	_, cbpErr := ParseCBPPolicy(namespace.RootNamespace, `path "mcp/+*" { capabilities = ["update"] }`)
+	_, mcpErr := ParseMCPPolicy(namespace.RootNamespace, "path \"mcp/+*\" {\n  methods { allowed = [\"tools/list\"] }\n}\n")
+	require.Error(t, cbpErr)
+	require.Error(t, mcpErr)
+}

--- a/core/policy_mcp_store_test.go
+++ b/core/policy_mcp_store_test.go
@@ -1,0 +1,208 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/internal/namespace"
+)
+
+func TestPolicyStore_MCPRoundTrip(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := testContext()
+
+	p := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
+}
+`)
+	p.Name = "gw-tools"
+	require.NoError(t, ps.SetPolicy(ctx, p, nil))
+
+	got, err := ps.GetPolicy(ctx, "gw-tools", PolicyTypeMCP)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, PolicyTypeMCP, got.Type)
+	require.Len(t, got.Paths, 1)
+	require.Len(t, got.Paths[0].Permissions.MCP, 1)
+	assert.Equal(t, []string{"tools/list"}, got.Paths[0].Permissions.MCP[0].AllowedMethods)
+
+	// The CBP view must not see it: the two types live in separate keyspaces.
+	cbpGot, err := ps.GetPolicy(ctx, "gw-tools", PolicyTypeCBP)
+	require.NoError(t, err)
+	assert.Nil(t, cbpGot)
+
+	names, err := ps.ListPolicies(ctx, PolicyTypeMCP, false)
+	require.NoError(t, err)
+	assert.Contains(t, names, "gw-tools")
+
+	cbpNames, err := ps.ListPolicies(ctx, PolicyTypeCBP, false)
+	require.NoError(t, err)
+	assert.NotContains(t, cbpNames, "gw-tools")
+
+	require.NoError(t, ps.DeletePolicy(ctx, "gw-tools", PolicyTypeMCP))
+	gone, err := ps.GetPolicy(ctx, "gw-tools", PolicyTypeMCP)
+	require.NoError(t, err)
+	assert.Nil(t, gone)
+}
+
+// TestPolicyStore_CrossTypeNameUniqueness pins the guard that keeps a flat
+// token policy list unambiguous: one name can only ever resolve to one policy.
+func TestPolicyStore_CrossTypeNameUniqueness(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := testContext()
+
+	cbp := testParsePolicy(t, `path "mcp/gateway/*" { capabilities = ["update"] }`)
+	cbp.Name = "shared-name"
+	require.NoError(t, ps.SetPolicy(ctx, cbp, nil))
+
+	mcp := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
+}
+`)
+	mcp.Name = "shared-name"
+	err := ps.SetPolicy(ctx, mcp, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already in use by a cbp policy")
+
+	// And the same in the other direction.
+	other := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
+}
+`)
+	other.Name = "mcp-only"
+	require.NoError(t, ps.SetPolicy(ctx, other, nil))
+
+	clash := testParsePolicy(t, `path "mcp/gateway/*" { capabilities = ["update"] }`)
+	clash.Name = "mcp-only"
+	err = ps.SetPolicy(ctx, clash, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already in use by a mcp policy")
+}
+
+// TestPolicyStore_UpdateOwnTypeStillWorks proves the uniqueness guard checks
+// the *other* view only — overwriting a policy with itself must not trip it.
+func TestPolicyStore_UpdateOwnTypeStillWorks(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := testContext()
+
+	p := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
+}
+`)
+	p.Name = "gw-tools"
+	require.NoError(t, ps.SetPolicy(ctx, p, nil))
+
+	updated := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+}
+`)
+	updated.Name = "gw-tools"
+	require.NoError(t, ps.SetPolicy(ctx, updated, nil))
+
+	got, err := ps.GetPolicy(ctx, "gw-tools", PolicyTypeMCP)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, []string{"tools/call"}, got.Paths[0].Permissions.MCP[0].AllowedMethods)
+}
+
+// TestPolicyStore_UnknownTypeErrors covers the delete path that previously
+// reported success while deleting nothing.
+func TestPolicyStore_UnknownTypeErrors(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := testContext()
+
+	unknown := PolicyType(99)
+
+	require.Error(t, ps.DeletePolicy(ctx, "whatever", unknown))
+
+	_, err := ps.GetPolicy(ctx, "whatever", unknown)
+	require.Error(t, err)
+
+	_, err = ps.ListPolicies(ctx, unknown, false)
+	require.Error(t, err)
+
+	// Writing an unrouted type must fail rather than land in the CBP view,
+	// which is what getBarrierView returning nil used to allow.
+	stray := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
+}
+`)
+	stray.Name = "stray"
+	stray.Type = unknown
+	require.Error(t, ps.SetPolicy(ctx, stray, nil))
+}
+
+// TestPolicyStore_CacheKeySeparatesTypes proves two policies of different types
+// cannot collide in the shared LRU.
+func TestPolicyStore_CacheKeySeparatesTypes(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+
+	cbpKey := ps.cacheKey(namespace.RootNamespace, "same", PolicyTypeCBP)
+	mcpKey := ps.cacheKey(namespace.RootNamespace, "same", PolicyTypeMCP)
+	assert.NotEqual(t, cbpKey, mcpKey)
+
+	// The namespace UUID stays the leading segment so invalidateNamespace's
+	// prefix sweep keeps clearing every type at once.
+	assert.Contains(t, cbpKey, namespace.RootNamespace.UUID)
+	assert.Contains(t, mcpKey, namespace.RootNamespace.UUID)
+}
+
+// TestClearNamespaceResources_ClearsBothPolicyTypes guards against MCP policies
+// being orphaned in storage. The deletion job clears resources type by type and
+// never wipes the namespace barrier prefix wholesale, so a policy type missing
+// from that sweep survives its namespace forever.
+func TestClearNamespaceResources_ClearsBothPolicyTypes(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := testContext()
+
+	target := &namespace.Namespace{Path: "sweep-test/"}
+	require.NoError(t, core.namespaceStore.SetNamespace(ctx, target))
+	nsCtx := namespace.ContextWithNamespace(context.Background(), target)
+
+	cbp, err := ParseCBPPolicy(target, `path "mcp/gateway/*" { capabilities = ["update"] }`)
+	require.NoError(t, err)
+	cbp.Name = "ns-gw-access"
+	require.NoError(t, ps.SetPolicy(nsCtx, cbp, nil))
+
+	mcp, err := ParseMCPPolicy(target, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
+}
+`)
+	require.NoError(t, err)
+	mcp.Name = "ns-gw-tools"
+	require.NoError(t, ps.SetPolicy(nsCtx, mcp, nil))
+
+	mcpNames, err := ps.ListPolicies(nsCtx, PolicyTypeMCP, false)
+	require.NoError(t, err)
+	require.Contains(t, mcpNames, "ns-gw-tools")
+
+	// Drive the production sweep, not a local reimplementation of it.
+	require.NoError(t, core.namespaceStore.clearNamespaceResources(nsCtx, target))
+
+	remainingMCP, err := ps.ListPolicies(nsCtx, PolicyTypeMCP, false)
+	require.NoError(t, err)
+	assert.Empty(t, remainingMCP, "MCP policies must not outlive their namespace")
+
+	remainingCBP, err := ps.ListPolicies(nsCtx, PolicyTypeCBP, false)
+	require.NoError(t, err)
+	assert.Empty(t, remainingCBP, "CBP policies are still swept, as before")
+}

--- a/core/policy_store.go
+++ b/core/policy_store.go
@@ -26,6 +26,10 @@ const (
 	// nested under policySubPath.
 	cbpSubPath = "cbp/"
 
+	// mcpSubPath is the sub-path used for the policy of type MCP. This is
+	// nested under policySubPath, beside cbpSubPath.
+	mcpSubPath = "mcp/"
+
 	// policyCacheSize is the number of policies that are kept cached
 	policyCacheSize = 1024
 )
@@ -133,7 +137,7 @@ func (ps *PolicyStore) invalidate(ctx context.Context, name string, policyType P
 
 	// This may come with a prefixed "/" due to joining the file path
 	saneName := strings.TrimPrefix(name, "/")
-	index := ps.cacheKey(ns, saneName)
+	index := ps.cacheKey(ns, saneName, policyType)
 
 	ps.modifyLock.Lock()
 	defer ps.modifyLock.Unlock()
@@ -141,13 +145,13 @@ func (ps *PolicyStore) invalidate(ctx context.Context, name string, policyType P
 	// We don't lock before removing from the LRU here because the worst that
 	// can happen is we load again if something since added it
 	switch policyType {
-	case PolicyTypeCBP:
+	case PolicyTypeCBP, PolicyTypeMCP:
 		if ps.tokenPoliciesLRU != nil {
 			ps.tokenPoliciesLRU.Remove(index)
 		}
 
 	default:
-		return fmt.Errorf("unknown policy type: %w", err)
+		return fmt.Errorf("unknown policy type %d", policyType)
 	}
 
 	return nil
@@ -176,6 +180,29 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy, casVers
 
 	// Get the appropriate view based on policy type and namespace
 	view := ps.getBarrierView(p.namespace, p.Type)
+	if view == nil {
+		return errors.New("unknown policy type, cannot set")
+	}
+
+	// Policy names are unique across types. Token attachment is a flat list of
+	// names with no type dimension, so a name resolving in both views would
+	// attach ambiguously. Read the other type's view directly: modifyLock is
+	// already held exclusively here, and switchedGetPolicy would take it again.
+	otherType := PolicyTypeMCP
+	if p.Type == PolicyTypeMCP {
+		otherType = PolicyTypeCBP
+	}
+	if otherView := ps.getBarrierView(p.namespace, otherType); otherView != nil {
+		conflict, err := otherView.Get(ctx, p.Name)
+		if err != nil {
+			return fmt.Errorf("unable to check policy name against %s policies: %w", otherType, err)
+		}
+		if conflict != nil {
+			return logical.ErrBadRequest(fmt.Sprintf(
+				"policy name %q is already in use by a %s policy; policy names are unique across %s and %s types",
+				p.Name, otherType, PolicyTypeCBP, PolicyTypeMCP))
+		}
+	}
 
 	p.Modified = time.Now()
 
@@ -226,10 +253,10 @@ func (ps *PolicyStore) setPolicyInternal(ctx context.Context, p *Policy, casVers
 	}
 
 	// Construct the cache key
-	index := ps.cacheKey(p.namespace, p.Name)
+	index := ps.cacheKey(p.namespace, p.Name, p.Type)
 
 	switch p.Type {
-	case PolicyTypeCBP:
+	case PolicyTypeCBP, PolicyTypeMCP:
 		if err := view.Put(ctx, entry); err != nil {
 			return fmt.Errorf("failed to persist policy: %w", err)
 		}
@@ -253,10 +280,26 @@ func (ps *PolicyStore) getCBPView(ns *namespace.Namespace) BarrierView {
 	return ps.core.namespaceMountEntryView(ns, systemBarrierPrefix+policySubPath+cbpSubPath)
 }
 
-// getBarrierView returns the appropriate barrier view for the given namespace and policy type.
-// Currently, this only supports CBP policies, so it delegates to getCBPView.
-func (ps *PolicyStore) getBarrierView(ns *namespace.Namespace, _ PolicyType) BarrierView {
-	return ps.getCBPView(ns)
+// getMCPView returns the MCP view for the given namespace
+func (ps *PolicyStore) getMCPView(ns *namespace.Namespace) BarrierView {
+	if ns.ID == namespace.RootNamespaceID {
+		return ps.core.systemBarrierView.SubView(policySubPath + mcpSubPath)
+	}
+
+	return ps.core.namespaceMountEntryView(ns, systemBarrierPrefix+policySubPath+mcpSubPath)
+}
+
+// getBarrierView returns the appropriate barrier view for the given namespace
+// and policy type, or nil for a type that has no view.
+func (ps *PolicyStore) getBarrierView(ns *namespace.Namespace, policyType PolicyType) BarrierView {
+	switch policyType {
+	case PolicyTypeCBP:
+		return ps.getCBPView(ns)
+	case PolicyTypeMCP:
+		return ps.getMCPView(ns)
+	}
+
+	return nil
 }
 
 // GetPolicy is used to fetch the named policy
@@ -272,16 +315,17 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 
 	// Policies are normalized to lower-case
 	name = ps.sanitizeName(name)
-	index := ps.cacheKey(ns, name)
+	index := ps.cacheKey(ns, name, policyType)
 
 	var cache *lru.TwoQueueCache[string, *Policy]
 	var view BarrierView
 
 	switch policyType {
-	case PolicyTypeCBP:
+	case PolicyTypeCBP, PolicyTypeMCP:
 		cache = ps.tokenPoliciesLRU
-		view = ps.getCBPView(ns)
-		policyType = PolicyTypeCBP
+		view = ps.getBarrierView(ns, policyType)
+	default:
+		return nil, fmt.Errorf("unknown policy type %d", policyType)
 	}
 
 	if cache != nil {
@@ -397,8 +441,17 @@ func (ps *PolicyStore) switchedGetPolicy(ctx context.Context, name string, polic
 
 		// Reset this in case they set the name in the policy itself
 		policy.Name = name
+	case PolicyTypeMCP:
+		p, err := ParseMCPPolicy(ns, policyEntry.Raw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse policy: %w", err)
+		}
+		policy.Paths = p.Paths
+
+		// Reset this in case they set the name in the policy itself
+		policy.Name = name
 	default:
-		return nil, fmt.Errorf("unknown policy type %q", policyEntry.Type.String())
+		return nil, fmt.Errorf("unknown policy type %d", policyEntry.Type)
 	}
 
 	if cache != nil {
@@ -433,10 +486,10 @@ func (ps *PolicyStore) ListPoliciesWithPrefix(ctx context.Context, policyType Po
 	// key names.
 	var keys []string
 	switch policyType {
-	case PolicyTypeCBP:
+	case PolicyTypeCBP, PolicyTypeMCP:
 		keys, err = sdklogical.CollectKeysWithPrefix(ctx, view, prefix)
 	default:
-		return nil, fmt.Errorf("unknown policy type %q", policyType)
+		return nil, fmt.Errorf("unknown policy type %d", policyType)
 	}
 
 	if omitNonAssignable {
@@ -475,17 +528,18 @@ func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, po
 
 	// Policies are normalized to lower-case
 	name = ps.sanitizeName(name)
-	index := ps.cacheKey(ns, name)
+	index := ps.cacheKey(ns, name, policyType)
 
 	view := ps.getBarrierView(ns, policyType)
 
 	switch policyType {
-	case PolicyTypeCBP:
+	case PolicyTypeCBP, PolicyTypeMCP:
 		if !force {
 			if slices.Contains(immutablePolicies, name) {
 				return fmt.Errorf("cannot delete %q policy", name)
 			}
-			if name == "default" {
+			// "default" is a CBP-only singleton; an MCP policy may use the name.
+			if policyType == PolicyTypeCBP && name == "default" {
 				return errors.New("cannot delete default policy")
 			}
 		}
@@ -501,6 +555,10 @@ func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, po
 			// Clear the cache
 			ps.tokenPoliciesLRU.Remove(index)
 		}
+	default:
+		// Previously an unrouted type fell out of this switch reporting success
+		// while deleting nothing.
+		return fmt.Errorf("unknown policy type %d", policyType)
 	}
 
 	return nil
@@ -589,8 +647,13 @@ func (ps *PolicyStore) sanitizeName(name string) string {
 	return strings.ToLower(strings.TrimSpace(name))
 }
 
-func (ps *PolicyStore) cacheKey(ns *namespace.Namespace, name string) string {
-	return path.Join(ns.UUID, name)
+// cacheKey builds the LRU key for a policy. The type is part of the key
+// because CBP and MCP policies live in separate storage views and share one
+// cache — without it, a CBP and an MCP policy of the same name would collide.
+// The namespace UUID stays first so invalidateNamespace's prefix sweep keeps
+// matching every type at once.
+func (ps *PolicyStore) cacheKey(ns *namespace.Namespace, name string, policyType PolicyType) string {
+	return path.Join(ns.UUID, policyType.String(), name)
 }
 
 // loadDefaultPolicies loads default policies for the namespace in the provided context

--- a/core/sys_policies.go
+++ b/core/sys_policies.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/internal/namespace"
@@ -10,11 +11,28 @@ import (
 	"github.com/stephnangue/warden/logical"
 )
 
-// pathPolicies returns the paths for policy operations
+// pathPolicies returns the paths for policy operations, one set per policy
+// type. CBP policies grant capabilities on paths; MCP policies are purely
+// restrictive tool contracts whose rules are ANDed with the CBP decision.
 func (b *SystemBackend) pathPolicies() []*framework.Path {
+	var paths []*framework.Path
+	for _, policyType := range []PolicyType{PolicyTypeCBP, PolicyTypeMCP} {
+		paths = append(paths, b.policyPaths(policyType)...)
+	}
+
+	return paths
+}
+
+// policyPaths builds the CRUD and list paths for one policy type. Everything
+// but the storage type and the help text is identical between types, so the
+// handlers are closures over the type rather than duplicated bodies.
+func (b *SystemBackend) policyPaths(policyType PolicyType) []*framework.Path {
+	name := policyType.String()
+	label := strings.ToUpper(name)
+
 	return []*framework.Path{
 		{
-			Pattern: "policies/cbp/" + framework.GenericNameRegex("name"),
+			Pattern: "policies/" + name + "/" + framework.GenericNameRegex("name"),
 			Fields: map[string]*framework.FieldSchema{
 				"name": {
 					Type:        framework.TypeString,
@@ -37,27 +55,27 @@ func (b *SystemBackend) pathPolicies() []*framework.Path {
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.CreateOperation: &framework.PathOperation{
-					Callback: b.handlePolicyCreate,
-					Summary:  "Create a new CBP policy",
+					Callback: b.handlePolicyCreate(policyType),
+					Summary:  "Create a new " + label + " policy",
 				},
 				logical.ReadOperation: &framework.PathOperation{
-					Callback: b.handlePolicyRead,
-					Summary:  "Get CBP policy",
+					Callback: b.handlePolicyRead(policyType),
+					Summary:  "Get " + label + " policy",
 				},
 				logical.UpdateOperation: &framework.PathOperation{
-					Callback: b.handlePolicyUpdate,
-					Summary:  "Update CBP policy",
+					Callback: b.handlePolicyUpdate(policyType),
+					Summary:  "Update " + label + " policy",
 				},
 				logical.DeleteOperation: &framework.PathOperation{
-					Callback: b.handlePolicyDelete,
-					Summary:  "Delete a CBP policy",
+					Callback: b.handlePolicyDelete(policyType),
+					Summary:  "Delete a " + label + " policy",
 				},
 			},
-			HelpSynopsis:    "Manage CBP policies",
-			HelpDescription: "Create, read, update, and delete capability-based policies.",
+			HelpSynopsis:    "Manage " + label + " policies",
+			HelpDescription: policyHelpDescription(policyType),
 		},
 		{
-			Pattern: "policies/cbp/?$",
+			Pattern: "policies/" + name + "/?$",
 			Fields: map[string]*framework.FieldSchema{
 				"prefix": {
 					Type:        framework.TypeString,
@@ -66,161 +84,193 @@ func (b *SystemBackend) pathPolicies() []*framework.Path {
 			},
 			Operations: map[logical.Operation]framework.OperationHandler{
 				logical.ListOperation: &framework.PathOperation{
-					Callback: b.handlePolicyList,
-					Summary:  "List all CBP policies",
+					Callback: b.handlePolicyList(policyType),
+					Summary:  "List all " + label + " policies",
 				},
 			},
-			HelpSynopsis:    "List CBP policies",
-			HelpDescription: "List all capability-based policies in the current namespace.",
+			HelpSynopsis:    "List " + label + " policies",
+			HelpDescription: "List all " + label + " policies in the current namespace.",
 		},
 	}
 }
 
-// handlePolicyCreate handles POST /sys/policies/cbp/{name}
-func (b *SystemBackend) handlePolicyCreate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	name := d.Get("name").(string)
-	policyText := d.Get("policy").(string)
-
-	b.logger.Info("creating policy", logger.String("name", name))
-
-	ns, err := namespace.FromContext(ctx)
-	if err != nil {
-		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+func policyHelpDescription(policyType PolicyType) string {
+	switch policyType {
+	case PolicyTypeMCP:
+		return "Create, read, update, and delete MCP policies. An MCP policy constrains " +
+			"the JSON-RPC methods, tool names, resource URIs and prompt names reachable on " +
+			"a path. It never grants access on its own: the request must already be allowed " +
+			"by a capability-based policy."
+	default:
+		return "Create, read, update, and delete capability-based policies."
 	}
-
-	// Parse the policy
-	policy, err := ParseCBPPolicy(ns, policyText)
-	if err != nil {
-		return logical.ErrorResponse(logical.ErrBadRequestf("failed to parse policy: %s", err.Error())), nil
-	}
-
-	policy.Name = name
-	policy.Type = PolicyTypeCBP
-
-	// Get CAS version if provided
-	var casVersion *int
-	if cas, ok := d.GetOk("cas"); ok {
-		v := cas.(int)
-		casVersion = &v
-	}
-
-	// Taken from the request on every write rather than carried over, so a policy
-	// that requires check-and-set can also stop requiring it — the store still
-	// demands a matching cas for the write that lifts the flag.
-	policy.CASRequired = d.Get("cas_required").(bool)
-
-	// Store the policy
-	if err := b.core.policyStore.SetPolicy(ctx, policy, casVersion); err != nil {
-		return logical.ErrorResponse(err), nil
-	}
-
-	return b.respondCreated(map[string]any{
-		"name":    name,
-		"message": fmt.Sprintf("Successfully created policy %s", name),
-	}), nil
 }
 
-// handlePolicyRead handles GET /sys/policies/cbp/{name}
-func (b *SystemBackend) handlePolicyRead(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	name := d.Get("name").(string)
-
-	// Get the policy
-	policy, err := b.core.policyStore.GetPolicy(ctx, name, PolicyTypeCBP)
-	if err != nil {
-		return logical.ErrorResponse(err), nil
+// parsePolicyForType parses a policy document with the parser matching its type.
+func parsePolicyForType(ns *namespace.Namespace, policyText string, policyType PolicyType) (*Policy, error) {
+	switch policyType {
+	case PolicyTypeMCP:
+		return ParseMCPPolicy(ns, policyText)
+	default:
+		return ParseCBPPolicy(ns, policyText)
 	}
-
-	if policy == nil {
-		return logical.ErrorResponse(logical.ErrNotFound("policy not found")), nil
-	}
-
-	return b.respondSuccess(map[string]any{
-		"name":         policy.Name,
-		"policy":       policy.Raw,
-		"data_version": policy.DataVersion,
-		"cas_required": policy.CASRequired,
-	}), nil
 }
 
-// handlePolicyUpdate handles PUT /sys/policies/cbp/{name}
-func (b *SystemBackend) handlePolicyUpdate(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	name := d.Get("name").(string)
-	policyText := d.Get("policy").(string)
+// handlePolicyCreate handles POST /sys/policies/{type}/{name}
+func (b *SystemBackend) handlePolicyCreate(policyType PolicyType) framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+		name := d.Get("name").(string)
+		policyText := d.Get("policy").(string)
 
-	b.logger.Info("updating policy", logger.String("name", name))
+		b.logger.Info("creating policy", logger.String("name", name), logger.String("type", policyType.String()))
 
-	ns, err := namespace.FromContext(ctx)
-	if err != nil {
-		return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+		ns, err := namespace.FromContext(ctx)
+		if err != nil {
+			return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+		}
+
+		// Parse the policy
+		policy, err := parsePolicyForType(ns, policyText, policyType)
+		if err != nil {
+			return logical.ErrorResponse(logical.ErrBadRequestf("failed to parse policy: %s", err.Error())), nil
+		}
+
+		policy.Name = name
+		policy.Type = policyType
+
+		// Get CAS version if provided
+		var casVersion *int
+		if cas, ok := d.GetOk("cas"); ok {
+			v := cas.(int)
+			casVersion = &v
+		}
+
+		// Taken from the request on every write rather than carried over, so a policy
+		// that requires check-and-set can also stop requiring it — the store still
+		// demands a matching cas for the write that lifts the flag.
+		policy.CASRequired = d.Get("cas_required").(bool)
+
+		// Store the policy
+		if err := b.core.policyStore.SetPolicy(ctx, policy, casVersion); err != nil {
+			return logical.ErrorResponse(err), nil
+		}
+
+		return b.respondCreated(map[string]any{
+			"name":    name,
+			"message": fmt.Sprintf("Successfully created policy %s", name),
+		}), nil
 	}
-
-	// Parse the policy
-	policy, err := ParseCBPPolicy(ns, policyText)
-	if err != nil {
-		return logical.ErrorResponse(logical.ErrBadRequestf("failed to parse policy: %s", err.Error())), nil
-	}
-
-	policy.Name = name
-	policy.Type = PolicyTypeCBP
-
-	// Get CAS version if provided
-	var casVersion *int
-	if cas, ok := d.GetOk("cas"); ok {
-		v := cas.(int)
-		casVersion = &v
-	}
-
-	// Taken from the request on every write rather than carried over, so a policy
-	// that requires check-and-set can also stop requiring it — the store still
-	// demands a matching cas for the write that lifts the flag.
-	policy.CASRequired = d.Get("cas_required").(bool)
-
-	// Store the policy
-	if err := b.core.policyStore.SetPolicy(ctx, policy, casVersion); err != nil {
-		return logical.ErrorResponse(err), nil
-	}
-
-	return b.respondSuccess(map[string]any{
-		"name":    name,
-		"message": fmt.Sprintf("Successfully updated policy %s", name),
-	}), nil
 }
 
-// handlePolicyDelete handles DELETE /sys/policies/cbp/{name}
-func (b *SystemBackend) handlePolicyDelete(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	name := d.Get("name").(string)
+// handlePolicyRead handles GET /sys/policies/{type}/{name}
+func (b *SystemBackend) handlePolicyRead(policyType PolicyType) framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+		name := d.Get("name").(string)
 
-	b.logger.Info("deleting policy", logger.String("name", name))
+		// Get the policy
+		policy, err := b.core.policyStore.GetPolicy(ctx, name, policyType)
+		if err != nil {
+			return logical.ErrorResponse(err), nil
+		}
 
-	// Delete the policy
-	if err := b.core.policyStore.DeletePolicy(ctx, name, PolicyTypeCBP); err != nil {
-		return logical.ErrorResponse(err), nil
+		if policy == nil {
+			return logical.ErrorResponse(logical.ErrNotFound("policy not found")), nil
+		}
+
+		return b.respondSuccess(map[string]any{
+			"name":         policy.Name,
+			"policy":       policy.Raw,
+			"data_version": policy.DataVersion,
+			"cas_required": policy.CASRequired,
+		}), nil
 	}
-
-	return b.respondSuccess(map[string]any{
-		"message": fmt.Sprintf("Successfully deleted policy %s", name),
-	}), nil
 }
 
-// handlePolicyList handles GET /sys/policies/cbp
-func (b *SystemBackend) handlePolicyList(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
-	prefix, _ := d.Get("prefix").(string)
+// handlePolicyUpdate handles PUT /sys/policies/{type}/{name}
+func (b *SystemBackend) handlePolicyUpdate(policyType PolicyType) framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+		name := d.Get("name").(string)
+		policyText := d.Get("policy").(string)
 
-	// List policies
-	var policies []string
-	var err error
+		b.logger.Info("updating policy", logger.String("name", name), logger.String("type", policyType.String()))
 
-	if prefix != "" {
-		policies, err = b.core.policyStore.ListPoliciesWithPrefix(ctx, PolicyTypeCBP, prefix, true)
-	} else {
-		policies, err = b.core.policyStore.ListPolicies(ctx, PolicyTypeCBP, true)
+		ns, err := namespace.FromContext(ctx)
+		if err != nil {
+			return logical.ErrorResponse(logical.ErrInternal(err.Error())), nil
+		}
+
+		// Parse the policy
+		policy, err := parsePolicyForType(ns, policyText, policyType)
+		if err != nil {
+			return logical.ErrorResponse(logical.ErrBadRequestf("failed to parse policy: %s", err.Error())), nil
+		}
+
+		policy.Name = name
+		policy.Type = policyType
+
+		// Get CAS version if provided
+		var casVersion *int
+		if cas, ok := d.GetOk("cas"); ok {
+			v := cas.(int)
+			casVersion = &v
+		}
+
+		// Taken from the request on every write rather than carried over, so a policy
+		// that requires check-and-set can also stop requiring it — the store still
+		// demands a matching cas for the write that lifts the flag.
+		policy.CASRequired = d.Get("cas_required").(bool)
+
+		// Store the policy
+		if err := b.core.policyStore.SetPolicy(ctx, policy, casVersion); err != nil {
+			return logical.ErrorResponse(err), nil
+		}
+
+		return b.respondSuccess(map[string]any{
+			"name":    name,
+			"message": fmt.Sprintf("Successfully updated policy %s", name),
+		}), nil
 	}
+}
 
-	if err != nil {
-		return logical.ErrorResponse(err), nil
+// handlePolicyDelete handles DELETE /sys/policies/{type}/{name}
+func (b *SystemBackend) handlePolicyDelete(policyType PolicyType) framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+		name := d.Get("name").(string)
+
+		b.logger.Info("deleting policy", logger.String("name", name), logger.String("type", policyType.String()))
+
+		// Delete the policy
+		if err := b.core.policyStore.DeletePolicy(ctx, name, policyType); err != nil {
+			return logical.ErrorResponse(err), nil
+		}
+
+		return b.respondSuccess(map[string]any{
+			"message": fmt.Sprintf("Successfully deleted policy %s", name),
+		}), nil
 	}
+}
 
-	return b.respondSuccess(map[string]any{
-		"keys": policies,
-	}), nil
+// handlePolicyList handles GET /sys/policies/{type}
+func (b *SystemBackend) handlePolicyList(policyType PolicyType) framework.OperationFunc {
+	return func(ctx context.Context, req *logical.Request, d *framework.FieldData) (*logical.Response, error) {
+		prefix, _ := d.Get("prefix").(string)
+
+		// List policies
+		var policies []string
+		var err error
+
+		if prefix != "" {
+			policies, err = b.core.policyStore.ListPoliciesWithPrefix(ctx, policyType, prefix, true)
+		} else {
+			policies, err = b.core.policyStore.ListPolicies(ctx, policyType, true)
+		}
+
+		if err != nil {
+			return logical.ErrorResponse(err), nil
+		}
+
+		return b.respondSuccess(map[string]any{
+			"keys": policies,
+		}), nil
+	}
 }

--- a/core/sys_policies_test.go
+++ b/core/sys_policies_test.go
@@ -14,7 +14,8 @@ func TestSystemBackend_PathPolicies(t *testing.T) {
 	backend, _, _ := setupTestSystemBackend(t)
 
 	paths := backend.pathPolicies()
-	require.Len(t, paths, 2)
+	// One CRUD path and one list path per policy type.
+	require.Len(t, paths, 4)
 
 	// Check policies/cbp/{name} path
 	assert.Equal(t, "policies/cbp/"+framework.GenericNameRegex("name"), paths[0].Pattern)
@@ -25,6 +26,16 @@ func TestSystemBackend_PathPolicies(t *testing.T) {
 	// Check policies/cbp/ list path
 	assert.Equal(t, "policies/cbp/?$", paths[1].Pattern)
 	assert.Contains(t, paths[1].Fields, "prefix")
+
+	// Check policies/mcp/{name} path
+	assert.Equal(t, "policies/mcp/"+framework.GenericNameRegex("name"), paths[2].Pattern)
+	assert.Contains(t, paths[2].Fields, "name")
+	assert.Contains(t, paths[2].Fields, "policy")
+	assert.Contains(t, paths[2].Fields, "cas")
+
+	// Check policies/mcp/ list path
+	assert.Equal(t, "policies/mcp/?$", paths[3].Pattern)
+	assert.Contains(t, paths[3].Fields, "prefix")
 }
 
 func TestSystemBackend_HandlePolicyCreate(t *testing.T) {
@@ -43,11 +54,99 @@ path "secret/*" {
 	req := createTestRequest(logical.CreateOperation, "policies/cbp/test-policy", raw)
 	fieldData := createFieldData(schema, raw)
 
-	resp, err := backend.handlePolicyCreate(ctx, req, fieldData)
+	resp, err := backend.handlePolicyCreate(PolicyTypeCBP)(ctx, req, fieldData)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 	assert.Equal(t, "test-policy", resp.Data["name"])
+}
+
+// TestSystemBackend_HandleMCPPolicyRoundTrip drives an MCP document through the
+// real handlers rather than calling ParseMCPPolicy directly, so the type
+// actually reaches the parser and the store. Without this, deleting the MCP arm
+// of parsePolicyForType would fall through to the CBP parser unnoticed.
+func TestSystemBackend_HandleMCPPolicyRoundTrip(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+
+	// paths[2] is the MCP CRUD path; see TestSystemBackend_PathPolicies.
+	schema := backend.pathPolicies()[2].Fields
+	document := `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
+  tools   { allowed = ["get_repository"] }
+}
+`
+	raw := map[string]interface{}{"name": "gw-tools", "policy": document}
+
+	req := createTestRequest(logical.CreateOperation, "policies/mcp/gw-tools", raw)
+	resp, err := backend.handlePolicyCreate(PolicyTypeMCP)(ctx, req, createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	// It must land in the MCP view, parsed by the MCP parser.
+	stored, err := backend.core.policyStore.GetPolicy(ctx, "gw-tools", PolicyTypeMCP)
+	require.NoError(t, err)
+	require.NotNil(t, stored)
+	assert.Equal(t, PolicyTypeMCP, stored.Type)
+	require.Len(t, stored.Paths, 1)
+	require.Len(t, stored.Paths[0].Permissions.MCP, 1)
+	assert.Equal(t, []string{"get_repository"}, stored.Paths[0].Permissions.MCP[0].AllowedTools)
+
+	readReq := createTestRequest(logical.ReadOperation, "policies/mcp/gw-tools", raw)
+	readResp, err := backend.handlePolicyRead(PolicyTypeMCP)(ctx, readReq, createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.NotNil(t, readResp)
+	assert.Equal(t, document, readResp.Data["policy"])
+}
+
+// TestSystemBackend_HandleMCPPolicyRejectsCBPGrammar proves the MCP endpoint is
+// really parsed as MCP: a capabilities stanza is a valid CBP policy and must
+// still be refused here.
+func TestSystemBackend_HandleMCPPolicyRejectsCBPGrammar(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+
+	schema := backend.pathPolicies()[2].Fields
+	raw := map[string]interface{}{
+		"name":   "wrong-grammar",
+		"policy": "path \"mcp/gateway/*\" {\n  capabilities = [\"update\"]\n}\n",
+	}
+
+	req := createTestRequest(logical.CreateOperation, "policies/mcp/wrong-grammar", raw)
+	resp, err := backend.handlePolicyCreate(PolicyTypeMCP)(ctx, req, createFieldData(schema, raw))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Err, "a CBP document must not be accepted on the MCP endpoint")
+}
+
+// TestSystemBackend_HandleMCPPolicyNameConflict exercises the cross-type
+// uniqueness guard through the wire mapping, so the operator-facing status is
+// pinned alongside the store-level behavior.
+func TestSystemBackend_HandleMCPPolicyNameConflict(t *testing.T) {
+	backend, ctx, _ := setupTestSystemBackend(t)
+
+	cbpSchema := backend.pathPolicies()[0].Fields
+	cbpRaw := map[string]interface{}{
+		"name":   "shared",
+		"policy": "path \"mcp/gateway/*\" {\n  capabilities = [\"update\"]\n}\n",
+	}
+	resp, err := backend.handlePolicyCreate(PolicyTypeCBP)(ctx,
+		createTestRequest(logical.CreateOperation, "policies/cbp/shared", cbpRaw),
+		createFieldData(cbpSchema, cbpRaw))
+	require.NoError(t, err)
+	require.Nil(t, resp.Err)
+
+	mcpSchema := backend.pathPolicies()[2].Fields
+	mcpRaw := map[string]interface{}{
+		"name":   "shared",
+		"policy": "path \"mcp/gateway/*\" {\n  methods { allowed = [\"tools/list\"] }\n}\n",
+	}
+	conflict, err := backend.handlePolicyCreate(PolicyTypeMCP)(ctx,
+		createTestRequest(logical.CreateOperation, "policies/mcp/shared", mcpRaw),
+		createFieldData(mcpSchema, mcpRaw))
+	require.NoError(t, err)
+	require.NotNil(t, conflict.Err)
+	assert.Contains(t, conflict.Err.Error(), "already in use by a cbp policy")
 }
 
 func TestSystemBackend_HandlePolicyCreate_InvalidPolicy(t *testing.T) {
@@ -62,7 +161,7 @@ func TestSystemBackend_HandlePolicyCreate_InvalidPolicy(t *testing.T) {
 	req := createTestRequest(logical.CreateOperation, "policies/cbp/test-policy", raw)
 	fieldData := createFieldData(schema, raw)
 
-	resp, err := backend.handlePolicyCreate(ctx, req, fieldData)
+	resp, err := backend.handlePolicyCreate(PolicyTypeCBP)(ctx, req, fieldData)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.NotNil(t, resp.Err)
@@ -85,11 +184,11 @@ path "secret/*" {
 	req := createTestRequest(logical.CreateOperation, "policies/cbp/test-policy", raw)
 	fieldData := createFieldData(schema, raw)
 
-	_, err := backend.handlePolicyCreate(ctx, req, fieldData)
+	_, err := backend.handlePolicyCreate(PolicyTypeCBP)(ctx, req, fieldData)
 	require.NoError(t, err)
 
 	// Now read it
-	resp, err := backend.handlePolicyRead(ctx, req, fieldData)
+	resp, err := backend.handlePolicyRead(PolicyTypeCBP)(ctx, req, fieldData)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -108,7 +207,7 @@ func TestSystemBackend_HandlePolicyRead_NotFound(t *testing.T) {
 	req := createTestRequest(logical.ReadOperation, "policies/cbp/nonexistent", raw)
 	fieldData := createFieldData(schema, raw)
 
-	resp, err := backend.handlePolicyRead(ctx, req, fieldData)
+	resp, err := backend.handlePolicyRead(PolicyTypeCBP)(ctx, req, fieldData)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -131,7 +230,7 @@ path "secret/*" {
 	req := createTestRequest(logical.CreateOperation, "policies/cbp/test-policy", createRaw)
 	fieldData := createFieldData(schema, createRaw)
 
-	_, err := backend.handlePolicyCreate(ctx, req, fieldData)
+	_, err := backend.handlePolicyCreate(PolicyTypeCBP)(ctx, req, fieldData)
 	require.NoError(t, err)
 
 	// Now update it
@@ -145,7 +244,7 @@ path "secret/*" {
 	}
 	fieldData = createFieldData(schema, updateRaw)
 
-	resp, err := backend.handlePolicyUpdate(ctx, req, fieldData)
+	resp, err := backend.handlePolicyUpdate(PolicyTypeCBP)(ctx, req, fieldData)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -169,11 +268,11 @@ path "secret/*" {
 	req := createTestRequest(logical.CreateOperation, "policies/cbp/test-policy", raw)
 	fieldData := createFieldData(schema, raw)
 
-	_, err := backend.handlePolicyCreate(ctx, req, fieldData)
+	_, err := backend.handlePolicyCreate(PolicyTypeCBP)(ctx, req, fieldData)
 	require.NoError(t, err)
 
 	// Now delete it
-	resp, err := backend.handlePolicyDelete(ctx, req, fieldData)
+	resp, err := backend.handlePolicyDelete(PolicyTypeCBP)(ctx, req, fieldData)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -196,7 +295,7 @@ path "secret/*" {
 		}
 		fieldData := createFieldData(schema, raw)
 		req := createTestRequest(logical.CreateOperation, "policies/cbp/"+name, raw)
-		_, err := backend.handlePolicyCreate(ctx, req, fieldData)
+		_, err := backend.handlePolicyCreate(PolicyTypeCBP)(ctx, req, fieldData)
 		require.NoError(t, err)
 	}
 
@@ -206,7 +305,7 @@ path "secret/*" {
 	req := createTestRequest(logical.ListOperation, "policies/cbp/", listRaw)
 	fieldData := createFieldData(listSchema, listRaw)
 
-	resp, err := backend.handlePolicyList(ctx, req, fieldData)
+	resp, err := backend.handlePolicyList(PolicyTypeCBP)(ctx, req, fieldData)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -232,7 +331,7 @@ path "secret/*" {
 		}
 		fieldData := createFieldData(schema, raw)
 		req := createTestRequest(logical.CreateOperation, "policies/cbp/"+name, raw)
-		_, err := backend.handlePolicyCreate(ctx, req, fieldData)
+		_, err := backend.handlePolicyCreate(PolicyTypeCBP)(ctx, req, fieldData)
 		require.NoError(t, err)
 	}
 
@@ -244,7 +343,7 @@ path "secret/*" {
 	req := createTestRequest(logical.ListOperation, "policies/cbp/", listRaw)
 	fieldData := createFieldData(listSchema, listRaw)
 
-	resp, err := backend.handlePolicyList(ctx, req, fieldData)
+	resp, err := backend.handlePolicyList(PolicyTypeCBP)(ctx, req, fieldData)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)


### PR DESCRIPTION
**PR 1 of 4.** Additive and inert — no request-time behavior changes.

Introduces `PolicyTypeMCP`: a policy whose document is entirely MCP authorization rules, keyed by request path like a capability policy but carrying no capabilities. An MCP policy is purely restrictive; it grants nothing on its own.

Nothing evaluates these policies yet. This ships the grammar, storage and API they need; enforcement lands in PR 3.

## Grammar

Rules group by what they govern rather than eight flat `allowed_X`/`denied_X` keys:

```hcl
path "mcp/gateway/github/*" {
  methods { allowed = ["tools/list", "tools/call"] }
  tools   { allowed = ["get_repository"] denied = ["delete_*"] }
  condition = "call.args.?env.orValue('') != 'prod'"
}
```

This matches `nameListForMethod`, which already dispatches an (allow, deny) pair per family, and a future per-family attribute costs one key instead of four.

## Why HCL v2

Parsed with HCL v2, unlike the v1-based capability grammar. Two properties are load-bearing: unsupported attributes and blocks are rejected, and a repeated block is an error rather than v1's silent field-wise merge (verified by probe — v1 merges duplicates additively).

The asymmetry is what makes this matter: a typo in `allowed` merely denies more than intended, but a typo in `denied` would leave the deny list empty and **silently widen** the policy. `TestParseMCPPolicy_RejectsMisspelledFamilyKey` pins it, including through the JSON path.

Stanzas flatten into the existing rule shape before canonicalisation, so wildcard validation, lowercasing and CEL compilation stay in one place and the compiled form is unchanged.

## Notable

- `normalizePathPattern` is factored out of `parsePaths` and called by both parsers. Sharing it guarantees the two policy indexes cannot disagree on a path key — a divergence would make MCP stanzas silently miss the requests they were written for. `TestPathNormalizationParity` pins it.
- `cacheKey` gains a type segment; the two views share one LRU, so without it same-named policies of different types would collide. The namespace UUID stays leading so `invalidateNamespace`'s sweep still clears both.
- Policy names are unique across types, enforced on write. Token attachment is a flat name list with no type dimension, so a name resolving in both views would attach ambiguously. The check reads the other view directly because `modifyLock` is already held exclusively and is not reentrant.
- Namespace deletion now sweeps every policy type. The deletion job clears resources type by type and never wipes the namespace barrier prefix, so MCP policies would otherwise outlive their namespace.
- `switchedDeletePolicy` grows a `default` case; an unrouted type previously reported success while deleting nothing.

## Verification

`go test ./... -count=1` green. Full e2e suite green (20 packages).