### PR TITLE
feat(policy)!: move MCP rules out of capability policies

### DIFF
--- a/core/policy.go
+++ b/core/policy.go
@@ -196,6 +196,12 @@ type CBPMCPRules struct {
 	// compiled against the MCP env (call.* available). The set allows a call
 	// only if its structural gates pass AND this condition evaluates true.
 	Condition *compiledCondition
+
+	// SourcePolicy names the MCP policy this rule-set came from, stamped onto
+	// the decision for audit. Contracts are separately-owned documents, so
+	// "which policy denied this?" is not answerable from the matched rule
+	// alone. Set by the index at compile time, not by the parser.
+	SourcePolicy string
 }
 
 // Clone returns a deep copy of the CBPMCPRules. Safe to call on a nil
@@ -205,7 +211,7 @@ func (m *CBPMCPRules) Clone() *CBPMCPRules {
 	if m == nil {
 		return nil
 	}
-	clone := &CBPMCPRules{}
+	clone := &CBPMCPRules{SourcePolicy: m.SourcePolicy}
 	if m.AllowedMethods != nil {
 		clone.AllowedMethods = append([]string(nil), m.AllowedMethods...)
 	}
@@ -383,6 +389,23 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 
 		if err := hcl.DecodeObject(&pc, item.Val); err != nil {
 			return multierror.Prefix(err, fmt.Sprintf("path %q:", key))
+		}
+
+		// Checked here rather than beside the other rule handling further down:
+		// the deny capability jumps to PathFinished, which would skip a check
+		// placed there and let a denying stanza carry the removed block forever.
+		if pc.MCPHCL != nil {
+			return fmt.Errorf("path %q: the mcp { } block has been removed from capability policies — "+
+				"MCP rules now live in their own policy, written to sys/policies/mcp/<name>, whose "+
+				"path stanzas group rules by what they govern:\n"+
+				"    path %q {\n"+
+				"      methods { allowed = [\"tools/call\"] }\n"+
+				"      tools {\n"+
+				"        allowed = [\"get_repository\"]\n"+
+				"        denied  = [\"delete_*\"]\n"+
+				"      }\n"+
+				"    }\n"+
+				"Create one and attach it to the token alongside this policy", key, key)
 		}
 
 		if len(pc.ExpirationRaw) > 0 {

--- a/core/policy_cbp.go
+++ b/core/policy_cbp.go
@@ -242,20 +242,6 @@ func NewCBP(ctx context.Context, policies []*Policy) (*CBP, error) {
 				existingPerms.Conditions = append(existingPerms.Conditions, pc.Permissions.Conditions...)
 			}
 
-			// MCP rule-set merging: additive OR across policies. Unlike
-			// conditions, an absent mcp block in one source does NOT
-			// disable enforcement contributed by another source — each
-			// stanza's mcp { } adds one entry to the slice and the
-			// per-set OR in evaluateMCPDescriptor means more entries
-			// can only admit more requests (never fewer). The clone
-			// protects against later mutation of the shared underlying
-			// slices.
-			if len(pc.Permissions.MCP) > 0 {
-				for _, m := range pc.Permissions.MCP {
-					existingPerms.MCP = append(existingPerms.MCP, m.Clone())
-				}
-			}
-
 		INSERT:
 			switch {
 			case pc.HasSegmentWildcards:
@@ -309,6 +295,9 @@ func (a *CBP) insertMCPPolicy(policy *Policy) error {
 			if err != nil {
 				return fmt.Errorf("error cloning MCP permissions: %w", err)
 			}
+			for _, m := range clonedPerms.MCP {
+				m.SourcePolicy = policy.Name
+			}
 			switch {
 			case pc.HasSegmentWildcards:
 				a.mcpSegmentWildcardPaths[pc.Path] = clonedPerms
@@ -323,7 +312,9 @@ func (a *CBP) insertMCPPolicy(policy *Policy) error {
 			return errors.New("error type casting MCP permissions")
 		}
 		for _, m := range pc.Permissions.MCP {
-			existingPerms.MCP = append(existingPerms.MCP, m.Clone())
+			clone := m.Clone()
+			clone.SourcePolicy = policy.Name
+			existingPerms.MCP = append(existingPerms.MCP, clone)
 		}
 	}
 
@@ -555,16 +546,21 @@ CHECK:
 	// MCP rule-set evaluation, body-authoritative. Runs after
 	// conditions (so source-IP / time gates apply first) and before
 	// parameter validation. Populates ret.MCPDecision on every branch
-	// when an mcp block was consulted, so the audit layer sees the
+	// when a rule-set was consulted, so the audit layer sees the
 	// decision whether the request was allowed or denied.
+	//
+	// The rule-sets come from the MCP index, a lookup independent of the one
+	// that chose `permissions` above: a request's capability grant and its tool
+	// contract live in separate documents whose stanzas need not be spelled the
+	// same way. The canonicalized `path` is the common key.
 	//
 	// req.MCPDescriptor is populated by the core/request_handler_mcp
 	// extractor on streaming MCP backends that opt into
 	// logical.MCPPolicyEnforced. A nil descriptor here means either
 	// the routed backend doesn't implement the marker, or it declined
 	// the request (wrong method / Content-Type) — fail closed.
-	if len(permissions.MCP) > 0 {
-		ret.MCPDecision = decideMCP(permissions.MCP, req, te, now, ns.Path)
+	if mcpSets := a.mcpRulesForPath(path); len(mcpSets) > 0 {
+		ret.MCPDecision = decideMCP(mcpSets, req, te, now, ns.Path)
 		if ret.MCPDecision != nil && ret.MCPDecision.Decision == "deny" {
 			return ret
 		}
@@ -572,7 +568,7 @@ CHECK:
 		// response-side list filtering: attach a keep-filter for a single
 		// list request, or fail closed on a batched list (unfilterable).
 		if !capCheckOnly && ret.MCPDecision != nil && ret.MCPDecision.Decision == "allow" {
-			if d := attachMCPListFilter(req, permissions.MCP); d != nil {
+			if d := attachMCPListFilter(req, mcpSets); d != nil {
 				sanitizeMCPDecision(d)
 				ret.MCPDecision = d
 				return ret

--- a/core/policy_cel_mcp_test.go
+++ b/core/policy_cel_mcp_test.go
@@ -45,15 +45,23 @@ func TestMCPCond_BatchSharesOneNow(t *testing.T) {
 // TestMCPCond_MultiSetConditionOR confirms cross-set OR at the condition level:
 // a call denied by one set's condition but allowed by another's is allowed.
 func TestMCPCond_MultiSetConditionOR(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp { allowed_methods = ["tools/call"] allowed_tools = ["pay"] condition = "call.args.amount <= 100" }
 }
+`, `
 path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp { allowed_methods = ["tools/call"] allowed_tools = ["pay"] condition = "call.args.amount <= 5000" }
-}`)
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["pay"] }
+  condition = "call.args.amount <= 100"
+}
+
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["pay"] }
+  condition = "call.args.amount <= 5000"
+}
+`)
 	req := mcpReq(t, `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"pay","arguments":{"amount":1000}},"id":1}`)
 	res := cbp.AllowOperation(testContext(), req, nil, false)
 	assert.True(t, res.Allowed, "set A denies (>100) but set B allows (<=5000) → cross-set OR allows")
@@ -70,15 +78,16 @@ func mcpReq(t *testing.T, body string) *logical.Request {
 
 func mcpAmountCapPolicy(t *testing.T) *CBP {
 	t.Helper()
-	return mustCBP(t, `
+	return mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    allowed_tools   = ["create_payment"]
-    condition       = "call.args.amount <= 1500"
-  }
-}`)
+}`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["create_payment"] }
+  condition = "call.args.amount <= 1500"
+}
+`)
 }
 
 func TestMCPCond_NumericAllowDeny(t *testing.T) {
@@ -115,18 +124,20 @@ func TestMCPCond_RecordsInputs(t *testing.T) {
 	assert.Equal(t, "2000", res.MCPDecision.Condition.Inputs["call.args.amount"])
 }
 
-// TestMCPCond_TokenNamespace confirms an mcp{} condition can read the token
+// TestMCPCond_TokenNamespace confirms an MCP condition can read the token
 // namespace (threaded via the TokenEntry), not just call.*.
 func TestMCPCond_TokenNamespace(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    allowed_tools   = ["create_payment"]
-    condition       = "token.metadata.env == 'prod'"
-  }
-}`)
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["create_payment"] }
+  condition = "token.metadata.env == 'prod'"
+}
+`)
 	body := `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{"amount":1}},"id":1}`
 
 	prod := cbp.AllowOperation(testContext(), mcpReq(t, body), &logical.TokenEntry{Metadata: map[string]string{"env": "prod"}}, false)
@@ -180,15 +191,16 @@ func TestMCPCond_MissingArgFailsClosed(t *testing.T) {
 // method (e.g. tools/list) the same set allows. Authors must scope with
 // call.method (e.g. `call.method != "tools/call" || call.args.amount <= 1500`).
 func TestMCPCond_AppliesToEveryMethodInSet(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    allowed_tools   = ["create_payment"]
-    condition       = "call.args.amount <= 1500"
-  }
-}`)
+}`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { allowed = ["create_payment"] }
+  condition = "call.args.amount <= 1500"
+}
+`)
 	// tools/list carries no args -> the args-referencing condition errors ->
 	// fail-closed deny (NOT a silent allow).
 	list := mcpReq(t, `{"jsonrpc":"2.0","method":"tools/list","id":1}`)
@@ -197,15 +209,16 @@ path "mcp/gateway/*" {
 	assert.Equal(t, mcpRuleTypeConditionError, res.MCPDecision.RuleType)
 
 	// A properly scoped condition lets tools/list through.
-	scoped := mustCBP(t, `
+	scoped := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    allowed_tools   = ["create_payment"]
-    condition       = "call.method != 'tools/call' || call.args.amount <= 1500"
-  }
-}`)
+}`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { allowed = ["create_payment"] }
+  condition = "call.method != 'tools/call' || call.args.amount <= 1500"
+}
+`)
 	list2 := mcpReq(t, `{"jsonrpc":"2.0","method":"tools/list","id":1}`)
 	assert.True(t, scoped.AllowOperation(testContext(), list2, nil, false).Allowed, "scoped condition admits tools/list")
 }
@@ -213,9 +226,9 @@ path "mcp/gateway/*" {
 // Benchmarks reuse one extracted request across iterations (the descriptor is
 // read-only during evaluation), isolating the per-call decide cost.
 
-func benchMCP(b *testing.B, policy, body string, te *logical.TokenEntry) {
+func benchMCP(b *testing.B, mcpPolicy, body string, te *logical.TokenEntry) {
 	b.Helper()
-	cbp := mustCBP(b, policy)
+	cbp := mustCBPWithMCP(b, benchMCPGrant, mcpPolicy)
 	req := buildE2ERequest(b, body)
 	runExtract(req, &mcpMockBackend{enforce: true, cap: 1 << 20})
 	ctx := testContext()
@@ -225,23 +238,22 @@ func benchMCP(b *testing.B, policy, body string, te *logical.TokenEntry) {
 	}
 }
 
-const benchMCPNoCond = `
+const benchMCPGrant = `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp { 
-    allowed_methods = ["tools/call"] 
-	allowed_tools   = ["create_payment"] 
-  }
+}`
+
+const benchMCPNoCond = `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["create_payment"] }
 }`
 
 const benchMCPWithCond = `
 path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    allowed_tools   = ["create_payment"]
-    condition       = "call.args.amount <= 1500"
-  }
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["create_payment"] }
+  condition = "call.args.amount <= 1500"
 }`
 
 const benchMCPCall = `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{"amount":1200}},"id":1}`

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -362,6 +362,9 @@ func evaluateMCPCall(sets []*CBPMCPRules, call *logical.MCPCall, act *celActivat
 
 	for _, set := range sets {
 		setDecision := evaluateMCPSetForCall(set, method, name, call, act)
+		// Stamp which contract decided, so an audit record can name the policy
+		// rather than only the rule that fired.
+		setDecision.PolicyName = set.SourcePolicy
 		if setDecision.Decision == "allow" {
 			return setDecision
 		}
@@ -667,6 +670,7 @@ func sanitizeMCPDecision(d *logical.MCPDecision) {
 	d.MatchedRule = stripCTL(d.MatchedRule)
 	d.ParamName = stripCTL(d.ParamName)
 	d.ParamValue = stripCTL(d.ParamValue)
+	d.PolicyName = stripCTL(d.PolicyName)
 	d.Condition.Sanitize()
 }
 

--- a/core/policy_mcp_e2e_test.go
+++ b/core/policy_mcp_e2e_test.go
@@ -96,13 +96,14 @@ func runExtract(req *logical.Request, backend logical.Backend) {
 // =============================================================================
 
 func TestMCPE2E_ToolsCallAllow(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    allowed_tools   = ["search_repos"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["search_repos"] }
 }
 `)
 	req := buildE2ERequest(t, `{
@@ -123,13 +124,14 @@ path "mcp/gateway/*" {
 }
 
 func TestMCPE2E_BatchAllAllowed(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    allowed_tools   = ["search_repos"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { allowed = ["search_repos"] }
 }
 `)
 	req := buildE2ERequest(t, `[
@@ -150,13 +152,14 @@ path "mcp/gateway/*" {
 func TestMCPE2E_BatchWithListMethodDenied(t *testing.T) {
 	// End-to-end: a batch carrying a list method is denied by the
 	// response-filter guard even when every call would otherwise pass.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    allowed_tools   = ["search_repos"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { allowed = ["search_repos"] }
 }
 `)
 	req := buildE2ERequest(t, `[
@@ -204,13 +207,14 @@ func TestMCPE2E_BodyByteIdentityAfterExtraction(t *testing.T) {
 // =============================================================================
 
 func TestMCPE2E_DeniedToolFiresCorrectly(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    denied_tools    = ["delete_*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { denied = ["delete_*"] }
 }
 `)
 	req := buildE2ERequest(t, `{
@@ -231,13 +235,14 @@ path "mcp/gateway/*" {
 }
 
 func TestMCPE2E_BatchDenyStampsBatchIndex(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    denied_tools    = ["delete_*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { denied = ["delete_*"] }
 }
 `)
 	req := buildE2ERequest(t, `[
@@ -260,12 +265,13 @@ path "mcp/gateway/*" {
 // =============================================================================
 
 func TestMCPE2E_MalformedBody_DeniesMalformedJSONRPC(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
 }
 `)
 	req := buildE2ERequest(t, `{ not json`)
@@ -278,12 +284,13 @@ path "mcp/gateway/*" {
 }
 
 func TestMCPE2E_DuplicateKey_DeniesDuplicateKey(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
 }
 `)
 	req := buildE2ERequest(t, `{
@@ -301,12 +308,13 @@ path "mcp/gateway/*" {
 }
 
 func TestMCPE2E_OversizedBody_DeniesOversizedBody(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
 }
 `)
 	const cap = int64(64)
@@ -342,12 +350,13 @@ path "mcp/gateway/*" {
 // the same RuleType. Pins the symmetry with malformed_jsonrpc /
 // duplicate_key / batch_empty through the production pipeline.
 func TestMCPE2E_MalformedParams_DeniesMalformedParams(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
 }
 `)
 	req := buildE2ERequest(t, `{
@@ -365,12 +374,13 @@ path "mcp/gateway/*" {
 }
 
 func TestMCPE2E_EmptyBatch_DeniesBatchEmpty(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
 }
 `)
 	req := buildE2ERequest(t, `[]`)
@@ -397,12 +407,13 @@ path "mcp/gateway/*" {
 // every MCP-spec-compliant client that opens an SSE notification
 // stream would hit missing_body.
 func TestMCPE2E_PerRequestOptOut_WithMCPBlock_PassesThrough(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
 }
 `)
 	req := buildE2ERequest(t, `{"jsonrpc":"2.0","method":"tools/list","id":1}`)
@@ -448,14 +459,15 @@ path "mcp/gateway/*" {
 
 // Backend doesn't implement MCPPolicyEnforced at all → same as
 // per-request opt-out from the extractor's perspective. Pins the
-// "operator bound mcp{} to a non-MCP path" misconfiguration scenario.
+// "operator bound an MCP contract to a non-MCP path" misconfiguration.
 func TestMCPE2E_NonMCPBackend_WithMCPBlock_DeniesMissingBody(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
 }
 `)
 	req := buildE2ERequest(t, `{"jsonrpc":"2.0","method":"tools/list","id":1}`)
@@ -481,13 +493,14 @@ path "mcp/gateway/*" {
 // is truly provider-agnostic and that future mcp_* providers inherit
 // enforcement by implementing one method.
 func TestMCPE2E_ProviderAgnostic_TwoBackendsSameOutcome(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    denied_tools    = ["delete_*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { denied = ["delete_*"] }
 }
 `)
 	body := `{

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -77,17 +77,44 @@ func mustCBP(t testing.TB, rules string) *CBP {
 	return cbp
 }
 
+// mustCBPWithMCP compiles one capability document and one MCP document into a
+// single CBP, which is how a governed mount is configured: the first grants the
+// path, the second constrains what may be called on it.
+func mustCBPWithMCP(t testing.TB, cbpRules, mcpRules string) *CBP {
+	t.Helper()
+	policies := []*Policy{testParsePolicy(t, cbpRules)}
+	if mcpRules != "" {
+		mcp := testParseMCPPolicy(t, mcpRules)
+		mcp.Name = "mcp-contract"
+		policies = append(policies, mcp)
+	}
+	cbp, err := NewCBP(testContext(), policies)
+	require.NoError(t, err)
+	return cbp
+}
+
+// mustMCPGateway is the shape almost every MCP test needs: the standard gateway
+// grant paired with a tool contract on the same path. body is the inside of the
+// MCP stanza.
+func mustMCPGateway(t testing.TB, body string) *CBP {
+	t.Helper()
+	return mustCBPWithMCP(t,
+		"path \"mcp/gateway/*\" {\n  capabilities = [\"update\"]\n}\n",
+		"path \"mcp/gateway/*\" {\n"+body+"\n}\n")
+}
+
 // =============================================================================
 // Method gate
 // =============================================================================
 
 func TestMCPEval_AllowedMethods_Match(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -106,12 +133,13 @@ path "mcp/gateway/*" {
 }
 
 func TestMCPEval_AllowedMethods_NoMatch(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -138,13 +166,14 @@ func TestMCPEval_LifecycleMethods_ExemptFromMethodGate(t *testing.T) {
 	// initialize / ping / notifications/* must pass even though the block
 	// allow-lists only data-plane methods — otherwise the MCP handshake
 	// breaks. The exemption skips the allowed_methods gate for them.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list"]
-    allowed_tools   = ["*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
+  tools { allowed = ["*"] }
 }
 `)
 	for _, method := range []string{"initialize", "ping", "notifications/initialized"} {
@@ -164,12 +193,15 @@ path "mcp/gateway/*" {
 func TestMCPEval_LifecycleMethod_ExplicitDenyStillBlocks(t *testing.T) {
 	// The deny gate runs before the exemption: an operator can still block
 	// a lifecycle method by naming it in denied_methods.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list"]
-    denied_methods  = ["ping"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods {
+    allowed = ["tools/list"]
+    denied = ["ping"]
   }
 }
 `)
@@ -184,12 +216,13 @@ path "mcp/gateway/*" {
 func TestMCPEval_ToolsCall_NeedsBothMethodAndToolAllow(t *testing.T) {
 	// Deny-by-default: allowing tools/call as a method is not enough — the
 	// tool name must also match allowed_tools. Empty allowed_tools ⇒ deny.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -206,13 +239,14 @@ path "mcp/gateway/*" {
 
 func TestMCPEval_StarOpensEverything(t *testing.T) {
 	// allowed_* = ["*"] restores fully-open behavior for a data-plane call.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["*"]
-    allowed_tools   = ["*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["*"] }
+  tools { allowed = ["*"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -228,12 +262,13 @@ path "mcp/gateway/*" {
 }
 
 func TestMCPEval_DeniedMethods_Match(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    denied_methods = ["tools/call"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { denied = ["tools/call"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -275,13 +310,14 @@ path "mcp/gateway/*" {
 // =============================================================================
 
 func TestMCPEval_AllowedTools_WildcardMatch(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    allowed_tools   = ["get_*", "list_*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["get_*", "list_*"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -301,13 +337,14 @@ path "mcp/gateway/*" {
 }
 
 func TestMCPEval_AllowedPrompts_BareStar(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["prompts/get"]
-    allowed_prompts = ["*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["prompts/get"] }
+  prompts { allowed = ["*"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -328,13 +365,14 @@ func TestMCPEval_DeniedTools_Match(t *testing.T) {
 	// allowed_methods admits tools/call so the request reaches the name
 	// gate; denied_tools then fires. (Under deny-by-default a set without
 	// allowed_methods would deny at the method gate before the name gate.)
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    denied_tools    = ["delete_*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { denied = ["delete_*"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -356,13 +394,14 @@ func TestMCPEval_DeniedResources_Match(t *testing.T) {
 	// resources/read with a denied_resources pattern that matches the
 	// requested URI → deny with rule_type denied_resources. Mirrors
 	// denied_tools but on the resources/read name gate.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods   = ["resources/read"]
-    denied_resources  = ["github://secrets/*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["resources/read"] }
+  resources { denied = ["github://secrets/*"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -383,13 +422,14 @@ path "mcp/gateway/*" {
 func TestMCPEval_DeniedPrompts_Match(t *testing.T) {
 	// prompts/get with a denied_prompts pattern that matches → deny
 	// with rule_type denied_prompts.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["prompts/get"]
-    denied_prompts  = ["sudo_*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["prompts/get"] }
+  prompts { denied = ["sudo_*"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -415,13 +455,14 @@ func TestMCPEval_DeniedResources_NoAllowList_Denies(t *testing.T) {
 	// Deny-by-default: allowed_methods admits resources/read, but with no
 	// allowed_resources every uri is denied — even one matching no
 	// denied_resources pattern. (Was allowed under allow-by-default.)
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods  = ["resources/read"]
-    denied_resources = ["github://secrets/*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["resources/read"] }
+  resources { denied = ["github://secrets/*"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -442,13 +483,16 @@ path "mcp/gateway/*" {
 // both allow and deny lists, the deny wins per evaluateMCPSetForCall
 // step (d) (deny-list scanned before allow-list).
 func TestMCPEval_DeniedResources_BeatsAllowedResources(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods   = ["resources/read"]
-    allowed_resources = ["github://*"]
-    denied_resources  = ["github://secrets/*"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["resources/read"] }
+  resources {
+    allowed = ["github://*"]
+    denied = ["github://secrets/*"]
   }
 }
 `)
@@ -468,13 +512,14 @@ func TestMCPEval_NameNotRequired_ListMethod(t *testing.T) {
 	// tools/list is name-less; allowed_tools is irrelevant for it
 	// even when configured. The method gate runs, the name gate is
 	// skipped per Semantics.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    allowed_tools   = ["get_*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { allowed = ["get_*"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -491,14 +536,15 @@ path "mcp/gateway/*" {
 }
 
 func TestMCPEval_EmptyBlock_DeniesByDefault(t *testing.T) {
-	// Deny-by-default: an empty mcp { } block allow-lists nothing, so a
-	// data-plane method is denied at the method gate (empty allowed_methods
-	// matches nothing). (Was allow-any before the flip.)
-	cbp := mustCBP(t, `
+	// Deny-by-default: an MCP stanza with no family blocks allow-lists nothing,
+	// so a data-plane method is denied at the method gate (an empty allowed
+	// list matches nothing). (Was allow-any before the flip.)
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {}
 }
+`, `
+path "mcp/gateway/*" {}
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
 		"jsonrpc": "2.0",
@@ -522,20 +568,21 @@ func TestMCPEval_MultiSet_FirstAllows(t *testing.T) {
 	// Two stanzas at the same path: set 1 allows the request, set 2
 	// would deny it. OR semantics: any allow wins, and audit records
 	// the first allowing set.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    allowed_tools   = ["get_repository"]
-  }
 }
 
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    denied_methods = ["tools/call"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["get_repository"] }
+}
+path "mcp/gateway/*" {
+  methods { denied = ["tools/call"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -552,29 +599,25 @@ path "mcp/gateway/*" {
 }
 
 func TestMCPEval_MultiPolicy_AdditiveMerge(t *testing.T) {
-	// Two separate Policy objects bound to the same effective path,
-	// merged at NewCBP time. The MCP slice grows additively — the
-	// presence of a policy WITHOUT an mcp block does NOT clear
-	// enforcement contributed by the policy WITH one. This is the
-	// design call documented next to the merge code: MCP differs
-	// from CEL conditions (where "absent clears") because adding a
-	// broader catch-all policy shouldn't accidentally lift an
-	// existing MCP restriction.
-	policyWithMCP := testParsePolicy(t, `
+	// An MCP contract bound to the same effective path as a bare capability
+	// grant. The contract still applies: a policy that says nothing about MCP
+	// does NOT lift it. MCP differs from CEL conditions (where "absent clears")
+	// because adding a broader catch-all grant shouldn't accidentally free the
+	// tools an existing contract narrowed.
+	contract := testParseMCPPolicy(t, `
 path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    allowed_tools   = ["get_*"]
-  }
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["get_*"] }
 }
 `)
-	policyWithoutMCP := testParsePolicy(t, `
+	contract.Name = "contract"
+	bareGrant := testParsePolicy(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
 }
 `)
-	cbp, err := NewCBP(testContext(), []*Policy{policyWithMCP, policyWithoutMCP})
+	bareGrant.Name = "grant"
+	cbp, err := NewCBP(testContext(), []*Policy{contract, bareGrant})
 	require.NoError(t, err)
 
 	// Forbidden tool: MCP gate from the first policy denies, the
@@ -594,21 +637,22 @@ func TestMCPEval_MultiSet_StrongestReasonDenyList(t *testing.T) {
 	// Both sets deny: set 1 via not-in-allow-list (weaker reason),
 	// set 2 via explicit deny-list (stronger reason). Audit should
 	// record the deny-list reason.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    allowed_tools   = ["get_repository"]
-  }
 }
 
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    denied_tools    = ["delete_*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["get_repository"] }
+}
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { denied = ["delete_*"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -635,13 +679,14 @@ func TestMCPEval_Batch_AllAllowed(t *testing.T) {
 	// and then through the matcher; the decision is the last allow
 	// and BatchIndex stays nil because no element denied. No list method
 	// is present, so the response-filter batch guard does not fire.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    allowed_tools   = ["search_repos", "get_repo"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["search_repos", "get_repo"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `[
@@ -662,13 +707,14 @@ func TestMCPEval_Batch_WithListMethod_Denied(t *testing.T) {
 	// A batch that contains a list method is denied even when every call
 	// would otherwise pass: a batched JSON-RPC list response can't be
 	// pruned per element, so the response-filter guard fails closed.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    allowed_tools   = ["search_repos"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { allowed = ["search_repos"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `[
@@ -688,13 +734,16 @@ func TestMCPEval_Batch_OneDeniedFailsBatch(t *testing.T) {
 	// A batch where the third element denies — the entire batch
 	// denies (single-fail-all-fail) with the denying call's
 	// MCPDecision stamped including BatchIndex.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    allowed_tools   = ["search_repos"]
-    denied_tools    = ["delete_*"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools {
+    allowed = ["search_repos"]
+    denied = ["delete_*"]
   }
 }
 `)
@@ -721,13 +770,14 @@ func TestMCPEval_Batch_TwoDenies_FirstWins(t *testing.T) {
 	// short-circuits at the FIRST denying call, so BatchIndex == 1.
 	// Pins the first-deny-wins contract independently from
 	// Batch_OneDeniedFailsBatch (which puts the only deny last).
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    denied_tools    = ["delete_*", "drop_*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { denied = ["delete_*", "drop_*"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `[
@@ -751,13 +801,14 @@ path "mcp/gateway/*" {
 // code path BUT doesn't stamp BatchIndex — the matcher only stamps
 // for genuinely batched bodies (len > 1). Pins the boundary.
 func TestMCPEval_Batch_SingleElement_NoBatchIndex(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    denied_tools    = ["delete_*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { denied = ["delete_*"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `[
@@ -776,12 +827,13 @@ func TestMCPEval_Batch_Empty_Denies(t *testing.T) {
 	// An empty batch body `[]` is rejected by the strict parser with
 	// batch_empty. The matcher never runs; decideMCP maps the
 	// ParseErr.Kind 1:1 to MCPDecision.RuleType.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `[]`)
@@ -796,12 +848,13 @@ path "mcp/gateway/*" {
 func TestMCPEval_Batch_DuplicateKey_Denies(t *testing.T) {
 	// A batch where one element has a duplicate key fails the WHOLE
 	// batch at parse time (strict-parser single-pass bail).
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `[
@@ -823,13 +876,14 @@ func TestMCPEval_BodyCaseInsensitive(t *testing.T) {
 	// method and tool name in the body. The matcher lowercases
 	// descriptor method/name once at the boundary so the comparison
 	// succeeds and the decision records the lowercased form.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    allowed_tools   = ["get_*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["get_*"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/", `{
@@ -1013,18 +1067,19 @@ path "secret/*" {
 }
 
 func BenchmarkAllowOperation_TypicalMCP(b *testing.B) {
-	cbp := buildBenchCBP(b, `
+	cbp := buildBenchCBPWithMCP(b, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call", "resources/list", "resources/read", "prompts/get"]
-    allowed_tools = [
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call", "resources/list", "resources/read", "prompts/get"] }
+  tools { allowed = [
       "get_repository", "get_pull_request", "list_issues", "list_pull_requests",
       "search_code", "search_issues", "search_repositories", "list_workflows",
       "list_commits", "get_file_contents",
-    ]
-    condition = "(!has(call.args.path) || call.args.path.startsWith('docs/')) && (!has(call.args.mode) || call.args.mode == '0644') && (!has(call.args.region) || call.args.region == 'us-west1')"
-  }
+    ] }
+  condition = "(!has(call.args.path) || call.args.path.startsWith('docs/')) && (!has(call.args.mode) || call.args.mode == '0644') && (!has(call.args.region) || call.args.region == 'us-west1')"
 }
 `)
 	req := newMCPRequest(b, "mcp/gateway/", `{
@@ -1051,8 +1106,11 @@ func BenchmarkAllowOperation_StressMCP(b *testing.B) {
 	// 5 stanzas at the same path, each with ~50 patterns across
 	// methods/tools/params. Operators shouldn't aim for this shape,
 	// but the bench bounds the cliff.
-	stress := buildStressPolicy(5, 50)
-	cbp := buildBenchCBP(b, stress)
+	cbp := buildBenchCBPWithMCP(b, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, buildStressPolicy(5, 50))
 	req := newMCPRequest(b, "mcp/gateway/", `{
 		"jsonrpc": "2.0",
 		"method":  "tools/call",
@@ -1079,14 +1137,35 @@ func buildBenchCBP(b *testing.B, rules string) *CBP {
 	return cbp
 }
 
+// buildBenchCBPWithMCP is buildBenchCBP for the two-document shape a governed
+// MCP mount uses.
+func buildBenchCBPWithMCP(b *testing.B, cbpRules, mcpRules string) *CBP {
+	b.Helper()
+	cbpPolicy, err := ParseCBPPolicy(namespace.RootNamespace, cbpRules)
+	if err != nil {
+		b.Fatalf("parse cbp: %v", err)
+	}
+	mcpPolicy, err := ParseMCPPolicy(namespace.RootNamespace, mcpRules)
+	if err != nil {
+		b.Fatalf("parse mcp: %v", err)
+	}
+	mcpPolicy.Name = "contract"
+	cbp, err := NewCBP(testContext(), []*Policy{cbpPolicy, mcpPolicy})
+	if err != nil {
+		b.Fatalf("build: %v", err)
+	}
+	return cbp
+}
+
+// buildStressPolicy emits an MCP document with `sets` stanzas at the same path,
+// which the index merges into that many rule-sets.
 func buildStressPolicy(sets, patternsPerList int) string {
 	var sb strings.Builder
 	for s := 0; s < sets; s++ {
 		sb.WriteString(`path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    allowed_tools = [`)
+  methods { allowed = ["tools/call"] }
+  tools {
+    allowed = [`)
 		for i := 0; i < patternsPerList; i++ {
 			if i > 0 {
 				sb.WriteString(", ")

--- a/core/policy_mcp_index_test.go
+++ b/core/policy_mcp_index_test.go
@@ -174,9 +174,11 @@ path "mcp/gateway/*" {
 		toolsOf(cbp.mcpRulesForPath("mcp/gateway/call")))
 }
 
-// TestMCPIndex_AllowOperationUnaffected is the inert-by-design pin for this PR:
-// attaching an MCP policy must not change any request-time decision yet.
-func TestMCPIndex_AllowOperationUnaffected(t *testing.T) {
+// TestMCPIndex_AllowOperationConsultsIndex is the other side of the grammar
+// move: an attached contract now decides the call, where the capability grant
+// alone used to. A path with no contract in scope still passes — that inversion
+// is the absence deny-by-default, which lands separately.
+func TestMCPIndex_AllowOperationConsultsIndex(t *testing.T) {
 	cbpPolicy := testParsePolicy(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
@@ -186,7 +188,8 @@ path "mcp/gateway/*" {
 
 	mcpPolicy := testParseMCPPolicy(t, `
 path "mcp/gateway/*" {
-  tools { allowed = ["nothing-matches-this"] }
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["permitted"] }
 }
 `)
 	mcpPolicy.Name = "contract"
@@ -196,15 +199,22 @@ path "mcp/gateway/*" {
 	withMCP, err := NewCBP(testContext(), []*Policy{cbpPolicy, mcpPolicy})
 	require.NoError(t, err)
 
-	req := newMCPRequest(t, "mcp/gateway/",
-		`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"anything"},"id":1}`)
+	denied := newMCPRequest(t, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"forbidden"},"id":1}`)
 
-	base := withoutMCP.AllowOperation(testContext(), req, nil, false)
-	withIndex := withMCP.AllowOperation(testContext(), req, nil, false)
+	base := withoutMCP.AllowOperation(testContext(), denied, nil, false)
+	assert.True(t, base.Allowed, "no contract in scope: the grant alone still decides")
+	assert.Nil(t, base.MCPDecision)
 
-	assert.Equal(t, base.Allowed, withIndex.Allowed)
-	assert.Equal(t, base.MCPDecision, withIndex.MCPDecision)
-	assert.True(t, base.Allowed, "the capability grant alone still decides in this PR")
+	gated := withMCP.AllowOperation(testContext(), denied, nil, false)
+	assert.False(t, gated.Allowed, "the contract is consulted through the index")
+	require.NotNil(t, gated.MCPDecision)
+	assert.Equal(t, mcpRuleTypeAllowedTools, gated.MCPDecision.RuleType)
+
+	permitted := newMCPRequest(t, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"permitted"},"id":1}`)
+	ok := withMCP.AllowOperation(testContext(), permitted, nil, false)
+	assert.True(t, ok.Allowed)
 }
 
 // TestGetPolicyAnyType_ResolvesBothTypes covers the flat-name resolution that
@@ -420,6 +430,82 @@ func TestNewCBP_RootWithAnotherGrantStillRejected(t *testing.T) {
 	_, err := NewCBP(testContext(), []*Policy{rootPolicy, other})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "other policies present along with root")
+}
+
+// TestMCPDecision_PolicyName_MultiplePolicies pins what PolicyName means when
+// several contracts cover one path — the case where a single name could
+// mislead. It always names the source of the reported rule.
+func TestMCPDecision_PolicyName_MultiplePolicies(t *testing.T) {
+	grant := testParsePolicy(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`)
+	grant.Name = "grant"
+
+	narrow := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["alpha"] }
+}
+`)
+	narrow.Name = "narrow-contract"
+
+	wide := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["beta"] }
+}
+`)
+	wide.Name = "wide-contract"
+
+	cbp, err := NewCBP(testContext(), []*Policy{grant, narrow, wide})
+	require.NoError(t, err)
+
+	// Allowed by the second contract only: evaluation stops there, and the
+	// record names the contract that permitted it.
+	allowed := cbp.AllowOperation(testContext(),
+		newMCPRequest(t, "mcp/gateway/",
+			`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"beta"},"id":1}`),
+		nil, false)
+	require.True(t, allowed.Allowed)
+	require.NotNil(t, allowed.MCPDecision)
+	assert.Equal(t, "wide-contract", allowed.MCPDecision.PolicyName)
+
+	// Denied by both: the reported rule comes from one of them, and PolicyName
+	// agrees with it. It is the source of the reason, not the sole cause —
+	// editing only that policy would not lift the denial.
+	denied := cbp.AllowOperation(testContext(),
+		newMCPRequest(t, "mcp/gateway/",
+			`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"gamma"},"id":1}`),
+		nil, false)
+	require.False(t, denied.Allowed)
+	require.NotNil(t, denied.MCPDecision)
+	assert.Contains(t, []string{"narrow-contract", "wide-contract"},
+		denied.MCPDecision.PolicyName)
+	assert.Equal(t, mcpRuleTypeAllowedTools, denied.MCPDecision.RuleType)
+}
+
+// TestMCPDecision_PolicyName_EmptyOnStructuralDeny pins the carve-out: a body
+// that never parses is refused before any contract is chosen, so there is no
+// policy to name.
+func TestMCPDecision_PolicyName_EmptyOnStructuralDeny(t *testing.T) {
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+}
+`)
+	res := cbp.AllowOperation(testContext(),
+		newMCPRequest(t, "mcp/gateway/", `{"jsonrpc":"2.0","method":`), nil, false)
+
+	require.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeMalformedJSONRPC, res.MCPDecision.RuleType)
+	assert.Empty(t, res.MCPDecision.PolicyName)
 }
 
 func testPastTime() time.Time {

--- a/core/policy_mcp_list_filter_test.go
+++ b/core/policy_mcp_list_filter_test.go
@@ -24,13 +24,16 @@ func filterKeeps(t *testing.T, cbp *CBP, path, body, listMethod string) func(str
 }
 
 func TestListFilter_ToolsList_KeepsOnlyCallableTools(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    allowed_tools   = ["get_*"]
-    denied_tools    = ["get_secret"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools {
+    allowed = ["get_*"]
+    denied = ["get_secret"]
   }
 }
 `)
@@ -46,12 +49,13 @@ path "mcp/gateway/*" {
 func TestListFilter_NoAllowedTools_KeepsNothing(t *testing.T) {
 	// Deny-by-default: tools/list is permitted as a method, but with no
 	// allowed_tools every item is filtered out — the list comes back empty.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
 }
 `)
 	keep := filterKeeps(t, cbp, "mcp/gateway/",
@@ -62,13 +66,14 @@ path "mcp/gateway/*" {
 }
 
 func TestListFilter_StarKeepsEverything(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    allowed_tools   = ["*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { allowed = ["*"] }
 }
 `)
 	keep := filterKeeps(t, cbp, "mcp/gateway/",
@@ -80,13 +85,14 @@ path "mcp/gateway/*" {
 func TestListFilter_ToolsListAllowedButNotToolsCall_EmptyList(t *testing.T) {
 	// allowed_methods permits tools/list but not tools/call, so nothing is
 	// callable → the filter keeps nothing. "Visible == callable."
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list"]
-    allowed_tools   = ["get_*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list"] }
+  tools { allowed = ["get_*"] }
 }
 `)
 	keep := filterKeeps(t, cbp, "mcp/gateway/",
@@ -96,13 +102,14 @@ path "mcp/gateway/*" {
 }
 
 func TestListFilter_ResourcesList_MatchesByUri(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods   = ["resources/list", "resources/read"]
-    allowed_resources = ["github://repo/*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["resources/list", "resources/read"] }
+  resources { allowed = ["github://repo/*"] }
 }
 `)
 	keep := filterKeeps(t, cbp, "mcp/gateway/",
@@ -113,13 +120,14 @@ path "mcp/gateway/*" {
 }
 
 func TestListFilter_PromptsList_MatchesByName(t *testing.T) {
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["prompts/list", "prompts/get"]
-    allowed_prompts = ["safe_*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["prompts/list", "prompts/get"] }
+  prompts { allowed = ["safe_*"] }
 }
 `)
 	keep := filterKeeps(t, cbp, "mcp/gateway/",
@@ -132,21 +140,22 @@ path "mcp/gateway/*" {
 func TestListFilter_CrossSetOR(t *testing.T) {
 	// Two stanzas: one allows get_*, the other allows list_*. A tool is kept
 	// if either set would allow the call (cross-set OR).
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    allowed_tools   = ["get_*"]
-  }
 }
 
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    allowed_tools   = ["list_*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { allowed = ["get_*"] }
+}
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { allowed = ["list_*"] }
 }
 `)
 	keep := filterKeeps(t, cbp, "mcp/gateway/",
@@ -163,14 +172,15 @@ func TestListFilter_ConditionGatedToolStaysListed(t *testing.T) {
 	// list time and enforced at call time. The condition is scoped with
 	// call.method so it doesn't deny the argument-less tools/list request
 	// itself (a set-wide call.args condition would — see docs/concepts/mcp.md).
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    allowed_tools   = ["create_payment"]
-    condition       = "call.method != 'tools/call' || call.args.amount <= 1500"
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { allowed = ["create_payment"] }
+  condition = "call.method != 'tools/call' || call.args.amount <= 1500"
 }
 `)
 	keep := filterKeeps(t, cbp, "mcp/gateway/",
@@ -181,13 +191,14 @@ path "mcp/gateway/*" {
 
 func TestListFilter_NotAttachedForToolsCall(t *testing.T) {
 	// A non-list call gets no filter — only list methods are filtered.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/call"]
-    allowed_tools   = ["get_repo"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["get_repo"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/",
@@ -200,13 +211,14 @@ path "mcp/gateway/*" {
 
 func TestListFilter_NotAttachedOnCapCheckOnly(t *testing.T) {
 	// The cap-check-only pass must not leave a filter behind.
-	cbp := mustCBP(t, `
+	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
-  mcp {
-    allowed_methods = ["tools/list", "tools/call"]
-    allowed_tools   = ["*"]
-  }
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { allowed = ["*"] }
 }
 `)
 	req := newMCPRequest(t, "mcp/gateway/",

--- a/core/policy_mcp_parse_test.go
+++ b/core/policy_mcp_parse_test.go
@@ -175,6 +175,79 @@ func TestParseMCPPolicy_RejectsBadPatterns(t *testing.T) {
 	}
 }
 
+func TestParseMCPPolicy_TrailingStarAccepted(t *testing.T) {
+	p := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  tools { denied = ["delete_*"] }
+}
+`)
+	assert.Equal(t, []string{"delete_*"}, p.Paths[0].Permissions.MCP[0].DeniedTools)
+}
+
+func TestParseMCPPolicy_BareStarAccepted(t *testing.T) {
+	// The bare `*` is a zero-prefix trailing-star and matches everything. Used
+	// to express "any value" without enumerating.
+	p := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  prompts { allowed = ["*"] }
+}
+`)
+	assert.Equal(t, []string{"*"}, p.Paths[0].Permissions.MCP[0].AllowedPrompts)
+}
+
+// TestParseMCPPolicy_MultipleStanzasSamePath pins that two stanzas at one path
+// each become their own PathRules carrying a one-entry rule-set. Folding them
+// into a single slice is the index's job, not the parser's.
+func TestParseMCPPolicy_MultipleStanzasSamePath(t *testing.T) {
+	p := testParseMCPPolicy(t, `
+path "mcp/gateway/*" {
+  methods { allowed = ["resources/read"] }
+  resources { allowed = ["github://repo/A/*"] }
+}
+
+path "mcp/gateway/*" {
+  methods { allowed = ["resources/list"] }
+}
+`)
+	require.Len(t, p.Paths, 2)
+	require.Len(t, p.Paths[0].Permissions.MCP, 1)
+	require.Len(t, p.Paths[1].Permissions.MCP, 1)
+	assert.Equal(t, []string{"resources/read"}, p.Paths[0].Permissions.MCP[0].AllowedMethods)
+	assert.Equal(t, []string{"resources/list"}, p.Paths[1].Permissions.MCP[0].AllowedMethods)
+}
+
+// TestParseCBPPolicy_RejectsMCPBlock pins the removal itself: the old nested
+// block must fail at parse with a message naming its replacement.
+func TestParseCBPPolicy_RejectsMCPBlock(t *testing.T) {
+	_, err := ParseCBPPolicy(namespace.RootNamespace, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+  mcp {
+    allowed_tools = ["get_repository"]
+  }
+}
+`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has been removed from capability policies")
+	assert.Contains(t, err.Error(), "sys/policies/mcp/")
+}
+
+// TestParseCBPPolicy_RejectsMCPBlockOnDenyStanza covers the case a check placed
+// beside the other rule handling would miss: the deny capability jumps to
+// PathFinished, skipping everything after it.
+func TestParseCBPPolicy_RejectsMCPBlockOnDenyStanza(t *testing.T) {
+	_, err := ParseCBPPolicy(namespace.RootNamespace, `
+path "mcp/gateway/*" {
+  capabilities = ["deny"]
+  mcp {
+    allowed_tools = ["get_repository"]
+  }
+}
+`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "has been removed from capability policies")
+}
+
 // TestParseMCPPolicy_JSONDocument covers the "HCL or JSON format" contract the
 // policy API advertises, which the v2 parser serves from its own json package.
 func TestParseMCPPolicy_JSONDocument(t *testing.T) {

--- a/core/policy_mcp_test.go
+++ b/core/policy_mcp_test.go
@@ -11,214 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseMCP_AllFields(t *testing.T) {
-	rules := `
-path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp {
-    allowed_methods   = ["tools/list", "tools/call"]
-    denied_methods    = ["tools/dangerous"]
-    allowed_tools     = ["get_repository", "list_issues"]
-    denied_tools      = ["delete_*", "force_*"]
-    allowed_resources = ["github://repo/*"]
-    denied_resources  = ["github://secrets/*"]
-    allowed_prompts   = ["*"]
-    denied_prompts    = ["sudo_*"]
-  }
-}
-`
-	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
-	require.NoError(t, err)
-	require.Len(t, policy.Paths, 1)
-
-	mcp := policy.Paths[0].Permissions.MCP
-	require.Len(t, mcp, 1, "one stanza must produce one MCP rule-set")
-	r := mcp[0]
-
-	assert.Equal(t, []string{"tools/list", "tools/call"}, r.AllowedMethods)
-	assert.Equal(t, []string{"tools/dangerous"}, r.DeniedMethods)
-	assert.Equal(t, []string{"get_repository", "list_issues"}, r.AllowedTools)
-	assert.Equal(t, []string{"delete_*", "force_*"}, r.DeniedTools)
-	assert.Equal(t, []string{"github://repo/*"}, r.AllowedResources)
-	assert.Equal(t, []string{"github://secrets/*"}, r.DeniedResources)
-	assert.Equal(t, []string{"*"}, r.AllowedPrompts)
-	assert.Equal(t, []string{"sudo_*"}, r.DeniedPrompts)
-}
-
-func TestParseMCP_EmptyBlock(t *testing.T) {
-	// An empty mcp { } block is the minimum opt-in: produces a
-	// non-nil rule-set with all empty fields. AllowOperation uses
-	// presence to trigger the missing-header check; emptiness means
-	// "no further restriction."
-	rules := `
-path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp {}
-}
-`
-	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
-	require.NoError(t, err)
-	require.Len(t, policy.Paths, 1)
-
-	mcp := policy.Paths[0].Permissions.MCP
-	require.Len(t, mcp, 1, "empty block must still produce a rule-set entry")
-	r := mcp[0]
-
-	assert.Nil(t, r.AllowedMethods)
-	assert.Nil(t, r.DeniedMethods)
-	assert.Nil(t, r.AllowedTools)
-	assert.Nil(t, r.DeniedTools)
-	assert.Nil(t, r.AllowedResources)
-	assert.Nil(t, r.DeniedResources)
-	assert.Nil(t, r.AllowedPrompts)
-	assert.Nil(t, r.DeniedPrompts)
-}
-
-func TestParseMCP_NoBlock(t *testing.T) {
-	// A path stanza without an mcp { } block leaves Permissions.MCP
-	// nil — every existing non-MCP policy keeps working unchanged.
-	rules := `
-path "secret/*" {
-  capabilities = ["read"]
-}
-`
-	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
-	require.NoError(t, err)
-	require.Len(t, policy.Paths, 1)
-	assert.Nil(t, policy.Paths[0].Permissions.MCP)
-}
-
-func TestParseMCP_Lowercasing(t *testing.T) {
-	// Operator-supplied mixed-case patterns are canonicalised at parse
-	// time so AllowOperation can do case-insensitive matching via plain
-	// string equality.
-	rules := `
-path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp {
-    allowed_methods = ["TOOLS/Call", "Tools/LIST"]
-    denied_tools    = ["Delete_*", "FORCE_*"]
-  }
-}
-`
-	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
-	require.NoError(t, err)
-	r := policy.Paths[0].Permissions.MCP[0]
-
-	assert.Equal(t, []string{"tools/call", "tools/list"}, r.AllowedMethods)
-	assert.Equal(t, []string{"delete_*", "force_*"}, r.DeniedTools)
-}
-
-func TestParseMCP_LeadingStarRejected(t *testing.T) {
-	rules := `
-path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp {
-    denied_tools = ["*_admin"]
-  }
-}
-`
-	_, err := ParseCBPPolicy(namespace.RootNamespace, rules)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "denied_tools")
-	assert.Contains(t, err.Error(), "*_admin")
-	assert.Contains(t, err.Error(), "trailing")
-}
-
-func TestParseMCP_InternalStarRejected(t *testing.T) {
-	rules := `
-path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp {
-    allowed_tools = ["get_*_admin"]
-  }
-}
-`
-	_, err := ParseCBPPolicy(namespace.RootNamespace, rules)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "allowed_tools")
-	assert.Contains(t, err.Error(), "get_*_admin")
-}
-
-func TestParseMCP_TrailingStarAccepted(t *testing.T) {
-	rules := `
-path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp {
-    denied_tools = ["delete_*"]
-  }
-}
-`
-	_, err := ParseCBPPolicy(namespace.RootNamespace, rules)
-	require.NoError(t, err)
-}
-
-func TestParseMCP_BareStarAccepted(t *testing.T) {
-	// The bare `*` is a zero-prefix trailing-star and matches
-	// everything. Used to express "any value" without enumerating.
-	rules := `
-path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp {
-    allowed_prompts = ["*"]
-  }
-}
-`
-	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
-	require.NoError(t, err)
-	assert.Equal(t, []string{"*"}, policy.Paths[0].Permissions.MCP[0].AllowedPrompts)
-}
-
-func TestParseMCP_ParamsRejected(t *testing.T) {
-	// The removed allowed_params/denied_params are rejected at parse time
-	// with a directed error pointing at the CEL call.args equivalent.
-	rules := `
-path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp {
-    allowed_params = {
-      path = ["docs/*"]
-    }
-  }
-}
-`
-	_, err := ParseCBPPolicy(namespace.RootNamespace, rules)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "allowed_params/denied_params have been removed")
-	assert.Contains(t, err.Error(), "call.args")
-}
-
-func TestParseMCP_MultipleStanzasSamePath(t *testing.T) {
-	// Two `path` stanzas at the same path in one policy each become
-	// their own PathRules, each with its own one-entry MCP slice. The
-	// OR-of-rule-sets merge into a single CBPPermissions.MCP slice
-	// happens at NewCBP time alongside the evaluation logic.
-	rules := `
-path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp {
-    allowed_methods = ["resources/read"]
-    allowed_resources = ["github://repo/A/*"]
-  }
-}
-
-path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp {
-    allowed_methods = ["resources/list"]
-  }
-}
-`
-	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
-	require.NoError(t, err)
-	require.Len(t, policy.Paths, 2)
-
-	require.Len(t, policy.Paths[0].Permissions.MCP, 1)
-	require.Len(t, policy.Paths[1].Permissions.MCP, 1)
-	assert.Equal(t, []string{"resources/read"}, policy.Paths[0].Permissions.MCP[0].AllowedMethods)
-	assert.Equal(t, []string{"resources/list"}, policy.Paths[1].Permissions.MCP[0].AllowedMethods)
-}
-
 func TestCBPMCPRules_Clone_Nil(t *testing.T) {
 	var r *CBPMCPRules
 	assert.Nil(t, r.Clone())
@@ -247,18 +39,16 @@ func TestCBPMCPRules_Clone_DeepCopy(t *testing.T) {
 }
 
 func TestCBPPermissions_Clone_MCPDeepCopy(t *testing.T) {
-	// End-to-end: parse a policy with an mcp block, clone the
-	// CBPPermissions, mutate the clone, confirm the original is
-	// unaffected.
+	// End-to-end: parse an MCP policy, clone the CBPPermissions, mutate the
+	// clone, confirm the original is unaffected. This is the discipline the
+	// index depends on — it clones before inserting so a compile can never
+	// mutate the cached policy it compiled from.
 	rules := `
 path "mcp/gateway/*" {
-  capabilities = ["update"]
-  mcp {
-    allowed_tools = ["get_*"]
-  }
+  tools { allowed = ["get_*"] }
 }
 `
-	policy, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+	policy, err := ParseMCPPolicy(namespace.RootNamespace, rules)
 	require.NoError(t, err)
 	original := policy.Paths[0].Permissions
 

--- a/e2e/fullchain/mcp_test.go
+++ b/e2e/fullchain/mcp_test.go
@@ -15,8 +15,8 @@ import (
 // names the tools a caller may invoke, and the decision needs the JSON-RPC call
 // itself.
 //
-// The decision logic is covered thoroughly in-process — core has seven files on
-// mcp { } parsing, evaluation and list filtering. What none of them exercise is
+// The decision logic is covered thoroughly in-process — core has several files
+// on MCP policy parsing, evaluation and list filtering. What none of them cover is
 // the wiring: that a policy written through the API, stored, attached to a token
 // minted for a certificate agent, and evaluated against a real request body,
 // actually reaches the enforcement point. Those tests construct a Core directly.
@@ -40,12 +40,10 @@ var mcpEnv = h.ProviderEnv{
 	CredType:   "api_key",
 	CredConfig: map[string]string{"api_key": mcpAPIKey},
 	// Naming one tool is what opts the mount into body-authoritative
-	// enforcement; without an mcp { } block the body is never inspected and
-	// every JSON-RPC call the capability allows would go through.
-	ExtraPolicyRules: `  mcp {
-    allowed_methods = ["tools/call", "tools/list"]
-    allowed_tools   = ["` + mcpAllowedTool + `"]
-  }`,
+	// enforcement; with no MCP contract in scope the body is never inspected
+	// and every JSON-RPC call the capability allows would go through.
+	MCPPolicyRules: `  methods { allowed = ["tools/call", "tools/list"] }
+  tools { allowed = ["` + mcpAllowedTool + `"] }`,
 }
 
 // The github_token arm needs its own mount: a role binds one spec, and a variant
@@ -240,8 +238,8 @@ func TestMCP_MalformedBodyIsRefused(t *testing.T) {
 //
 // That is the property worth pinning: a body the filter cannot interpret is
 // denied rather than waved through as "no rule matched", which is how a filter
-// of this shape usually breaks. This row would pass differently with the
-// mcp { } block removed.
+// of this shape usually breaks. This row would pass differently with no MCP
+// contract attached to the mount.
 func TestMCP_ValidJSONButInvalidJSONRPCIsDeniedByPolicy(t *testing.T) {
 	ensureEnv(t)
 

--- a/e2e/helpers/fullchain_helpers.go
+++ b/e2e/helpers/fullchain_helpers.go
@@ -109,9 +109,18 @@ type ProviderEnv struct {
 	SourceRotationPeriod int
 
 	// ExtraPolicyRules are appended inside the mount's gateway path stanza,
-	// for providers whose authorization is finer-grained than a capability —
-	// a body-authoritative rule set, say, which cannot be expressed as one.
+	// for providers whose authorization is finer-grained than a capability and
+	// still belongs in the capability document — a path-level CEL condition,
+	// say.
 	ExtraPolicyRules string
+
+	// MCPPolicyRules is the body of an MCP policy stanza — methods, tools,
+	// resources, prompts, condition. When set, a second policy is written to
+	// sys/policies/mcp/ covering the same gateway shapes and attached to every
+	// role alongside the capability policy. Left empty, the mount gets no MCP
+	// contract at all, which is what a test wants when it means to exercise an
+	// ungoverned path.
+	MCPPolicyRules string
 
 	// CredConfig is the spec config. For a local source these values are copied
 	// verbatim into the minted credential, which is what lets a test assert on
@@ -154,6 +163,10 @@ func (p ProviderEnv) DenyRole() string { return p.Mount + "-agent-denied" }
 
 // DenyPolicy is the policy DenyRole carries.
 func (p ProviderEnv) DenyPolicy() string { return p.Mount + "-denied" }
+
+// MCPPolicy is the mount's tool contract, attached alongside Policy. Named
+// distinctly because policy names are unique across types.
+func (p ProviderEnv) MCPPolicy() string { return p.Mount + "-mcp" }
 
 // JWTAgentRole authenticates the agent by bearer token instead of certificate.
 // Needed for every shape where the agent arrives in a header — the dedicated
@@ -372,10 +385,21 @@ func SetupFullChainProvider(t *testing.T, port int, upstreamURL string, p Provid
 		mustJSON(t, map[string]any{"policy": gatewayPolicy(p.Mount, p.ExtraPolicyRules)}),
 		"create policy for "+p.Mount)
 
+	// The tool contract, when the provider wants one. It is a second document
+	// attached alongside the capability policy: it grants nothing by itself and
+	// only narrows what may be called on the paths already granted above.
+	tokenPolicies := []string{p.Policy()}
+	if p.MCPPolicyRules != "" {
+		mustAPI(t, port, "POST", "sys/policies/mcp/"+p.MCPPolicy(),
+			mustJSON(t, map[string]any{"policy": gatewayMCPPolicy(p.Mount, p.MCPPolicyRules)}),
+			"create mcp policy for "+p.Mount)
+		tokenPolicies = append(tokenPolicies, p.MCPPolicy())
+	}
+
 	mustAPI(t, port, "POST", "auth/cert/role/"+p.CertRole(),
 		mustJSON(t, map[string]any{
 			"allowed_common_names": []string{FullChainAgentCN},
-			"token_policies":       []string{p.Policy()},
+			"token_policies":       tokenPolicies,
 			"cred_spec_name":       p.Spec(),
 			"token_ttl":            3600,
 		}),
@@ -405,7 +429,7 @@ func SetupFullChainProvider(t *testing.T, port int, upstreamURL string, p Provid
 	APIRequest(t, "DELETE", "auth/jwt/role/"+p.JWTAgentRole(), port, "")
 	mustAPI(t, port, "POST", "auth/jwt/role/"+p.JWTAgentRole(),
 		mustJSON(t, map[string]any{
-			"token_policies": []string{p.Policy()},
+			"token_policies": tokenPolicies,
 			"cred_spec_name": p.Spec(),
 			"user_claim":     "sub",
 			"token_ttl":      3600,
@@ -427,7 +451,7 @@ func SetupFullChainProvider(t *testing.T, port int, upstreamURL string, p Provid
 		mustAPI(t, port, "POST", "auth/cert/role/"+p.VariantRole(name),
 			mustJSON(t, map[string]any{
 				"allowed_common_names": []string{FullChainAgentCN},
-				"token_policies":       []string{p.Policy()},
+				"token_policies":       tokenPolicies,
 				"cred_spec_name":       p.VariantSpec(name),
 				"token_ttl":            3600,
 			}),
@@ -446,6 +470,17 @@ func gatewayPolicy(mount, extraRules string) string {
 			body += extraRules + "\n"
 		}
 		return fmt.Sprintf("path %q {\n%s}\n", path, body)
+	}
+	return stanza(mount+"/gateway*") + stanza(mount+"/role/+/gateway*")
+}
+
+// gatewayMCPPolicy is gatewayPolicy's counterpart for the tool contract. It
+// covers both gateway shapes for the same reason: the contract has to apply
+// however the role was selected, and the two indexes are matched against the
+// request path independently.
+func gatewayMCPPolicy(mount, rules string) string {
+	stanza := func(path string) string {
+		return fmt.Sprintf("path %q {\n%s\n}\n", path, rules)
 	}
 	return stanza(mount+"/gateway*") + stanza(mount+"/role/+/gateway*")
 }
@@ -933,6 +968,7 @@ func TeardownFullChainProviderBestEffort(port int, p ProviderEnv) {
 	del("sys/policies/cbp/" + p.DenyPolicy())
 	del("auth/cert/role/" + p.CertRole())
 	del("sys/policies/cbp/" + p.Policy())
+	del("sys/policies/mcp/" + p.MCPPolicy())
 	del("sys/cred/specs/" + p.Spec())
 	del("sys/cred/sources/" + p.Source())
 	del("sys/providers/" + p.Mount)

--- a/logical/auth.go
+++ b/logical/auth.go
@@ -101,9 +101,25 @@ type MCPDecision struct {
 	// produced before the name gate ran.
 	Name string `json:"name,omitempty"`
 
-	// Decision is "allow" or "deny". Always populated when an mcp { }
-	// block was consulted.
+	// Decision is "allow" or "deny". Always populated when an MCP
+	// rule-set was consulted.
 	Decision string `json:"decision"`
+
+	// PolicyName is the MCP policy that MatchedRule and RuleType came from.
+	// Tool contracts are separately-owned documents, so a record carrying only
+	// the rule cannot say which document to edit.
+	//
+	// Several contracts can cover one path, and the two outcomes differ in what
+	// this names. On allow, evaluation stops at the first rule-set that permits
+	// the call, so this is *a* contract that allowed it — others may also have
+	// allowed it and were never consulted. On deny, every rule-set refused and
+	// the most informative refusal is reported, so this names the source of the
+	// reported reason rather than the sole cause: editing that one policy need
+	// not lift the denial, because the others denied too.
+	//
+	// Empty on structural denies (malformed body, oversized, and so on), which
+	// are produced before any rule-set is chosen.
+	PolicyName string `json:"policy_name,omitempty"`
 
 	// MatchedRule is the pattern from the policy (allow- or deny-list
 	// entry) that fired. For a literal match it equals the request's

--- a/logical/mcp_enforced.go
+++ b/logical/mcp_enforced.go
@@ -3,12 +3,17 @@
 
 package logical
 
-// MCPPolicyEnforced is implemented by backends that participate in CBP
-// `mcp { }` body-authoritative policy enforcement. The core handler
-// calls ShouldEnforceMCPPolicy on every matched backend; when it
-// returns enforce=true the handler buffers the request body (up to
-// cap bytes), strict-parses it as JSON-RPC, and stashes the resulting
+// MCPPolicyEnforced is implemented by backends that participate in
+// body-authoritative MCP policy enforcement. The core handler calls
+// ShouldEnforceMCPPolicy on every matched backend; when it returns
+// enforce=true the handler buffers the request body (up to cap bytes),
+// strict-parses it as JSON-RPC, and stashes the resulting
 // MCPRequestDescriptor on the request before policy evaluation runs.
+//
+// The rules themselves live in an MCP policy — a document of their own,
+// attached to the token alongside the capability policy that grants the
+// path. They only ever narrow: the request must already be allowed by a
+// capability-based policy before any of this is consulted.
 //
 // This interface is the per-backend opt-in. The marker pattern mirrors
 // StreamBodyParser so reviewers can pattern-match the shape, and lets
@@ -23,7 +28,7 @@ package logical
 // hook by request shape so their domains do not overlap.
 type MCPPolicyEnforced interface {
 	// ShouldEnforceMCPPolicy reports whether this request on this
-	// backend is subject to `mcp { }` body-based enforcement, and the
+	// backend is subject to body-based MCP enforcement, and the
 	// maximum body size in bytes the policy extractor may buffer.
 	//
 	// cap <= 0 falls back to framework.DefaultMaxBodySize at the

--- a/provider/mcp/provider.go
+++ b/provider/mcp/provider.go
@@ -90,9 +90,9 @@ func extractBearerToken(req *logical.Request) (map[string]string, error) {
 	return map[string]string{"Authorization": "Bearer " + token}, nil
 }
 
-// shouldEnforceMCPPolicy opts the generic mcp provider into CBP
-// body-authoritative mcp { } enforcement for the subset of traffic where it is
-// meaningful: JSON-RPC POSTs. GET (SSE reconnect) and DELETE (session close),
+// shouldEnforceMCPPolicy opts the generic mcp provider into
+// body-authoritative MCP policy enforcement for the subset of traffic where it
+// is meaningful: JSON-RPC POSTs. GET (SSE reconnect) and DELETE (session close),
 // and any non-JSON Content-Type, decline and pass through under
 // token-scope-only enforcement.
 func shouldEnforceMCPPolicy(req *logical.Request) bool {
@@ -170,10 +170,13 @@ check the upstream's MCP auth before assuming a credspec can be reused.
 Policy:
 Two layers of authorization apply to MCP traffic. The minted bearer token is
 the security boundary — its scopes bound what the agent can actually do at the
-upstream regardless of what Warden lets through. On top of that, Warden's CBP
-policies support an mcp { } block for governance-style restrictions enforced at
-the gateway: allow- and deny-lists for JSON-RPC methods, tool names, resource
-URIs, prompt names, and selected tool arguments. Enforcement is
+upstream regardless of what Warden lets through. On top of that, Warden supports
+MCP policies for governance-style restrictions enforced at the gateway: a
+document of its own, written to sys/policies/mcp/<name> and attached to the
+token alongside the capability policy that grants the path, whose stanzas group
+allow- and deny-lists by what they govern — methods, tools, resources, prompts —
+plus a CEL condition over the call arguments. An MCP policy only ever narrows:
+the request must already be allowed by a capability policy. Enforcement is
 body-authoritative — Warden strict-parses the JSON-RPC request body and matches
 against the parsed body, never against client-supplied request headers. The
 parser rejects malformed bodies, duplicate keys at any depth, empty batches, and
@@ -185,12 +188,12 @@ structured tool-call failure.
 
 Body parsing runs only for POST requests carrying Content-Type
 application/json. Other request shapes do not produce a parsed body descriptor:
-when a policy in scope binds an mcp { } block to a path that also receives
-non-POST or non-JSON traffic, those requests deny with rule_type missing_body.
-Operators scope mcp { } blocks to paths they expect to carry JSON-RPC POSTs.
+when an MCP policy stanza covers a path that also receives non-POST or non-JSON
+traffic, those requests deny with rule_type missing_body. Operators scope MCP
+stanzas to paths they expect to carry JSON-RPC POSTs.
 
-Policies without an mcp { } block in scope skip the strict parser entirely
-— no body buffering or parsing is performed on those paths.
+Paths with no MCP stanza in scope skip the strict parser entirely — no body
+buffering or parsing is performed on them.
 
 Configuration:
 - mcp_url: MCP server base URL (required; no default)

--- a/provider/mcp_aws/provider.go
+++ b/provider/mcp_aws/provider.go
@@ -16,17 +16,17 @@ import (
 	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 )
 
-// Compile-time assertion: mcp_aws opts into CBP `mcp { }` body-authoritative
-// policy enforcement. Without this assertion the core's request handler type-
+// Compile-time assertion: mcp_aws opts into body-authoritative MCP policy
+// enforcement. Without this assertion the core's request handler type-
 // asserts to logical.MCPPolicyEnforced, fails silently, skips body extraction,
-// and any mcp { } block bound to an mcp_aws path becomes a no-op. The unit
+// and any MCP stanza covering an mcp_aws path becomes a no-op. The unit
 // test in provider_test.go also asserts this at the type level so an
 // accidental refactor that drops the method surfaces as a compile error in
 // the test, not as a quiet over-permission at runtime.
 var _ logical.MCPPolicyEnforced = (*mcpAWSBackend)(nil)
 
-// ShouldEnforceMCPPolicy reports whether this request is subject to mcp { }
-// body-authoritative policy enforcement. The gate matches the generic mcp
+// ShouldEnforceMCPPolicy reports whether this request is subject to
+// body-authoritative MCP policy enforcement. The gate matches the generic mcp
 // provider exactly: JSON-RPC POSTs only. GET (SSE reconnect) and DELETE (session
 // close), and any non-JSON Content-Type, decline and pass through under
 // credential-scope-only enforcement (IAM here, bearer-token scopes there).

--- a/provider/sdk/httpproxy/provider.go
+++ b/provider/sdk/httpproxy/provider.go
@@ -179,8 +179,8 @@ type ProviderSpec struct {
 	// StreamUnauthenticated guard).
 	IsUnauthenticatedRequest func(r *http.Request, path string) bool
 
-	// ShouldEnforceMCPPolicy optionally opts this provider into CBP
-	// `mcp { }` body-authoritative policy enforcement. When set, the
+	// ShouldEnforceMCPPolicy optionally opts this provider into
+	// body-authoritative MCP policy enforcement. When set, the
 	// core handler calls this hook on every request matched to this
 	// backend; if it returns true the request body is buffered and
 	// strict-parsed as JSON-RPC before policy evaluation runs. The


### PR DESCRIPTION
**PR 3 of 4.** Stacked on #585. **Breaking**, but semantics are unchanged.

The `mcp { }` block nested inside a `path` stanza is gone. A capability policy carrying one is rejected at parse with a message naming its replacement, and `AllowOperation` now reads its rule-sets from the MCP index instead of from the winning capability node.

**Semantics are identical to before:** a path with no MCP rules in scope still imposes no MCP governance. Inverting that default is PR 4, and it has to ship in the same release as this one — see below.

## Review gate

**No test expectation changes.** ~82 inline policy strings change shape across six files and not one assertion moves:

```
git diff -U0 core/policy_mcp_eval_test.go core/policy_mcp_e2e_test.go \
  core/policy_mcp_list_filter_test.go core/policy_cel_mcp_test.go \
  | grep -E '^[-+].*(assert\.|require\.)'
```

returns nothing. **If any assertion is edited in this diff, the mechanical move changed behavior and something is wrong.**

## Notes for review

- The rejection sits immediately after `DecodeObject` rather than beside the other rule handling, because the deny capability jumps to `PathFinished`; a check placed there would let a denying stanza carry the removed block forever without a word. Pinned by `TestParseCBPPolicy_RejectsMCPBlockOnDenyStanza`.
- Because rule-sets now come from an independent lookup, the capability stanza and the MCP stanza no longer have to be spelled the same way. **One documented exception to "behavior-preserving":** a stanza that shadows a broader one carrying MCP rules used to escape them and no longer does. The direction is deny-only, so nothing that was governed becomes ungoverned.
- `MCPDecision` gains `PolicyName`, naming the contract the reported rule came from — with contracts as separate documents, the matched rule alone no longer says which document to edit. Its meaning differs by outcome and the doc comment says so: on allow it is the first contract that permitted the call; on deny it is the source of the most informative refusal rather than the sole cause, since every contract refused. Empty on structural denies.
- Parse coverage the new parser's own tests already cover is dropped rather than duplicated. What was unique to the old file (trailing/bare star acceptance, multiple stanzas at one path) moves across, joined by pins for the rejection itself.

## Release constraint

This PR and PR 4 **must ship in the same release.** Two reasons:

1. A release carrying this alone breaks stored policies while still being fail-open — all of the migration pain, none of the security gain.
2. `expiration` on an MCP stanza drops it at parse, mechanically like a capability stanza but in the opposite direction: dropping an expired capability stanza removes a *grant* (fails closed), while dropping an expired MCP stanza removes a *restriction*. Under this PR alone, a time-boxed tool contract that lapses leaves its path ungoverned.

## Migration

Split every policy carrying an `mcp { }` block in two. Keep the `path` stanza with its `capabilities` as the capability policy; move the block contents into an MCP policy at the same path, regrouped into `methods`/`tools`/`resources`/`prompts` blocks. Write it with `warden policy write -type mcp <name> <file>` and add that name to the role's `token_policies` alongside the existing one.

There is no compatibility window: a stored policy still carrying the block fails to parse when next loaded, which surfaces as an error on every request by a token that carries it.

## Verification

`go test ./... -count=1` green with no assertion edits. Full e2e suite green.
