### PR TITLE
feat(policy): compile MCP policies into a second path index

### DIFF
--- a/core/policy_cbp.go
+++ b/core/policy_cbp.go
@@ -29,6 +29,16 @@ type CBP struct {
 
 	segmentWildcardPaths map[string]interface{}
 
+	// The MCP index mirrors the three above for PolicyTypeMCP policies. It is
+	// keyed and ranked identically — same normalized path keys, same
+	// single-winner resolution — but consulted separately, so a request's
+	// capability grant and its tool contract can come from different documents
+	// whose stanzas need not be spelled the same way. Values are
+	// *CBPPermissions carrying only .MCP.
+	mcpExactRules           *radix.Tree
+	mcpPrefixRules          *radix.Tree
+	mcpSegmentWildcardPaths map[string]interface{}
+
 	// root is enabled if the "root" named policy is present.
 	root bool
 }
@@ -78,10 +88,13 @@ const limitParameterName = "limit"
 func NewCBP(ctx context.Context, policies []*Policy) (*CBP, error) {
 	// Initialize
 	a := &CBP{
-		exactRules:           radix.New(),
-		prefixRules:          radix.New(),
-		segmentWildcardPaths: make(map[string]interface{}, len(policies)),
-		root:                 false,
+		exactRules:              radix.New(),
+		prefixRules:             radix.New(),
+		segmentWildcardPaths:    make(map[string]interface{}, len(policies)),
+		mcpExactRules:           radix.New(),
+		mcpPrefixRules:          radix.New(),
+		mcpSegmentWildcardPaths: make(map[string]interface{}, len(policies)),
+		root:                    false,
 	}
 
 	ns, err := namespace.FromContext(ctx)
@@ -101,6 +114,14 @@ func NewCBP(ctx context.Context, policies []*Policy) (*CBP, error) {
 
 		switch policy.Type {
 		case PolicyTypeCBP:
+		case PolicyTypeMCP:
+			// MCP policies go into their own index and never touch the
+			// capability trees, the granting-policies map or the deny-collapse
+			// path below — they carry no capabilities to collapse.
+			if err := a.insertMCPPolicy(policy); err != nil {
+				return nil, err
+			}
+			continue
 		default:
 			return nil, errors.New("unable to parse policy (wrong type)")
 		}
@@ -232,6 +253,86 @@ func NewCBP(ctx context.Context, policies []*Policy) (*CBP, error) {
 		}
 	}
 	return a, nil
+}
+
+// insertMCPPolicy adds one MCP policy's stanzas to the MCP index.
+//
+// Stanzas at the same normalized path key merge additively, so several MCP
+// policies covering one path contribute several rule-sets and evaluateMCPCall's
+// cross-set OR decides between them — the same shape the mcp { } block had when
+// two CBP policies named the same path.
+func (a *CBP) insertMCPPolicy(policy *Policy) error {
+	for _, pc := range policy.Paths {
+		if !pc.Expiration.IsZero() && time.Now().After(pc.Expiration) {
+			// Skip expired stanzas, as the capability index does.
+			continue
+		}
+		if pc.Permissions == nil || len(pc.Permissions.MCP) == 0 {
+			continue
+		}
+
+		var raw interface{}
+		var ok bool
+		var tree *radix.Tree
+
+		switch {
+		case pc.HasSegmentWildcards:
+			raw, ok = a.mcpSegmentWildcardPaths[pc.Path]
+		default:
+			tree = a.mcpExactRules
+			if pc.IsPrefix {
+				tree = a.mcpPrefixRules
+			}
+			raw, ok = tree.Get(pc.Path)
+		}
+
+		if !ok {
+			clonedPerms, err := pc.Permissions.Clone()
+			if err != nil {
+				return fmt.Errorf("error cloning MCP permissions: %w", err)
+			}
+			switch {
+			case pc.HasSegmentWildcards:
+				a.mcpSegmentWildcardPaths[pc.Path] = clonedPerms
+			default:
+				tree.Insert(pc.Path, clonedPerms)
+			}
+			continue
+		}
+
+		existingPerms, castOK := raw.(*CBPPermissions)
+		if !castOK {
+			return errors.New("error type casting MCP permissions")
+		}
+		for _, m := range pc.Permissions.MCP {
+			existingPerms.MCP = append(existingPerms.MCP, m.Clone())
+		}
+	}
+
+	return nil
+}
+
+// mcpRulesForPath returns the rule-sets of the single MCP stanza that wins for
+// the given canonicalized request path, or nil when none matches.
+//
+// Resolution mirrors the capability index: an exact hit wins outright,
+// otherwise the shared wildcard resolver picks one candidate by the same
+// ranking. The List/Scan trailing-slash retries AllowOperation performs are
+// deliberately absent — a populated MCP descriptor only ever exists on a POST.
+func (a *CBP) mcpRulesForPath(path string) []*CBPMCPRules {
+	if raw, ok := a.mcpExactRules.Get(path); ok {
+		if perms, castOK := raw.(*CBPPermissions); castOK {
+			return perms.MCP
+		}
+	}
+
+	if perms := checkAllowedFromNonExactPaths(
+		a.mcpPrefixRules, a.mcpSegmentWildcardPaths, path, false,
+	); perms != nil {
+		return perms.MCP
+	}
+
+	return nil
 }
 
 func (a *CBP) Capabilities(ctx context.Context, path string) (pathCapabilities []string) {
@@ -521,7 +622,20 @@ type wcPathDescr struct {
 // of permissions from some allowed path underneath the mount (for use in mount
 // access checks), or nil indicating no non-deny permissions were found.
 func (a *CBP) CheckAllowedFromNonExactPaths(path string, bareMount bool) *CBPPermissions {
-	wcPathDescrs := make([]wcPathDescr, 0, len(a.segmentWildcardPaths)+1)
+	return checkAllowedFromNonExactPaths(a.prefixRules, a.segmentWildcardPaths, path, bareMount)
+}
+
+// checkAllowedFromNonExactPaths is the resolution itself, taking the two
+// indexes it reads rather than a receiver so the capability index and the MCP
+// index resolve by exactly the same ranking. Duplicating this logic per index
+// is how the two would drift apart on which stanza wins a request.
+func checkAllowedFromNonExactPaths(
+	prefixRules *radix.Tree,
+	segmentWildcardPaths map[string]interface{},
+	path string,
+	bareMount bool,
+) *CBPPermissions {
+	wcPathDescrs := make([]wcPathDescr, 0, len(segmentWildcardPaths)+1)
 
 	less := func(i, j int) bool {
 		// In the case of multiple matches, we use this priority order,
@@ -581,9 +695,9 @@ func (a *CBP) CheckAllowedFromNonExactPaths(path string, bareMount bool) *CBPPer
 
 	// Find a prefix rule if any.
 	{
-		prefix, raw, ok := a.prefixRules.LongestPrefix(path)
+		prefix, raw, ok := prefixRules.LongestPrefix(path)
 		if ok {
-			if len(a.segmentWildcardPaths) == 0 {
+			if len(segmentWildcardPaths) == 0 {
 				return raw.(*CBPPermissions)
 			}
 			wcPathDescrs = append(wcPathDescrs, wcPathDescr{
@@ -595,14 +709,14 @@ func (a *CBP) CheckAllowedFromNonExactPaths(path string, bareMount bool) *CBPPer
 		}
 	}
 
-	if len(a.segmentWildcardPaths) == 0 {
+	if len(segmentWildcardPaths) == 0 {
 		return nil
 	}
 
 	pathParts := strings.Split(path, "/")
 
 SWCPATH:
-	for fullWCPath := range a.segmentWildcardPaths {
+	for fullWCPath := range segmentWildcardPaths {
 		if fullWCPath == "" {
 			continue
 		}
@@ -650,7 +764,7 @@ SWCPATH:
 				// Check the current joined path so far. If we find a prefix,
 				// check permissions. If they're defined but not deny, success.
 				if strings.HasPrefix(joinedPath, path) {
-					permissions := a.segmentWildcardPaths[fullWCPath].(*CBPPermissions)
+					permissions := segmentWildcardPaths[fullWCPath].(*CBPPermissions)
 					if permissions.CapabilitiesBitmap&DenyCapabilityInt == 0 && permissions.CapabilitiesBitmap > 0 {
 						return permissions
 					}
@@ -658,7 +772,7 @@ SWCPATH:
 				continue SWCPATH
 			}
 		}
-		pd.perms = a.segmentWildcardPaths[fullWCPath].(*CBPPermissions)
+		pd.perms = segmentWildcardPaths[fullWCPath].(*CBPPermissions)
 		wcPathDescrs = append(wcPathDescrs, pd)
 	}
 

--- a/core/policy_cbp.go
+++ b/core/policy_cbp.go
@@ -105,6 +105,19 @@ func NewCBP(ctx context.Context, policies []*Policy) (*CBP, error) {
 		return nil, namespace.ErrNoNamespace
 	}
 
+	// The root policy must stand alone among *grants*. MCP policies are counted
+	// out of that: they grant nothing, and AllowOperation's root fast path
+	// returns before the MCP gate anyway, so attaching one to a root token is
+	// inert rather than contradictory. Counting them would turn a harmless
+	// attachment into a compile failure, which surfaces as a 500 on every
+	// request the token makes.
+	grantingPolicyCount := 0
+	for _, policy := range policies {
+		if policy != nil && policy.Type == PolicyTypeCBP {
+			grantingPolicyCount++
+		}
+	}
+
 	// Inject each policy
 	for _, policy := range policies {
 		// Ignore a nil policy object
@@ -132,7 +145,7 @@ func NewCBP(ctx context.Context, policies []*Policy) (*CBP, error) {
 				return nil, errors.New("root policy is only allowed in root namespace")
 			}
 
-			if len(policies) != 1 {
+			if grantingPolicyCount != 1 {
 				return nil, errors.New("other policies present along with root")
 			}
 			a.root = true
@@ -287,6 +300,11 @@ func (a *CBP) insertMCPPolicy(policy *Policy) error {
 		}
 
 		if !ok {
+			// Clone before inserting: CBP() compiles from *Policy values held in
+			// the LRU and shared across requests, so the index must never hold
+			// a CBPPermissions the cached policy still owns — the same-key
+			// append below would otherwise grow the cached rule-sets on every
+			// compile.
 			clonedPerms, err := pc.Permissions.Clone()
 			if err != nil {
 				return fmt.Errorf("error cloning MCP permissions: %w", err)
@@ -318,12 +336,16 @@ func (a *CBP) insertMCPPolicy(policy *Policy) error {
 // Resolution mirrors the capability index: an exact hit wins outright,
 // otherwise the shared wildcard resolver picks one candidate by the same
 // ranking. The List/Scan trailing-slash retries AllowOperation performs are
-// deliberately absent — a populated MCP descriptor only ever exists on a POST.
+// deliberately absent — a populated MCP descriptor only ever exists on a POST,
+// because every MCPPolicyEnforced implementer gates on POST plus a JSON
+// content type.
+//
+// The returned slice is owned by the compiled index and shared by every request
+// evaluated against it. Callers must treat it as read-only: sorting or
+// appending would corrupt the CBP for every other caller holding it.
 func (a *CBP) mcpRulesForPath(path string) []*CBPMCPRules {
 	if raw, ok := a.mcpExactRules.Get(path); ok {
-		if perms, castOK := raw.(*CBPPermissions); castOK {
-			return perms.MCP
-		}
+		return raw.(*CBPPermissions).MCP
 	}
 
 	if perms := checkAllowedFromNonExactPaths(

--- a/core/policy_mcp_index_test.go
+++ b/core/policy_mcp_index_test.go
@@ -1,0 +1,299 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/logical"
+)
+
+// mustMCPIndex compiles the given MCP documents into a CBP and returns it.
+func mustMCPIndex(t testing.TB, documents ...string) *CBP {
+	t.Helper()
+	policies := make([]*Policy, 0, len(documents))
+	for i, doc := range documents {
+		p := testParseMCPPolicy(t, doc)
+		p.Name = string(rune('a' + i))
+		policies = append(policies, p)
+	}
+	cbp, err := NewCBP(testContext(), policies)
+	require.NoError(t, err)
+	return cbp
+}
+
+func toolsOf(sets []*CBPMCPRules) []string {
+	var out []string
+	for _, s := range sets {
+		out = append(out, s.AllowedTools...)
+	}
+	return out
+}
+
+func TestMCPIndex_ExactBeatsPrefix(t *testing.T) {
+	cbp := mustMCPIndex(t, `
+path "mcp/gateway/tools" {
+  tools { allowed = ["exact"] }
+}
+
+path "mcp/gateway/*" {
+  tools { allowed = ["prefix"] }
+}
+`)
+	assert.Equal(t, []string{"exact"}, toolsOf(cbp.mcpRulesForPath("mcp/gateway/tools")))
+	assert.Equal(t, []string{"prefix"}, toolsOf(cbp.mcpRulesForPath("mcp/gateway/other")))
+}
+
+// TestMCPIndex_LongestPrefixWinsSingleWinner pins that differently-shaped
+// stanzas do NOT union: one wins outright. Unioning would let a broad allow-all
+// policy silently widen a deliberately narrow one.
+func TestMCPIndex_LongestPrefixWinsSingleWinner(t *testing.T) {
+	cbp := mustMCPIndex(t, `
+path "mcp/*" {
+  tools { allowed = ["broad"] }
+}
+
+path "mcp/gateway/*" {
+  tools { allowed = ["narrow"] }
+}
+`)
+	got := toolsOf(cbp.mcpRulesForPath("mcp/gateway/call"))
+	assert.Equal(t, []string{"narrow"}, got)
+	assert.NotContains(t, got, "broad", "a broader stanza must not widen the winner")
+}
+
+// TestMCPIndex_SameKeyStanzasMerge is the other half of the rule: stanzas at
+// the *same* normalized key are additive, so several documents covering one
+// path all contribute and evaluateMCPCall's cross-set OR decides.
+func TestMCPIndex_SameKeyStanzasMerge(t *testing.T) {
+	cbp := mustMCPIndex(t,
+		`
+path "mcp/gateway/*" {
+  tools { allowed = ["from-first"] }
+}
+`,
+		`
+path "mcp/gateway/*" {
+  tools { allowed = ["from-second"] }
+}
+`)
+	sets := cbp.mcpRulesForPath("mcp/gateway/call")
+	require.Len(t, sets, 2, "same-key stanzas from separate policies both apply")
+	assert.ElementsMatch(t, []string{"from-first", "from-second"}, toolsOf(sets))
+}
+
+func TestMCPIndex_SegmentWildcard(t *testing.T) {
+	cbp := mustMCPIndex(t, `
+path "mcp/role/+/gateway/*" {
+  tools { allowed = ["role-scoped"] }
+}
+`)
+	assert.Equal(t, []string{"role-scoped"},
+		toolsOf(cbp.mcpRulesForPath("mcp/role/analyst/gateway/call")))
+	assert.Nil(t, cbp.mcpRulesForPath("mcp/role/analyst/other/call"))
+}
+
+func TestMCPIndex_NoMatchReturnsNil(t *testing.T) {
+	cbp := mustMCPIndex(t, `
+path "mcp/gateway/*" {
+  tools { allowed = ["x"] }
+}
+`)
+	assert.Nil(t, cbp.mcpRulesForPath("other/mount/call"))
+}
+
+func TestMCPIndex_ExpiredStanzaNotIndexed(t *testing.T) {
+	p := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  tools { allowed = ["x"] }
+}
+`)
+	// Expire the stanza after parsing, so the drop is the index's doing rather
+	// than the parser's.
+	p.Name = "expiring"
+	p.Paths[0].Expiration = testPastTime()
+
+	cbp, err := NewCBP(testContext(), []*Policy{p})
+	require.NoError(t, err)
+	assert.Nil(t, cbp.mcpRulesForPath("mcp/gateway/call"))
+}
+
+// TestMCPIndex_DoesNotTouchCapabilityIndex pins the separation: an MCP policy
+// contributes no capabilities, so it can never grant on its own.
+func TestMCPIndex_DoesNotTouchCapabilityIndex(t *testing.T) {
+	cbp := mustMCPIndex(t, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools   { allowed = ["x"] }
+}
+`)
+	assert.Nil(t, cbp.CheckAllowedFromNonExactPaths("mcp/gateway/call", false),
+		"an MCP policy must contribute nothing to the capability index")
+
+	_, exact := cbp.exactRules.Get("mcp/gateway/call")
+	assert.False(t, exact)
+}
+
+// TestMCPIndex_MixedPoliciesIndexSeparately compiles a CBP grant and an MCP
+// contract together — the normal configuration — and checks each lands in its
+// own index, matching the same request path from differently-shaped stanzas.
+func TestMCPIndex_MixedPoliciesIndexSeparately(t *testing.T) {
+	cbpPolicy := testParsePolicy(t, `
+path "mcp/gateway*" {
+  capabilities = ["update"]
+}
+`)
+	cbpPolicy.Name = "grant"
+
+	mcpPolicy := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  tools { allowed = ["get_repository"] }
+}
+`)
+	mcpPolicy.Name = "contract"
+
+	cbp, err := NewCBP(testContext(), []*Policy{cbpPolicy, mcpPolicy})
+	require.NoError(t, err)
+
+	// Both stanzas cover mcp/gateway/call despite different shapes, because the
+	// common key is the request path rather than the stanza text.
+	perms := cbp.CheckAllowedFromNonExactPaths("mcp/gateway/call", false)
+	require.NotNil(t, perms)
+	assert.NotZero(t, perms.CapabilitiesBitmap&UpdateCapabilityInt)
+	assert.Empty(t, perms.MCP, "the capability node carries no MCP rules")
+
+	assert.Equal(t, []string{"get_repository"},
+		toolsOf(cbp.mcpRulesForPath("mcp/gateway/call")))
+}
+
+// TestMCPIndex_AllowOperationUnaffected is the inert-by-design pin for this PR:
+// attaching an MCP policy must not change any request-time decision yet.
+func TestMCPIndex_AllowOperationUnaffected(t *testing.T) {
+	cbpPolicy := testParsePolicy(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`)
+	cbpPolicy.Name = "grant"
+
+	mcpPolicy := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  tools { allowed = ["nothing-matches-this"] }
+}
+`)
+	mcpPolicy.Name = "contract"
+
+	withoutMCP, err := NewCBP(testContext(), []*Policy{cbpPolicy})
+	require.NoError(t, err)
+	withMCP, err := NewCBP(testContext(), []*Policy{cbpPolicy, mcpPolicy})
+	require.NoError(t, err)
+
+	req := newMCPRequest(t, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"anything"},"id":1}`)
+
+	base := withoutMCP.AllowOperation(testContext(), req, nil, false)
+	withIndex := withMCP.AllowOperation(testContext(), req, nil, false)
+
+	assert.Equal(t, base.Allowed, withIndex.Allowed)
+	assert.Equal(t, base.MCPDecision, withIndex.MCPDecision)
+	assert.True(t, base.Allowed, "the capability grant alone still decides in this PR")
+}
+
+// TestGetPolicyAnyType_ResolvesBothTypes covers the flat-name resolution that
+// lets a token attach a CBP and an MCP policy in one list.
+func TestGetPolicyAnyType_ResolvesBothTypes(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := testContext()
+
+	cbpPolicy := testParsePolicy(t, `path "mcp/gateway/*" { capabilities = ["update"] }`)
+	cbpPolicy.Name = "grant"
+	require.NoError(t, ps.SetPolicy(ctx, cbpPolicy, nil))
+
+	mcpPolicy := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  tools { allowed = ["x"] }
+}
+`)
+	mcpPolicy.Name = "contract"
+	require.NoError(t, ps.SetPolicy(ctx, mcpPolicy, nil))
+
+	got, err := ps.getPolicyAnyType(ctx, "grant")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, PolicyTypeCBP, got.Type)
+
+	got, err = ps.getPolicyAnyType(ctx, "contract")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, PolicyTypeMCP, got.Type)
+
+	missing, err := ps.getPolicyAnyType(ctx, "nobody")
+	require.NoError(t, err)
+	assert.Nil(t, missing, "a dangling name resolves to nothing, as before")
+}
+
+// TestGetPolicyAnyType_ResolvesRoot is the regression guard for the trap in
+// this resolver: the root policy is synthesized, never stored. A version built
+// on direct barrier reads returns nil here, NewCBP never sets a.root, and every
+// root token is denied everywhere.
+func TestGetPolicyAnyType_ResolvesRoot(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := testContext()
+
+	got, err := ps.getPolicyAnyType(ctx, "root")
+	require.NoError(t, err)
+	require.NotNil(t, got, "the synthesized root policy must resolve")
+	assert.Equal(t, "root", got.Name)
+	assert.Equal(t, PolicyTypeCBP, got.Type)
+
+	cbp, err := ps.CBP(ctx, map[string][]string{namespace.RootNamespaceID: {"root"}})
+	require.NoError(t, err)
+	assert.True(t, cbp.root, "a root token must still get root privileges")
+
+	res := cbp.AllowOperation(ctx, &logical.Request{
+		Path:      "any/path/at/all",
+		Operation: logical.UpdateOperation,
+	}, nil, false)
+	assert.True(t, res.Allowed)
+	assert.True(t, res.IsRoot)
+}
+
+// TestCBP_CompilesAttachedMCPPolicy proves an MCP policy attached by name
+// reaches the index through the store, not just through a hand-built CBP.
+func TestCBP_CompilesAttachedMCPPolicy(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := testContext()
+
+	cbpPolicy := testParsePolicy(t, `path "mcp/gateway/*" { capabilities = ["update"] }`)
+	cbpPolicy.Name = "grant"
+	require.NoError(t, ps.SetPolicy(ctx, cbpPolicy, nil))
+
+	mcpPolicy := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  tools { allowed = ["get_repository"] }
+}
+`)
+	mcpPolicy.Name = "contract"
+	require.NoError(t, ps.SetPolicy(ctx, mcpPolicy, nil))
+
+	cbp, err := ps.CBP(ctx, map[string][]string{
+		namespace.RootNamespaceID: {"grant", "contract"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"get_repository"},
+		toolsOf(cbp.mcpRulesForPath("mcp/gateway/call")))
+}
+
+func testPastTime() time.Time {
+	return time.Now().Add(-time.Hour)
+}

--- a/core/policy_mcp_index_test.go
+++ b/core/policy_mcp_index_test.go
@@ -4,6 +4,8 @@
 package core
 
 import (
+	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -20,7 +22,7 @@ func mustMCPIndex(t testing.TB, documents ...string) *CBP {
 	policies := make([]*Policy, 0, len(documents))
 	for i, doc := range documents {
 		p := testParseMCPPolicy(t, doc)
-		p.Name = string(rune('a' + i))
+		p.Name = fmt.Sprintf("p%d", i)
 		policies = append(policies, p)
 	}
 	cbp, err := NewCBP(testContext(), policies)
@@ -292,6 +294,132 @@ path "mcp/gateway/*" {
 
 	assert.Equal(t, []string{"get_repository"},
 		toolsOf(cbp.mcpRulesForPath("mcp/gateway/call")))
+}
+
+// TestCBP_RepeatedCompileDoesNotAccumulate is the regression guard for the
+// sharpest hazard in the index: CBP() hands out cached *Policy pointers from
+// the LRU, so if the same-key merge appended to a CBPPermissions still owned by
+// a cached policy, every compile would grow the rule-sets and corrupt the
+// cache. Building the index twice from the same cached policies must be
+// idempotent, and the source policies must come back unchanged.
+func TestCBP_RepeatedCompileDoesNotAccumulate(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	ctx := testContext()
+
+	for i, doc := range []string{
+		`
+path "mcp/gateway/*" {
+  tools { allowed = ["first"] }
+}
+`,
+		`
+path "mcp/gateway/*" {
+  tools { allowed = ["second"] }
+}
+`,
+	} {
+		p := testParseMCPPolicy(t, doc)
+		p.Name = fmt.Sprintf("contract-%d", i)
+		require.NoError(t, ps.SetPolicy(ctx, p, nil))
+	}
+
+	names := map[string][]string{
+		namespace.RootNamespaceID: {"contract-0", "contract-1"},
+	}
+
+	first, err := ps.CBP(ctx, names)
+	require.NoError(t, err)
+	require.Len(t, first.mcpRulesForPath("mcp/gateway/call"), 2)
+
+	second, err := ps.CBP(ctx, names)
+	require.NoError(t, err)
+	assert.Len(t, second.mcpRulesForPath("mcp/gateway/call"), 2,
+		"a second compile over the same cached policies must not accumulate rule-sets")
+
+	// And the cached policies themselves must still hold one rule-set each.
+	for _, name := range []string{"contract-0", "contract-1"} {
+		cached, err := ps.GetPolicy(ctx, name, PolicyTypeMCP)
+		require.NoError(t, err)
+		require.Len(t, cached.Paths, 1)
+		assert.Len(t, cached.Paths[0].Permissions.MCP, 1,
+			"compiling must not mutate the cached policy %q", name)
+	}
+}
+
+// TestMCPIndex_NamespaceScoped covers the namespace-prefixed path key and the
+// child-namespace MCP view, neither of which the root-namespace tests exercise.
+func TestMCPIndex_NamespaceScoped(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	rootCtx := testContext()
+
+	child := &namespace.Namespace{Path: "team-a/"}
+	require.NoError(t, core.namespaceStore.SetNamespace(rootCtx, child))
+	nsCtx := namespace.ContextWithNamespace(context.Background(), child)
+
+	p, err := ParseMCPPolicy(child, `
+path "mcp/gateway/*" {
+  tools { allowed = ["scoped"] }
+}
+`)
+	require.NoError(t, err)
+	p.Name = "ns-contract"
+	require.NoError(t, ps.SetPolicy(nsCtx, p, nil))
+
+	// The stanza key carries the namespace path, so it matches only there.
+	require.Len(t, p.Paths, 1)
+	assert.Equal(t, "team-a/mcp/gateway/", p.Paths[0].Path)
+
+	cbp, err := ps.CBP(nsCtx, map[string][]string{child.ID: {"ns-contract"}})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"scoped"},
+		toolsOf(cbp.mcpRulesForPath("team-a/mcp/gateway/call")))
+	assert.Nil(t, cbp.mcpRulesForPath("mcp/gateway/call"),
+		"a namespaced contract must not match the unprefixed path")
+}
+
+// TestNewCBP_RootWithMCPPolicy pins that an MCP policy alongside root is inert
+// rather than fatal. Root bypasses the MCP gate entirely, so counting a
+// contract as a competing grant would turn a harmless attachment into a 500 on
+// every request the token makes.
+func TestNewCBP_RootWithMCPPolicy(t *testing.T) {
+	rootPolicy := &Policy{Name: "root", Type: PolicyTypeCBP, namespace: namespace.RootNamespace}
+
+	contract := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  tools { allowed = ["ignored"] }
+}
+`)
+	contract.Name = "contract"
+
+	cbp, err := NewCBP(testContext(), []*Policy{rootPolicy, contract})
+	require.NoError(t, err, "an MCP policy must not collide with root")
+	assert.True(t, cbp.root)
+
+	// The contract is still indexed; root simply never consults it.
+	assert.Equal(t, []string{"ignored"}, toolsOf(cbp.mcpRulesForPath("mcp/gateway/call")))
+
+	res := cbp.AllowOperation(testContext(), &logical.Request{
+		Path:      "mcp/gateway/call",
+		Operation: logical.UpdateOperation,
+	}, nil, false)
+	assert.True(t, res.Allowed)
+	assert.True(t, res.IsRoot)
+}
+
+// TestNewCBP_RootWithAnotherGrantStillRejected proves the exclusivity rule
+// still holds for the case it was written for: a second capability policy.
+func TestNewCBP_RootWithAnotherGrantStillRejected(t *testing.T) {
+	rootPolicy := &Policy{Name: "root", Type: PolicyTypeCBP, namespace: namespace.RootNamespace}
+
+	other := testParsePolicy(t, `path "secret/*" { capabilities = ["read"] }`)
+	other.Name = "other"
+
+	_, err := NewCBP(testContext(), []*Policy{rootPolicy, other})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "other policies present along with root")
 }
 
 func testPastTime() time.Time {

--- a/core/policy_store.go
+++ b/core/policy_store.go
@@ -564,6 +564,57 @@ func (ps *PolicyStore) switchedDeletePolicy(ctx context.Context, name string, po
 	return nil
 }
 
+// getPolicyAnyType resolves a token-attached policy name across both policy
+// types. Token attachment is a flat list of names with no type dimension, so a
+// name has to be looked for in each view; names are unique across types, so at
+// most one view can answer.
+//
+// It resolves through GetPolicy rather than reading the barrier views
+// directly. That path owns two things a raw read would lose: the root policy is
+// synthesized and never stored, so a direct view read returns nil for it and
+// every root token would end up with an empty CBP; and the locked branch
+// deletes an expired policy from the correct typed view.
+//
+// The cache is probed under both typed keys first so a warm MCP name costs one
+// extra map lookup instead of a miss against the CBP view on every request.
+// Only a name in neither view reaches storage twice, and such a name grants and
+// restricts nothing either way.
+func (ps *PolicyStore) getPolicyAnyType(ctx context.Context, name string) (*Policy, error) {
+	ns, err := namespace.FromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	saneName := ps.sanitizeName(name)
+
+	if ps.tokenPoliciesLRU != nil {
+		for _, policyType := range []PolicyType{PolicyTypeCBP, PolicyTypeMCP} {
+			raw, ok := ps.tokenPoliciesLRU.Get(ps.cacheKey(ns, saneName, policyType))
+			if !ok {
+				continue
+			}
+			if !raw.Expiration.IsZero() && time.Now().After(raw.Expiration) {
+				// Leave the eviction to the locked path below, which also
+				// removes it from storage.
+				break
+			}
+			return raw, nil
+		}
+	}
+
+	for _, policyType := range []PolicyType{PolicyTypeCBP, PolicyTypeMCP} {
+		p, err := ps.GetPolicy(ctx, saneName, policyType)
+		if err != nil {
+			return nil, err
+		}
+		if p != nil {
+			return p, nil
+		}
+	}
+
+	return nil, nil
+}
+
 // policyNamespaceUUID returns a policy's namespace UUID, or "" when it carries
 // no namespace, so ordering stays total over a mixed set.
 func policyNamespaceUUID(p *Policy) string {
@@ -589,7 +640,7 @@ func (ps *PolicyStore) CBP(ctx context.Context, policyNames map[string][]string,
 		}
 		policyCtx := namespace.ContextWithNamespace(ctx, policyNS)
 		for _, nsPolicyName := range nsPolicyNames {
-			p, err := ps.GetPolicy(policyCtx, nsPolicyName, PolicyTypeCBP)
+			p, err := ps.getPolicyAnyType(policyCtx, nsPolicyName)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get policy: %w", err)
 			}
@@ -619,17 +670,28 @@ func (ps *PolicyStore) CBP(ctx context.Context, policyNames map[string][]string,
 
 	for i, policy := range allPolicies {
 		// Reuse the parse already performed and cached by GetPolicy. Re-parse
-		// only when a prefetched policy arrived without parsed paths. CBP
-		// policies carry no per-request templating, so a cached parse is always
-		// reusable and never identity-dependent.
-		if policy.Type == PolicyTypeCBP && policy.Paths == nil {
-			p, err := parseCBPPolicy(policy.namespace, policy.Raw)
-			if err != nil {
-				return nil, fmt.Errorf("error parsing policy %q: %w", policy.Name, err)
-			}
-			p.Name = policy.Name
-			allPolicies[i] = p
+		// only when a prefetched policy arrived without parsed paths. Neither
+		// policy type carries per-request templating, so a cached parse is
+		// always reusable and never identity-dependent.
+		if policy.Paths != nil {
+			continue
 		}
+
+		var p *Policy
+		var err error
+		switch policy.Type {
+		case PolicyTypeCBP:
+			p, err = parseCBPPolicy(policy.namespace, policy.Raw)
+		case PolicyTypeMCP:
+			p, err = ParseMCPPolicy(policy.namespace, policy.Raw)
+		default:
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("error parsing policy %q: %w", policy.Name, err)
+		}
+		p.Name = policy.Name
+		allPolicies[i] = p
 	}
 
 	// Compiled fresh every time. The policies themselves come from a cache; only


### PR DESCRIPTION
**PR 2 of 4.** Stacked on #584. Additive — `AllowOperation` is untouched, so this changes no authorization decision.

Adds the index and name resolution MCP policies need, without consulting either at request time. Wiring it up is PR 3.

## Design

The MCP index mirrors the capability index — same three trees, same normalized path keys, same single-winner ranking — but is consulted separately. That separation is the point: a request's capability grant and its tool contract come from different documents whose stanzas need not be spelled the same way. `mcp/gateway*` in a capability policy and `mcp/gateway/*` in an MCP policy both cover a request to `mcp/gateway/call`, because the common key is the request path rather than the stanza text.

`CheckAllowedFromNonExactPaths` becomes a thin wrapper over a free function taking the two indexes it reads. It touched only `prefixRules` and `segmentWildcardPaths`, so both indexes now resolve through the identical five-tier ranking rather than a copy of it — duplicating that logic is how the two would drift apart on which stanza wins a request.

## Two behaviors, deliberately different

- **Same normalized key** → stanzas merge additively, so several policies covering one path all contribute and the cross-set OR in `evaluateMCPCall` decides.
- **Different shapes both matching** → single winner, no union. A broad allow-all policy must never silently widen a deliberately narrow one; `TestMCPIndex_LongestPrefixWinsSingleWinner` asserts the broad stanza's tool is *absent*.

MCP policies never reach the capability trees, the granting-policies map or the deny-collapse path — they carry no capabilities to collapse.

## getPolicyAnyType

Resolves a name across both types, since token attachment is a flat list with no type dimension. It goes through `GetPolicy` rather than reading the barrier views directly: that path owns the **root policy, which is synthesized and never stored** — a direct view read returns nil for it and every root token would end up with an empty CBP — and the locked branch that evicts an expired policy from the correct view. Mutation-tested: a direct-view implementation makes `TestGetPolicyAnyType_ResolvesRoot` fail.

The cache is probed under both typed keys first, so a warm MCP name costs an extra map lookup instead of a miss against the capability view on every request.

## Review-fix commit (b0694e5)

Two corrections found in review:

1. **Root plus an MCP policy would have answered 500 on every request.** Before the index, an attached MCP name resolved to nil and was dropped, so `["root", "contract"]` compiled fine. Once both types resolved, the second policy tripped the root-exclusivity check, and `NewCBP` returning an error becomes `ErrInternalError`. The check exists to stop root being combined with other *grants*; an MCP policy grants nothing, and the root fast path returns before the MCP gate. It now counts capability policies only.
2. **The clone in `insertMCPPolicy` is load-bearing and now says so.** `CBP()` compiles from `*Policy` values held in the LRU and shared across requests. Removing the clone makes `TestCBP_RepeatedCompileDoesNotAccumulate` fail with three rule-sets where there should be two, and mutates the cached policies — authorization drifting across requests under load.

## Verification

`go test ./... -count=1` green. Full e2e suite green.
