### PR TITLE
feat(policy)!: deny MCP traffic with no policy in scope

### DIFF
--- a/core/policy_cbp.go
+++ b/core/policy_cbp.go
@@ -64,11 +64,12 @@ type CBPResults struct {
 	GrantingPolicies       []sdklogical.PolicyInfo
 	ResponseKeysFilterPath string
 
-	// MCPDecision is populated whenever an mcp { } rule-set was
-	// consulted during AllowOperation, on every branch (allow and
-	// deny) so the audit and deny-response layers can render the
-	// decision unconditionally. Nil when no rule-set applied (the
-	// vast majority of requests — every non-MCP provider).
+	// MCPDecision is populated on every branch of the MCP gate, allow and
+	// deny, so the audit and deny-response layers can render the decision
+	// unconditionally. That covers two cases: a rule-set was consulted, or an
+	// MCP-shaped request met no rule-set at all and was denied with
+	// no_mcp_policy. Nil for everything else — every non-MCP provider, and the
+	// body-less verbs an MCP mount serves alongside its JSON-RPC POSTs.
 	//
 	// Invariant: when MCPDecision.Decision == "deny", Allowed is
 	// false. The reverse (Allowed=false with Decision="allow") is
@@ -552,8 +553,8 @@ CHECK:
 
 	// MCP rule-set evaluation, body-authoritative. Runs after
 	// conditions (so source-IP / time gates apply first) and before
-	// parameter validation. Populates ret.MCPDecision on every branch
-	// when a rule-set was consulted, so the audit layer sees the
+	// parameter validation. Populates ret.MCPDecision on every branch it
+	// takes — including the absence deny below — so the audit layer sees the
 	// decision whether the request was allowed or denied.
 	//
 	// The rule-sets come from the MCP index, a lookup independent of the one

--- a/core/policy_cbp.go
+++ b/core/policy_cbp.go
@@ -400,7 +400,14 @@ func (a *CBP) Capabilities(ctx context.Context, path string) (pathCapabilities [
 func (a *CBP) AllowOperation(ctx context.Context, req *logical.Request, te *logical.TokenEntry, capCheckOnly bool) (ret *CBPResults) {
 	ret = new(CBPResults)
 
-	// Fast-path root
+	// Fast-path root.
+	//
+	// This returns before the MCP gate, so a root token is not subject to tool
+	// contracts — deliberately, and consistently with root already bypassing
+	// explicit deny capabilities and path conditions. Root is the break-glass
+	// path: making it answer to a contract would mean a misconfigured MCP
+	// policy could lock an operator out of the mount that has to be used to fix
+	// it. Agents hold real tokens, not root.
 	if a.root {
 		ret.Allowed = true
 		ret.RootPrivs = true
@@ -559,7 +566,9 @@ CHECK:
 	// logical.MCPPolicyEnforced. A nil descriptor here means either
 	// the routed backend doesn't implement the marker, or it declined
 	// the request (wrong method / Content-Type) — fail closed.
-	if mcpSets := a.mcpRulesForPath(path); len(mcpSets) > 0 {
+	mcpSets := a.mcpRulesForPath(path)
+	switch {
+	case len(mcpSets) > 0:
 		ret.MCPDecision = decideMCP(mcpSets, req, te, now, ns.Path)
 		if ret.MCPDecision != nil && ret.MCPDecision.Decision == "deny" {
 			return ret
@@ -574,6 +583,20 @@ CHECK:
 				return ret
 			}
 		}
+
+	case mcpDescriptorPopulated(req):
+		// An MCP-shaped request with no contract in scope. The capability
+		// grant said the caller may reach this mount; nothing has said which
+		// calls are permitted on it, so none are. Opening a mount deliberately
+		// is an explicit wildcard MCP policy, which stays visible in a policy
+		// listing and in audit — unlike the absence this replaces, which used
+		// to read as "unrestricted" and was indistinguishable from an operator
+		// forgetting to attach the contract.
+		ret.MCPDecision = &logical.MCPDecision{
+			Decision: "deny",
+			RuleType: mcpRuleTypeNoMCPPolicy,
+		}
+		return ret
 	}
 
 	ret.GrantingPolicies = grantingPolicies

--- a/core/policy_cbp_test.go
+++ b/core/policy_cbp_test.go
@@ -1396,6 +1396,52 @@ path "other/*" { capabilities = ["read"] }
 			}
 		})
 	}
+
+	// A compile is per request — CBP() rebuilds from cached policies every
+	// time — so what a contract adds here is paid on every call, not once.
+	// Compared against 2-policies rather than 3, this isolates the second
+	// index from the extra document.
+	mcpRules := `
+path "prov/gateway*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { allowed = ["get_repository", "list_issues"] }
+}
+path "prov/role/+/gateway*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { allowed = ["get_repository", "list_issues"] }
+}
+`
+	mixed := make([]*Policy, 0, 3)
+	for i := 0; i < 2; i++ {
+		p, err := ParseCBPPolicy(namespace.RootNamespace, rules)
+		if err != nil {
+			b.Fatal(err)
+		}
+		p.Name = fmt.Sprintf("p%d", i)
+		mixed = append(mixed, p)
+	}
+	contract, err := ParseMCPPolicy(namespace.RootNamespace, mcpRules)
+	if err != nil {
+		b.Fatal(err)
+	}
+	contract.Name = "contract"
+
+	b.Run("2-policies", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := NewCBP(ctx, mixed); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	withContract := append(append([]*Policy(nil), mixed...), contract)
+	b.Run("2-policies+1-mcp", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := NewCBP(ctx, withContract); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }
 
 // TestCBP_CompilationIsOrderIndependent pins that a token's policies compile to

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -225,15 +225,25 @@ func attachMCPListFilter(req *logical.Request, sets []*CBPMCPRules) *logical.MCP
 }
 
 // mcpKeepsEveryItem reports whether the keep-predicate would admit every
-// possible name, making the filter a no-op.
+// possible name, making the filter a no-op worth skipping.
 //
-// Because mcpListItemAllowed ORs across sets, one unconstrained set is enough:
-// its method gate must pass for the mapped call method, its allow-list must
-// carry the bare `*`, and its deny-list must be empty. A deny entry anywhere in
-// that set can exclude a name, so the filter stays.
+// It models mcpListItemAllowed exactly, and must keep doing so: that predicate
+// runs evaluateMCPGates only, which for a fixed callMethod can refuse a name in
+// three ways — a denied_methods match, an allowed_methods miss, or the family
+// gate. One set clearing all three admits every name, and since the predicate
+// ORs across sets, one is enough.
+//
+// Conditions are deliberately not considered, because the predicate does not
+// consider them either: list responses carry no call arguments, so a
+// condition-gated tool stays listed and is refused at call time instead.
+// Treating a condition as a reason to keep the filter would buffer the whole
+// response to prune nothing. If list filtering ever becomes condition-aware,
+// this has to change with it.
 func mcpKeepsEveryItem(sets []*CBPMCPRules, callMethod string) bool {
 	for _, set := range sets {
-		if len(set.DeniedMethods) > 0 || set.Condition != nil {
+		// Only a deny entry that can actually match this method excludes a
+		// name; an unrelated one cannot.
+		if matchMCPAny(callMethod, set.DeniedMethods) != "" {
 			continue
 		}
 		if matchMCPAny(callMethod, set.AllowedMethods) == "" {
@@ -269,24 +279,24 @@ func mcpDescriptorPopulated(req *logical.Request) bool {
 }
 
 // decideMCP is the production entry point called from
-// AllowOperation when the matched permissions carry a non-empty
-// mcp { } rule-set slice. It bridges req.MCPDescriptor's four
+// AllowOperation when the MCP index returned a non-empty rule-set
+// slice for the request path. It bridges req.MCPDescriptor's four
 // terminal states to MCPDecision (see extractMCPDescriptor for how
 // each state is produced):
 //
 //   - Nil descriptor — no MCP-aware backend handled this request.
-//     If an operator bound mcp{} to a non-MCP path, that's a misconfig
-//     and we fail closed with missing_body. This is the safety net.
+//     If an operator bound a contract to a non-MCP path, that's a
+//     misconfig and we fail closed with missing_body. The safety net.
 //
 //   - Non-nil, empty descriptor (Calls nil, ParseErr nil) — the
 //     backend is MCP-aware but ShouldEnforceMCPPolicy declined for
 //     this request (typically a non-POST verb, or a non-JSON
-//     Content-Type). The mcp{} block is body-authoritative; a verb
-//     with no body cannot be governed by method/tool/param allow-
-//     lists, so we return nil to skip mcp{} evaluation and let the
-//     cap-level check decide. This is what makes MCP Streamable
-//     HTTP's GET (notification SSE stream) and DELETE (session
-//     terminate) work on the same URL that POST gates.
+//     Content-Type). A contract is body-authoritative; a verb with no
+//     body cannot be governed by method/tool allow-lists, so we
+//     return nil to skip evaluation and let the cap-level check
+//     decide. This is what makes MCP Streamable HTTP's GET
+//     (notification SSE stream) and DELETE (session terminate) work
+//     on the same URL that POST gates.
 //
 //   - descriptor.ParseErr non-nil — strict JSON-RPC parse failed.
 //     Deny with the typed rule_type (malformed_jsonrpc, duplicate_key,

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -57,6 +58,17 @@ const (
 	// than stream an unfiltered list. (JSON-RPC batching was dropped from
 	// the MCP spec in 2025-06-18.)
 	mcpRuleTypeBatchListUnfilterable = "batch_list_unfilterable"
+
+	// mcpRuleTypeNoMCPPolicy denies an MCP-shaped request on a path with no
+	// MCP policy in scope. It is produced by AllowOperation before any
+	// rule-set is chosen — there is none — so unlike every other rule type it
+	// carries no matched rule and no policy name.
+	//
+	// This is the absence rule, distinct from the deny-by-default *inside* a
+	// rule-set: an empty allow-list refuses every call the set covers, while
+	// this refuses calls no set covers at all. Together they mean MCP traffic
+	// always answers to an explicit contract.
+	mcpRuleTypeNoMCPPolicy = "no_mcp_policy"
 )
 
 // MCP JSON-RPC method names that carry name-bearing semantics. For
@@ -193,6 +205,16 @@ func attachMCPListFilter(req *logical.Request, sets []*CBPMCPRules) *logical.MCP
 	if !ok {
 		return nil
 	}
+
+	// A filter that keeps everything is not free: the gateway has to buffer the
+	// whole upstream response to rewrite it, and fails closed above
+	// max_body_size. Attaching one to a deliberately unrestricted mount would
+	// make the sanctioned wildcard contract more brittle than the absence it
+	// replaces, so skip it and leave the response streaming.
+	if mcpKeepsEveryItem(sets, callMethod) {
+		return nil
+	}
+
 	req.MCPListFilter = &logical.MCPListFilter{
 		ListMethod: method,
 		Keep: func(name string) bool {
@@ -200,6 +222,50 @@ func attachMCPListFilter(req *logical.Request, sets []*CBPMCPRules) *logical.MCP
 		},
 	}
 	return nil
+}
+
+// mcpKeepsEveryItem reports whether the keep-predicate would admit every
+// possible name, making the filter a no-op.
+//
+// Because mcpListItemAllowed ORs across sets, one unconstrained set is enough:
+// its method gate must pass for the mapped call method, its allow-list must
+// carry the bare `*`, and its deny-list must be empty. A deny entry anywhere in
+// that set can exclude a name, so the filter stays.
+func mcpKeepsEveryItem(sets []*CBPMCPRules, callMethod string) bool {
+	for _, set := range sets {
+		if len(set.DeniedMethods) > 0 || set.Condition != nil {
+			continue
+		}
+		if matchMCPAny(callMethod, set.AllowedMethods) == "" {
+			continue
+		}
+		denyList, allowList := nameListForMethod(set, callMethod)
+		if len(denyList) > 0 {
+			continue
+		}
+		if slices.Contains(allowList, "*") {
+			return true
+		}
+	}
+	return false
+}
+
+// mcpDescriptorPopulated reports whether the extractor produced a descriptor
+// carrying an actual JSON-RPC body — parsed calls, or a typed parse failure.
+//
+// This is the predicate that separates "MCP-shaped request" from everything
+// else, and it is deliberately narrow. A nil descriptor means the routed
+// backend does not implement MCPPolicyEnforced at all, which covers every
+// non-MCP mount. The empty sentinel means the backend declined this particular
+// request — the body-less verbs MCP Streamable HTTP puts on the same URL as the
+// POST (GET for the notification stream, DELETE to close the session), and
+// every httpproxy provider whose spec leaves the enforcement hook unset.
+// Neither can be judged against a tool contract, so neither is treated as one.
+func mcpDescriptorPopulated(req *logical.Request) bool {
+	if req == nil || req.MCPDescriptor == nil {
+		return false
+	}
+	return req.MCPDescriptor.Calls != nil || req.MCPDescriptor.ParseErr != nil
 }
 
 // decideMCP is the production entry point called from
@@ -566,7 +632,11 @@ func mcpDenyRank(ruleType string) int {
 		mcpRuleTypeOversizedBody,
 		mcpRuleTypeBatchEmpty,
 		mcpRuleTypeMalformedParams,
-		mcpRuleTypeBatchListUnfilterable:
+		mcpRuleTypeBatchListUnfilterable,
+		// Never actually competes — it is produced outside evaluateMCPCall,
+		// where there are no rule-sets to rank against. Listed so the ranking
+		// stays total over the rule-type domain.
+		mcpRuleTypeNoMCPPolicy:
 		return 4
 	case mcpRuleTypeDeniedMethods,
 		mcpRuleTypeDeniedTools,
@@ -650,6 +720,13 @@ func BuildMCPDenyDescription(d *logical.MCPDecision) string {
 		return "Batched list requests are not supported."
 	case mcpRuleTypeMissingMethod:
 		return "Request method required."
+	case mcpRuleTypeNoMCPPolicy:
+		// Names the misconfiguration rather than the call. Every other message
+		// answers "what did I ask for that was refused?"; this one answers
+		// "nothing here is permitted yet", which is the actionable difference
+		// between a too-narrow contract and no contract at all. It discloses
+		// only that none is attached, never any rule shape.
+		return "No MCP policy permits this request."
 	}
 	return "Request denied by policy."
 }

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -1200,3 +1200,83 @@ func buildStressPolicy(sets, patternsPerList int) string {
 	}
 	return sb.String()
 }
+
+// BenchmarkAllowOperation_MCPNoContract measures the absence deny: an
+// MCP-shaped request on a granted path with no contract in scope. This is the
+// cost of the second index lookup missing, which every ungoverned MCP request
+// now pays before being refused.
+func BenchmarkAllowOperation_MCPNoContract(b *testing.B) {
+	cbp := buildBenchCBP(b, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`)
+	req := newMCPRequest(b, "mcp/gateway/", `{
+		"jsonrpc": "2.0",
+		"method":  "tools/call",
+		"params":  {"name": "get_repository"},
+		"id":      1
+	}`)
+	ctx := testContext()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cbp.AllowOperation(ctx, req, nil, false)
+	}
+}
+
+// BenchmarkAllowOperation_MCPNoCondition isolates the contract's structural
+// gates from CEL. Paired with TypicalMCP — same shape, minus the condition —
+// it says how much of an MCP request's cost is the condition rather than the
+// method and name matching.
+func BenchmarkAllowOperation_MCPNoCondition(b *testing.B) {
+	cbp := buildBenchCBPWithMCP(b, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call", "resources/list", "resources/read", "prompts/get"] }
+  tools { allowed = [
+      "get_repository", "get_pull_request", "list_issues", "list_pull_requests",
+      "search_code", "search_issues", "search_repositories", "list_workflows",
+      "list_commits", "get_file_contents",
+    ] }
+}
+`)
+	req := newMCPRequest(b, "mcp/gateway/", `{
+		"jsonrpc": "2.0",
+		"method":  "tools/call",
+		"params": {
+			"name": "get_repository",
+			"arguments": {"path": "docs/api.md", "mode": "0644", "region": "us-west1"}
+		},
+		"id": 1
+	}`)
+	ctx := testContext()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cbp.AllowOperation(ctx, req, nil, false)
+	}
+}
+
+// BenchmarkAllowOperation_NonMCPWithContractAttached measures what a contract
+// costs a request it does not govern — a plain path read by a token that also
+// carries an MCP policy. The index is built but never consulted for this path.
+func BenchmarkAllowOperation_NonMCPWithContractAttached(b *testing.B) {
+	cbp := buildBenchCBPWithMCP(b, `
+path "secret/data/*" {
+  capabilities = ["read"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["get_repository"] }
+}
+`)
+	req := &logical.Request{Path: "secret/data/app", Operation: logical.ReadOperation}
+	ctx := testContext()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = cbp.AllowOperation(ctx, req, nil, false)
+	}
+}

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -286,9 +286,12 @@ path "mcp/gateway/*" {
 	assert.Equal(t, mcpRuleTypeDeniedMethods, res.MCPDecision.RuleType)
 }
 
-func TestMCPEval_NoMCPBlock_PassesThrough(t *testing.T) {
-	// A policy with no mcp { } block leaves MCPDecision nil — the
-	// MCP gate doesn't run, the request goes through to the proxy.
+func TestMCPEval_NoMCPPolicy_Denies(t *testing.T) {
+	// A capability grant with no contract in scope refuses MCP-shaped traffic.
+	// The grant says the caller may reach the mount; nothing says which calls
+	// are permitted on it, so none are. (Was a clean pass-through before the
+	// absence flip — that default was indistinguishable from an operator
+	// forgetting to attach the contract.)
 	cbp := mustCBP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
@@ -301,8 +304,29 @@ path "mcp/gateway/*" {
 	}`)
 	res := cbp.AllowOperation(testContext(), req, nil, false)
 
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "deny", res.MCPDecision.Decision)
+	assert.Equal(t, mcpRuleTypeNoMCPPolicy, res.MCPDecision.RuleType)
+	assert.Empty(t, res.MCPDecision.MatchedRule, "no rule-set was chosen")
+	assert.Empty(t, res.MCPDecision.PolicyName, "no policy to name")
+}
+
+func TestMCPEval_NoMCPPolicy_NonMCPTrafficUnaffected(t *testing.T) {
+	// The absence deny keys on an MCP-shaped body, not on the path. A request
+	// with no descriptor at all — every non-MCP mount — is untouched.
+	cbp := mustCBP(t, `
+path "secret/data/*" {
+  capabilities = ["read"]
+}
+`)
+	res := cbp.AllowOperation(testContext(), &logical.Request{
+		Path:      "secret/data/app",
+		Operation: logical.ReadOperation,
+	}, nil, false)
+
 	assert.True(t, res.Allowed)
-	assert.Nil(t, res.MCPDecision, "no mcp block → no decision recorded")
+	assert.Nil(t, res.MCPDecision)
 }
 
 // =============================================================================

--- a/core/policy_mcp_index_test.go
+++ b/core/policy_mcp_index_test.go
@@ -566,6 +566,19 @@ path "mcp/gateway/*" {
 		assert.Equal(t, mcpRuleTypeNoMCPPolicy, res.MCPDecision.RuleType)
 	})
 
+	t.Run("batch denies", func(t *testing.T) {
+		// A batch is as MCP-shaped as a single call; nothing about the absence
+		// deny depends on there being exactly one.
+		req := newMCPRequest(t, "mcp/gateway/", `[
+			{"jsonrpc":"2.0","method":"tools/call","params":{"name":"a"},"id":1},
+			{"jsonrpc":"2.0","method":"tools/call","params":{"name":"b"},"id":2}
+		]`)
+		res := cbp.AllowOperation(testContext(), req, nil, false)
+		assert.False(t, res.Allowed)
+		require.NotNil(t, res.MCPDecision)
+		assert.Equal(t, mcpRuleTypeNoMCPPolicy, res.MCPDecision.RuleType)
+	})
+
 	t.Run("parse failure denies", func(t *testing.T) {
 		// A malformed body is populated too, so it is refused rather than
 		// proxied. It reports the absence, not the malformation — the contract
@@ -576,6 +589,55 @@ path "mcp/gateway/*" {
 		require.NotNil(t, res.MCPDecision)
 		assert.Equal(t, mcpRuleTypeNoMCPPolicy, res.MCPDecision.RuleType)
 	})
+}
+
+// TestMCPAbsenceDeny_NamespaceScoped covers the absence deny where the path key
+// carries a namespace prefix. PR 4 is the first place absence itself decides an
+// outcome, so the namespaced lookup is worth pinning on both sides: a contract
+// in the namespace governs, and the same mount without one refuses.
+func TestMCPAbsenceDeny_NamespaceScoped(t *testing.T) {
+	core := createTestCore(t)
+	ps := core.policyStore
+	rootCtx := testContext()
+
+	child := &namespace.Namespace{Path: "team-a/"}
+	require.NoError(t, core.namespaceStore.SetNamespace(rootCtx, child))
+	nsCtx := namespace.ContextWithNamespace(context.Background(), child)
+
+	grant, err := ParseCBPPolicy(child, `path "mcp/gateway/*" { capabilities = ["update"] }`)
+	require.NoError(t, err)
+	grant.Name = "ns-grant"
+	require.NoError(t, ps.SetPolicy(nsCtx, grant, nil))
+
+	// The request path is namespace-relative; AllowOperation prefixes it.
+	req := func() *logical.Request {
+		return newMCPRequest(t, "mcp/gateway/",
+			`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x"},"id":1}`)
+	}
+
+	ungoverned, err := ps.CBP(nsCtx, map[string][]string{child.ID: {"ns-grant"}})
+	require.NoError(t, err)
+	res := ungoverned.AllowOperation(nsCtx, req(), nil, false)
+	assert.False(t, res.Allowed, "a namespaced mount with no contract refuses too")
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeNoMCPPolicy, res.MCPDecision.RuleType)
+
+	contract, err := ParseMCPPolicy(child, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["x"] }
+}
+`)
+	require.NoError(t, err)
+	contract.Name = "ns-contract"
+	require.NoError(t, ps.SetPolicy(nsCtx, contract, nil))
+
+	governed, err := ps.CBP(nsCtx, map[string][]string{child.ID: {"ns-grant", "ns-contract"}})
+	require.NoError(t, err)
+	ok := governed.AllowOperation(nsCtx, req(), nil, false)
+	assert.True(t, ok.Allowed, "the namespaced contract governs the namespaced path")
+	require.NotNil(t, ok.MCPDecision)
+	assert.Equal(t, "allow", ok.MCPDecision.Decision)
 }
 
 func testPastTime() time.Time {

--- a/core/policy_mcp_index_test.go
+++ b/core/policy_mcp_index_test.go
@@ -203,8 +203,9 @@ path "mcp/gateway/*" {
 		`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"forbidden"},"id":1}`)
 
 	base := withoutMCP.AllowOperation(testContext(), denied, nil, false)
-	assert.True(t, base.Allowed, "no contract in scope: the grant alone still decides")
-	assert.Nil(t, base.MCPDecision)
+	assert.False(t, base.Allowed, "no contract in scope: nothing permits the call")
+	require.NotNil(t, base.MCPDecision)
+	assert.Equal(t, mcpRuleTypeNoMCPPolicy, base.MCPDecision.RuleType)
 
 	gated := withMCP.AllowOperation(testContext(), denied, nil, false)
 	assert.False(t, gated.Allowed, "the contract is consulted through the index")
@@ -506,6 +507,75 @@ path "mcp/gateway/*" {
 	require.NotNil(t, res.MCPDecision)
 	assert.Equal(t, mcpRuleTypeMalformedJSONRPC, res.MCPDecision.RuleType)
 	assert.Empty(t, res.MCPDecision.PolicyName)
+}
+
+// TestMCPAbsenceDeny_RootBypasses pins that a root token still reaches an
+// MCP-shaped request with no contract in scope. Root is the break-glass path:
+// making it answer to a contract would let a misconfigured MCP policy lock an
+// operator out of the mount they need to fix it.
+func TestMCPAbsenceDeny_RootBypasses(t *testing.T) {
+	rootPolicy := &Policy{Name: "root", Type: PolicyTypeCBP, namespace: namespace.RootNamespace}
+	cbp, err := NewCBP(testContext(), []*Policy{rootPolicy})
+	require.NoError(t, err)
+
+	req := newMCPRequest(t, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"anything"},"id":1}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.True(t, res.Allowed)
+	assert.True(t, res.IsRoot)
+	assert.Nil(t, res.MCPDecision, "root returns before the MCP gate")
+	assert.Nil(t, req.MCPListFilter)
+}
+
+// TestMCPAbsenceDeny_DescriptorStates walks the states the extractor can
+// produce against a path with no contract, because only one of them denies.
+func TestMCPAbsenceDeny_DescriptorStates(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`)
+	base := func() *logical.Request {
+		return &logical.Request{Path: "mcp/gateway/", Operation: logical.UpdateOperation}
+	}
+
+	t.Run("nil descriptor passes", func(t *testing.T) {
+		// Every non-MCP mount: the backend does not implement the marker.
+		res := cbp.AllowOperation(testContext(), base(), nil, false)
+		assert.True(t, res.Allowed)
+		assert.Nil(t, res.MCPDecision)
+	})
+
+	t.Run("empty sentinel passes", func(t *testing.T) {
+		// The body-less verbs on an MCP URL, and every httpproxy provider whose
+		// spec leaves the enforcement hook unset.
+		req := base()
+		req.MCPDescriptor = &logical.MCPRequestDescriptor{}
+		res := cbp.AllowOperation(testContext(), req, nil, false)
+		assert.True(t, res.Allowed)
+		assert.Nil(t, res.MCPDecision)
+	})
+
+	t.Run("populated denies", func(t *testing.T) {
+		req := newMCPRequest(t, "mcp/gateway/",
+			`{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+		res := cbp.AllowOperation(testContext(), req, nil, false)
+		assert.False(t, res.Allowed)
+		require.NotNil(t, res.MCPDecision)
+		assert.Equal(t, mcpRuleTypeNoMCPPolicy, res.MCPDecision.RuleType)
+	})
+
+	t.Run("parse failure denies", func(t *testing.T) {
+		// A malformed body is populated too, so it is refused rather than
+		// proxied. It reports the absence, not the malformation — the contract
+		// that would have judged the body does not exist.
+		req := newMCPRequest(t, "mcp/gateway/", `{"jsonrpc":"2.0","method":`)
+		res := cbp.AllowOperation(testContext(), req, nil, false)
+		assert.False(t, res.Allowed)
+		require.NotNil(t, res.MCPDecision)
+		assert.Equal(t, mcpRuleTypeNoMCPPolicy, res.MCPDecision.RuleType)
+	})
 }
 
 func testPastTime() time.Time {

--- a/core/policy_mcp_list_filter_test.go
+++ b/core/policy_mcp_list_filter_test.go
@@ -65,7 +65,12 @@ path "mcp/gateway/*" {
 	assert.False(t, keep("anything"))
 }
 
-func TestListFilter_StarKeepsEverything(t *testing.T) {
+// TestListFilter_WildcardContractAttachesNoFilter covers the deliberately
+// unrestricted mount. A keep-everything predicate is not free — the gateway
+// buffers the whole upstream response to rewrite it, and fails closed above
+// max_body_size — so the wildcard contract must leave the response streaming
+// exactly as an ungoverned path used to.
+func TestListFilter_WildcardContractAttachesNoFilter(t *testing.T) {
 	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
@@ -76,10 +81,60 @@ path "mcp/gateway/*" {
   tools { allowed = ["*"] }
 }
 `)
+	req := newMCPRequest(t, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.True(t, res.Allowed)
+	assert.Nil(t, req.MCPListFilter,
+		"a filter that keeps everything is skipped, not attached")
+}
+
+// TestListFilter_PartialWildcardStillFilters is the other half: a deny entry
+// anywhere in the family means some name can be excluded, so the filter stays.
+func TestListFilter_PartialWildcardStillFilters(t *testing.T) {
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools {
+    allowed = ["*"]
+    denied  = ["delete_everything"]
+  }
+}
+`)
 	keep := filterKeeps(t, cbp, "mcp/gateway/",
 		`{"jsonrpc":"2.0","method":"tools/list","id":1}`, "tools/list")
 
-	assert.True(t, keep("delete_everything"))
+	assert.True(t, keep("get_repository"))
+	assert.False(t, keep("delete_everything"))
+}
+
+// TestListFilter_WildcardWithConditionStillFilters pins the other exclusion: a
+// per-call condition can refuse a name at call time, so "visible == callable"
+// requires the filter to stay even though the allow-list is a bare star.
+func TestListFilter_WildcardWithConditionStillFilters(t *testing.T) {
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/list", "tools/call"] }
+  tools { allowed = ["*"] }
+  condition = "call.args.?env.orValue('') != 'prod'"
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.True(t, res.Allowed)
+	assert.NotNil(t, req.MCPListFilter,
+		"a conditioned contract is not unconstrained, so the filter stays")
 }
 
 func TestListFilter_ToolsListAllowedButNotToolsCall_EmptyList(t *testing.T) {
@@ -228,9 +283,11 @@ path "mcp/gateway/*" {
 	assert.Nil(t, req.MCPListFilter, "cap-check-only must not attach a filter")
 }
 
-func TestListFilter_NotAttachedWithoutMCPBlock(t *testing.T) {
-	// A path without an mcp{} block imposes no MCP governance (opt-in), so a
-	// tools/list request streams through unfiltered.
+func TestListFilter_NoMCPPolicyDeniesTheListing(t *testing.T) {
+	// A path with no contract in scope refuses the listing outright rather than
+	// streaming it unfiltered. An agent gets an explicit misconfiguration
+	// signal instead of a catalog it was never meant to see. (Before the
+	// absence flip this passed through with no filter attached.)
 	cbp := mustCBP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
@@ -240,6 +297,8 @@ path "mcp/gateway/*" {
 		`{"jsonrpc":"2.0","method":"tools/list","id":1}`)
 	res := cbp.AllowOperation(testContext(), req, nil, false)
 
-	assert.True(t, res.Allowed)
-	assert.Nil(t, req.MCPListFilter, "no mcp{} block → no filter")
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeNoMCPPolicy, res.MCPDecision.RuleType)
+	assert.Nil(t, req.MCPListFilter, "a denied listing never reaches the filter")
 }

--- a/core/policy_mcp_list_filter_test.go
+++ b/core/policy_mcp_list_filter_test.go
@@ -113,10 +113,15 @@ path "mcp/gateway/*" {
 	assert.False(t, keep("delete_everything"))
 }
 
-// TestListFilter_WildcardWithConditionStillFilters pins the other exclusion: a
-// per-call condition can refuse a name at call time, so "visible == callable"
-// requires the filter to stay even though the allow-list is a bare star.
-func TestListFilter_WildcardWithConditionStillFilters(t *testing.T) {
+// TestListFilter_WildcardWithConditionAttachesNoFilter pins that a per-call
+// condition does not by itself keep the filter.
+//
+// It is tempting to reason that a condition can refuse a call, so the listing
+// should be pruned — but list filtering deliberately skips CEL, because a
+// listing carries no call arguments to evaluate against. A condition-gated tool
+// stays listed either way and is refused at call time. Keeping the filter here
+// would buffer the whole response to prune nothing.
+func TestListFilter_WildcardWithConditionAttachesNoFilter(t *testing.T) {
 	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]
@@ -133,8 +138,57 @@ path "mcp/gateway/*" {
 	res := cbp.AllowOperation(testContext(), req, nil, false)
 
 	assert.True(t, res.Allowed)
-	assert.NotNil(t, req.MCPListFilter,
-		"a conditioned contract is not unconstrained, so the filter stays")
+	assert.Nil(t, req.MCPListFilter,
+		"the keep-predicate ignores conditions, so this filter would prune nothing")
+}
+
+// TestListFilter_UnrelatedDeniedMethodStillSkips pins the other refinement: a
+// denied_methods entry that cannot match the mapped call method cannot exclude
+// a name either, so it does not force the filter back on.
+func TestListFilter_UnrelatedDeniedMethodStillSkips(t *testing.T) {
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods {
+    allowed = ["tools/list", "tools/call"]
+    denied  = ["prompts/get"]
+  }
+  tools { allowed = ["*"] }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/list","id":1}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.True(t, res.Allowed)
+	assert.Nil(t, req.MCPListFilter,
+		"a deny on an unrelated method cannot exclude a tool name")
+}
+
+// TestListFilter_DeniedCallMethodKeepsFilter is the boundary of the above: when
+// the deny entry does match the mapped call method, nothing is callable, so the
+// filter stays and empties the listing.
+func TestListFilter_DeniedCallMethodKeepsFilter(t *testing.T) {
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods {
+    allowed = ["tools/list", "tools/call"]
+    denied  = ["tools/call"]
+  }
+  tools { allowed = ["*"] }
+}
+`)
+	keep := filterKeeps(t, cbp, "mcp/gateway/",
+		`{"jsonrpc":"2.0","method":"tools/list","id":1}`, "tools/list")
+
+	assert.False(t, keep("anything"), "tools/call is denied, so no tool is callable")
 }
 
 func TestListFilter_ToolsListAllowedButNotToolsCall_EmptyList(t *testing.T) {

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -994,6 +994,14 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 	// ShouldEnforceMCPPolicy. One future spec setting both makes this live, so
 	// it fails closed and loudly rather than passing traffic silently.
 	if req.StreamUnauthenticated && mcpDescriptorPopulated(req) {
+		// Logged because this branch firing means one specific thing — a
+		// provider spec now sets both IsUnauthenticatedRequest and
+		// ShouldEnforceMCPPolicy — and the operator should learn it here
+		// rather than from a client reporting refusals. Audit is skipped for
+		// this path by design (no principal exists to attribute it to), so the
+		// operational log is the only signal.
+		c.logger.Warn("refusing MCP request on an unauthenticated streaming path",
+			logger.String("path", req.Path))
 		return logical.ErrorResponse(logical.ErrForbidden(
 			"MCP requests cannot use unauthenticated streaming paths")), nil, nil
 	}

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -982,6 +982,22 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 	var auth *logical.Auth
 	var te *logical.TokenEntry
 
+	// An unauthenticated streaming path skips CheckToken, and with it every
+	// policy gate — including the MCP contract. A JSON-RPC body reaching that
+	// branch would be proxied having answered to nothing, which is exactly the
+	// invariant the absence deny exists to hold.
+	//
+	// No provider produces this combination today. Unreachability rests on the
+	// spec hooks rather than the interfaces: httpproxy's shared backend
+	// implements both TransparentModeProvider and MCPPolicyEnforced, and only
+	// github and gitlab set IsUnauthenticatedRequest while only mcp sets
+	// ShouldEnforceMCPPolicy. One future spec setting both makes this live, so
+	// it fails closed and loudly rather than passing traffic silently.
+	if req.StreamUnauthenticated && mcpDescriptorPopulated(req) {
+		return logical.ErrorResponse(logical.ErrForbidden(
+			"MCP requests cannot use unauthenticated streaming paths")), nil, nil
+	}
+
 	// Validate the token (non-login requests require authentication)
 	// Skip for unauthenticated streaming paths
 	if !req.StreamUnauthenticated {

--- a/core/request_handler_unauth_gate_test.go
+++ b/core/request_handler_unauth_gate_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stephnangue/warden/internal/namespace"
@@ -131,5 +132,74 @@ func TestStreamUnauthenticatedGate(t *testing.T) {
 		_, _, _ = core.handleNonLoginRequest(ctx, req)
 		assert.False(t, req.StreamUnauthenticated,
 			"an agent credential off the user leg must still be authenticated")
+	})
+}
+
+// mcpUnauthPathBackend is the combination no shipped provider produces today:
+// a backend that declares its paths unauthenticated AND enforces MCP policy.
+// The two are independent opt-ins, so nothing but convention keeps them apart —
+// httpproxy's shared backend already implements both interfaces, and only the
+// spec hooks decide which providers turn each on.
+type mcpUnauthPathBackend struct {
+	mockUnauthPathBackend
+}
+
+func (m *mcpUnauthPathBackend) ShouldEnforceMCPPolicy(_ *logical.Request) (bool, int64) {
+	return true, 1 << 20
+}
+
+// TestStreamUnauthenticatedGate_MCPBodyIsRefused pins the guard that keeps an
+// MCP-shaped body from skipping policy evaluation entirely.
+//
+// The unauthenticated streaming path exists for credential-less protocol probes
+// and bypasses CheckToken, and with it every gate including the tool contract.
+// A JSON-RPC body arriving there would be proxied having answered to nothing —
+// precisely the invariant the absence deny exists to hold. It fails closed and
+// loudly rather than passing traffic silently, so the day a provider sets both
+// hooks it surfaces as a refusal instead of a quiet hole.
+func TestStreamUnauthenticatedGate_MCPBodyIsRefused(t *testing.T) {
+	core := createTestCore(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	backend := &mcpUnauthPathBackend{}
+	entry := &MountEntry{
+		Path:        "mcp-unauth/",
+		Type:        "mcp",
+		Class:       mountClassProvider,
+		UUID:        "mcp-unauth-uuid",
+		Accessor:    "mcp-unauth-uuid_acc",
+		NamespaceID: namespace.RootNamespaceID,
+		namespace:   namespace.RootNamespace,
+	}
+	require.NoError(t, core.router.Mount("mcp-unauth/", backend, entry,
+		&mockBarrierView{prefix: "provider/mcp-unauth-uuid/"}))
+
+	newReq := func(body string) *logical.Request {
+		p := "mcp-unauth/gateway/messages"
+		hr := httptest.NewRequest(http.MethodPost, "/v1/"+p, strings.NewReader(body))
+		hr.Header.Set("Content-Type", "application/json")
+		return &logical.Request{Path: p, Operation: logical.CreateOperation, HTTPRequest: hr}
+	}
+
+	t.Run("a JSON-RPC body is refused", func(t *testing.T) {
+		req := newReq(`{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x"},"id":1}`)
+		resp, _, err := core.handleNonLoginRequest(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, resp.Err)
+		assert.Contains(t, resp.Err.Error(), "unauthenticated streaming paths")
+		assert.True(t, req.StreamUnauthenticated,
+			"the request did take the unauthenticated path — the guard is what stops it")
+	})
+
+	t.Run("a malformed body is refused too", func(t *testing.T) {
+		// A parse failure is still a populated descriptor, so it must not slip
+		// past on the grounds that no call could be extracted from it.
+		req := newReq(`{"jsonrpc":"2.0","method":`)
+		resp, _, err := core.handleNonLoginRequest(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.NotNil(t, resp.Err)
+		assert.Contains(t, resp.Err.Error(), "unauthenticated streaming paths")
 	})
 }

--- a/e2e/fullchain/main_test.go
+++ b/e2e/fullchain/main_test.go
@@ -52,7 +52,8 @@ import (
 var allEnvs = []h.ProviderEnv{
 	openaiEnv, anthropicEnv, newrelicEnv, elasticEnv, githubEnv,
 	splunkEnv, datadogEnv, restEnv, dynatraceEnv, dynatraceOAuthEnv, mcpEnv, mcpGitHubEnv,
-	mcpAWSEnv, mcpAWSWrongCredEnv, mcpNoContractEnv, atlassianEnv, honeycombEnv, grafanaEnv,
+	mcpAWSEnv, mcpAWSWrongCredEnv, mcpNoContractEnv, mcpUnrestrictedSmallCapEnv,
+	atlassianEnv, honeycombEnv, grafanaEnv,
 	prometheusEnv, prometheusBasicEnv,
 	scalewayEnv, cloudflareEnv,
 	vaultEnv,

--- a/e2e/fullchain/main_test.go
+++ b/e2e/fullchain/main_test.go
@@ -52,7 +52,7 @@ import (
 var allEnvs = []h.ProviderEnv{
 	openaiEnv, anthropicEnv, newrelicEnv, elasticEnv, githubEnv,
 	splunkEnv, datadogEnv, restEnv, dynatraceEnv, dynatraceOAuthEnv, mcpEnv, mcpGitHubEnv,
-	mcpAWSEnv, mcpAWSWrongCredEnv, atlassianEnv, honeycombEnv, grafanaEnv,
+	mcpAWSEnv, mcpAWSWrongCredEnv, mcpNoContractEnv, atlassianEnv, honeycombEnv, grafanaEnv,
 	prometheusEnv, prometheusBasicEnv,
 	scalewayEnv, cloudflareEnv,
 	vaultEnv,

--- a/e2e/fullchain/mcp_aws_test.go
+++ b/e2e/fullchain/mcp_aws_test.go
@@ -56,6 +56,10 @@ var mcpAWSEnv = h.ProviderEnv{
 		"secret_access_key": mcpAWSSecretKey,
 	},
 	ExtraConfig: map[string]any{"region": mcpAWSRegion},
+	// mcp_aws is MCP-enforcing and these tests POST JSON-RPC to assert on
+	// request signing, not on authorization. With no contract in scope the
+	// policy layer would refuse them before a signature was ever computed.
+	MCPPolicyRules: h.MCPUnrestricted,
 }
 
 // mcpAWSWrongCredEnv is the same provider bound to a credential it cannot sign
@@ -72,6 +76,10 @@ var mcpAWSWrongCredEnv = h.ProviderEnv{
 	CredType:    "api_key",
 	CredConfig:  map[string]string{"api_key": "fc-mcp-aws-wrong-type"},
 	ExtraConfig: map[string]any{"region": mcpAWSRegion},
+	// Needed for the test's premise to survive: policy evaluation runs before
+	// credential minting, so with no contract in scope the request would 403 at
+	// the policy layer rather than reaching the minting failure this asserts.
+	MCPPolicyRules: h.MCPUnrestricted,
 }
 
 // TestMCPAWS_RequestIsSigned checks the upstream received a signature derived

--- a/e2e/fullchain/mcp_filter_test.go
+++ b/e2e/fullchain/mcp_filter_test.go
@@ -223,3 +223,97 @@ func tryToolNames(body []byte) []string {
 	}
 	return names
 }
+
+// TestMCPFilter_NoContractDeniesTheListing is the absence deny proven end to
+// end, and it is the row that changed direction. A mount with a capability
+// grant and no tool contract used to return the upstream's whole catalog; it
+// now refuses, and the upstream is never reached at all.
+//
+// That inversion is the point of the contract being a separate document: the
+// state an operator lands in by forgetting to attach one is no longer
+// indistinguishable from deliberately opening the mount.
+func TestMCPFilter_NoContractDeniesTheListing(t *testing.T) {
+	ensureEnv(t)
+	upstream.SetHandler(t, mcpToolsListUpstream(mcpToolsListBody(), "application/json"))
+
+	status, body, _ := h.ChainRequest(t, leaderPort, mcpNoContractEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         mcpNoContractEnv.CertRole(),
+		Body:         `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+	})
+
+	if status != http.StatusForbidden {
+		t.Fatalf("status: got %d, want 403 (body: %s)", status, body)
+	}
+	if names := tryToolNames(body); len(names) != 0 {
+		t.Errorf("a refused listing advertised %v — nothing may be disclosed", names)
+	}
+	if n := len(upstream.Requests()); n != 0 {
+		t.Errorf("upstream served %d requests, want 0 — the denial must precede the proxy", n)
+	}
+}
+
+// TestMCPFilter_UnrestrictedContractServesTheWholeListing is the escape hatch.
+// A wildcard contract must be equivalent to the ungoverned mount it replaces:
+// the caller sees every tool the upstream advertises, unmodified.
+func TestMCPFilter_UnrestrictedContractServesTheWholeListing(t *testing.T) {
+	ensureEnv(t)
+	upstream.SetHandler(t, mcpToolsListUpstream(mcpToolsListBody(), "application/json"))
+
+	status, body, _ := h.ChainRequest(t, leaderPort, mcpGitHubEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         mcpGitHubEnv.CertRole(),
+		Body:         `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+	})
+
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body: %s)", status, body)
+	}
+	got := toolNames(t, body)
+	if len(got) != 2 {
+		t.Errorf("advertised tools: got %v, want both — a wildcard contract must not prune", got)
+	}
+	assertUpstreamServed(t)
+}
+
+// TestMCPFilter_UnrestrictedContractDoesNotBufferLargeListings is the guard on
+// the no-op short-circuit, and the row most likely to be found in production
+// rather than in CI without it.
+//
+// Attaching a keep-everything filter is not free: the gateway buffers the whole
+// upstream response to rewrite it, and fails closed above max_body_size. A
+// listing past that cap would therefore start failing on a mount that only ever
+// adopted the sanctioned wildcard contract — a catalog large enough to trip it
+// is ordinary for a real MCP server.
+func TestMCPFilter_UnrestrictedContractDoesNotBufferLargeListings(t *testing.T) {
+	ensureEnv(t)
+
+	// Comfortably past the mount's max_body_size, built from tools the contract
+	// permits so nothing but the buffering could refuse it.
+	var sb strings.Builder
+	sb.WriteString(`{"jsonrpc":"2.0","id":1,"result":{"tools":[`)
+	for i := 0; i < 40000; i++ {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		fmt.Fprintf(&sb, `{"name":"tool_%d","description":"a tool"}`, i)
+	}
+	sb.WriteString(`]}}`)
+	upstream.SetHandler(t, mcpToolsListUpstream(sb.String(), "application/json"))
+
+	status, body, _ := h.ChainRequest(t, leaderPort, mcpGitHubEnv, h.ChainOpts{
+		AgentCertPEM: agentCert(t),
+		Bearer:       h.FullChainUserJWT(t),
+		Role:         mcpGitHubEnv.CertRole(),
+		Body:         `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+	})
+
+	if status != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body: %.200s) — an unrestricted contract must "+
+			"stream rather than buffer, or a large catalog fails above max_body_size",
+			status, body)
+	}
+	assertUpstreamServed(t)
+}

--- a/e2e/fullchain/mcp_filter_test.go
+++ b/e2e/fullchain/mcp_filter_test.go
@@ -246,6 +246,14 @@ func TestMCPFilter_NoContractDeniesTheListing(t *testing.T) {
 	if status != http.StatusForbidden {
 		t.Fatalf("status: got %d, want 403 (body: %s)", status, body)
 	}
+	// The status alone would also be satisfied by a contract that exists and
+	// refuses, or by an auth failure. The description is what says the refusal
+	// was the *absence* — and it is the sentence pointing the operator at the
+	// missing contract rather than at the call they made.
+	if !strings.Contains(string(body), "No MCP policy permits this request") {
+		t.Errorf("body: got %s, want the absence-deny description — a bare 403 does not "+
+			"distinguish a missing contract from a restrictive one", body)
+	}
 	if names := tryToolNames(body); len(names) != 0 {
 		t.Errorf("a refused listing advertised %v — nothing may be disclosed", names)
 	}
@@ -283,30 +291,42 @@ func TestMCPFilter_UnrestrictedContractServesTheWholeListing(t *testing.T) {
 // rather than in CI without it.
 //
 // Attaching a keep-everything filter is not free: the gateway buffers the whole
-// upstream response to rewrite it, and fails closed above max_body_size. A
-// listing past that cap would therefore start failing on a mount that only ever
-// adopted the sanctioned wildcard contract — a catalog large enough to trip it
-// is ordinary for a real MCP server.
+// upstream response to rewrite it, and fails closed above max_body_size. So a
+// wildcard contract — the sanctioned way to open a mount — would be *more*
+// brittle than the ungoverned mount it replaces, on exactly the catalogs a real
+// MCP server serves.
+//
+// The mount caps bodies deliberately low and the listing is sized well past it,
+// because the two outcomes are otherwise indistinguishable: a filter that keeps
+// everything and no filter at all produce the same bytes. Only the cap
+// separates them. Remove the short-circuit and this row answers 502.
 func TestMCPFilter_UnrestrictedContractDoesNotBufferLargeListings(t *testing.T) {
 	ensureEnv(t)
 
-	// Comfortably past the mount's max_body_size, built from tools the contract
-	// permits so nothing but the buffering could refuse it.
+	// Built from tools the wildcard contract permits, so nothing but the
+	// buffering could refuse it.
 	var sb strings.Builder
 	sb.WriteString(`{"jsonrpc":"2.0","id":1,"result":{"tools":[`)
-	for i := 0; i < 40000; i++ {
+	for i := 0; sb.Len() < 4*mcpBodyCapBytes; i++ {
 		if i > 0 {
 			sb.WriteString(",")
 		}
 		fmt.Fprintf(&sb, `{"name":"tool_%d","description":"a tool"}`, i)
 	}
 	sb.WriteString(`]}}`)
-	upstream.SetHandler(t, mcpToolsListUpstream(sb.String(), "application/json"))
+	listing := sb.String()
+	if len(listing) <= mcpBodyCapBytes {
+		t.Fatalf("fixture is %d bytes, which does not exceed the mount's %d-byte cap — "+
+			"this row would pass whether or not the filter was skipped",
+			len(listing), mcpBodyCapBytes)
+	}
+	upstream.SetHandler(t, mcpToolsListUpstream(listing, "application/json"))
 
-	status, body, _ := h.ChainRequest(t, leaderPort, mcpGitHubEnv, h.ChainOpts{
+	env := mcpUnrestrictedSmallCapEnv
+	status, body, _ := h.ChainRequest(t, leaderPort, env, h.ChainOpts{
 		AgentCertPEM: agentCert(t),
 		Bearer:       h.FullChainUserJWT(t),
-		Role:         mcpGitHubEnv.CertRole(),
+		Role:         env.CertRole(),
 		Body:         `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
 	})
 
@@ -316,4 +336,7 @@ func TestMCPFilter_UnrestrictedContractDoesNotBufferLargeListings(t *testing.T) 
 			status, body)
 	}
 	assertUpstreamServed(t)
+	if got := len(toolNames(t, body)); got == 0 {
+		t.Errorf("the caller received no tools from a listing the contract permits in full")
+	}
 }

--- a/e2e/fullchain/mcp_test.go
+++ b/e2e/fullchain/mcp_test.go
@@ -75,6 +75,27 @@ var mcpNoContractEnv = h.ProviderEnv{
 	CredConfig: map[string]string{"api_key": mcpAPIKey},
 }
 
+// mcpBodyCapBytes is small enough that an ordinary tool catalog exceeds it, so
+// a test can tell buffering from streaming. The default cap is 10MB, which no
+// plausible fixture reaches — a listing sized against it would prove nothing.
+const mcpBodyCapBytes = 65536
+
+// mcpUnrestrictedSmallCapEnv pairs the wildcard contract with a deliberately
+// tight max_body_size. Attaching a keep-everything filter makes the gateway
+// buffer the whole upstream response against that cap and fail closed above it,
+// so this mount is what separates "the filter was skipped" from "the filter ran
+// and happened to keep everything" — two outcomes that are otherwise identical
+// on the wire.
+var mcpUnrestrictedSmallCapEnv = h.ProviderEnv{
+	Mount:          "fc-mcp-bigcatalog",
+	Type:           "mcp",
+	URLKey:         "mcp_url",
+	CredType:       "api_key",
+	CredConfig:     map[string]string{"api_key": mcpAPIKey},
+	MCPPolicyRules: h.MCPUnrestricted,
+	ExtraConfig:    map[string]any{"max_body_size": mcpBodyCapBytes},
+}
+
 func mcpToolCall(tool string) string {
 	return mcpToolCallID(tool, 1)
 }
@@ -255,8 +276,12 @@ func TestMCP_MalformedBodyIsRefused(t *testing.T) {
 //
 // That is the property worth pinning: a body the filter cannot interpret is
 // denied rather than waved through as "no rule matched", which is how a filter
-// of this shape usually breaks. This row would pass differently with no MCP
-// contract attached to the mount.
+// of this shape usually breaks.
+//
+// Note the status alone no longer distinguishes this from an ungoverned mount —
+// both answer 403 with the same challenge. What makes this row specific is the
+// contract being attached: the refusal comes from the body failing to parse
+// against rules that exist, not from there being no rules.
 func TestMCP_ValidJSONButInvalidJSONRPCIsDeniedByPolicy(t *testing.T) {
 	ensureEnv(t)
 

--- a/e2e/fullchain/mcp_test.go
+++ b/e2e/fullchain/mcp_test.go
@@ -56,6 +56,23 @@ var mcpGitHubEnv = h.ProviderEnv{
 	URLKey:     "mcp_url",
 	CredType:   "github_token",
 	CredConfig: map[string]string{"token": mcpGitHubToken},
+	// This mount is about credential extraction, not authorization, so it wants
+	// every call to reach the upstream. Since an MCP-enforcing mount now
+	// refuses traffic with no contract in scope, "unrestricted" has to be said
+	// out loud — which is the point: it stays visible in a policy listing.
+	MCPPolicyRules: h.MCPUnrestricted,
+}
+
+// mcpNoContractEnv is an MCP mount with a capability grant and deliberately no
+// tool contract. It exists to prove the absence deny end to end: the shape an
+// operator lands in by granting a mount and forgetting the contract used to be
+// indistinguishable from meaning "unrestricted".
+var mcpNoContractEnv = h.ProviderEnv{
+	Mount:      "fc-mcp-nocontract",
+	Type:       "mcp",
+	URLKey:     "mcp_url",
+	CredType:   "api_key",
+	CredConfig: map[string]string{"api_key": mcpAPIKey},
 }
 
 func mcpToolCall(tool string) string {

--- a/e2e/helpers/fullchain_helpers.go
+++ b/e2e/helpers/fullchain_helpers.go
@@ -168,6 +168,15 @@ func (p ProviderEnv) DenyPolicy() string { return p.Mount + "-denied" }
 // distinctly because policy names are unique across types.
 func (p ProviderEnv) MCPPolicy() string { return p.Mount + "-mcp" }
 
+// MCPUnrestricted is the sanctioned escape hatch for a mount that means to
+// permit every call: an MCP-enforcing mount refuses traffic with no contract in
+// scope, so "unrestricted" is stated rather than implied by an absence. Use it
+// for mounts whose tests are about something other than authorization.
+const MCPUnrestricted = `  methods   { allowed = ["*"] }
+  tools     { allowed = ["*"] }
+  resources { allowed = ["*"] }
+  prompts   { allowed = ["*"] }`
+
 // JWTAgentRole authenticates the agent by bearer token instead of certificate.
 // Needed for every shape where the agent arrives in a header — the dedicated
 // agent channel, or a provider's own native channel — because those carry a


### PR DESCRIPTION
**PR 4 of 4.** Stacked on #586. **Breaking**, and the semantic change the whole split was for.

An MCP-shaped request — a populated JSON-RPC descriptor — on a path with no MCP policy covering it is now denied with rule type `no_mcp_policy`, where it used to pass through unrestricted.

## Why

A capability grant says the caller may reach the mount; nothing said which calls were permitted on it, and that absence read as "everything". The state an operator lands in by granting a mount and **forgetting** to attach the contract was indistinguishable from deliberately opening it. Opening one is now an explicit wildcard policy, which stays visible in a policy listing and in audit.

The previously documented behavior was explicit about the old default: *granting the capability without an `mcp` block allows every call on that path.*

## The predicate is narrow on purpose

| Descriptor | Meaning | Result |
|---|---|---|
| nil | backend does not implement `MCPPolicyEnforced` | pass — **every non-MCP mount untouched** |
| empty sentinel | backend declined this request | pass — body-less MCP verbs, and every httpproxy provider with no spec hook (github/slack/openai/anthropic) |
| populated | parsed body, or typed parse failure | **denied when no contract is in scope** |

All four states are pinned as subtests, so the blast radius is explicit rather than inferred.

## Two holes this default would otherwise leave open

**Unauthenticated streaming paths** skip `CheckToken` and every gate with it, so a JSON-RPC body arriving there would be proxied having answered to nothing. It is refused. No provider produces that combination today — the shared httpproxy backend implements both interfaces, but only github and gitlab set `IsUnauthenticatedRequest` while only mcp sets `ShouldEnforceMCPPolicy` — so this fails closed and loudly the day a spec sets both. Mutation-tested: disabling the guard fails both subtests.

**A wildcard contract would otherwise be more brittle than the absence it replaces.** `attachMCPListFilter` now skips a filter whose keep-predicate would admit every name: attaching one makes the gateway buffer the whole upstream response to rewrite it, and fail closed above `max_body_size`, so a large tool catalog would start failing on a mount that only ever adopted the sanctioned escape hatch. A deny entry or a per-call condition anywhere in the family keeps the filter, since either can still exclude a name.

## Root keeps its bypass

Now stated at the fast path rather than implied by where the return sits. Root already bypasses explicit deny capabilities and path conditions, and it is the break-glass path: making it answer to a contract would let a misconfigured MCP policy lock an operator out of the mount they need to fix it.

## Expected breakage

Four existing expectations flip, all of them the old fail-open default being written down. Every MCP-enforcing mount with no attached contract goes from working to 403 — that is the feature.

The e2e suite gains an ungoverned mount proving the denial reaches the wire without touching the upstream, and the three mounts that POST JSON-RPC while testing something other than authorization get explicit wildcard contracts. That includes the `mcp_aws` wrong-credential mount, whose premise depended on reaching credential minting — policy evaluation now precedes it, so without a contract it would have quietly started asserting a 403 instead of the 500 it exists to assert.

## Review-fix commits (1d24a3e, c41f313)

- The e2e row billed as the critical guard **tested nothing**: its 40,000-tool fixture came to ~1.8 MB against the 10 MB default cap, so a keep-everything filter buffered it happily and the row passed with or without the short-circuit. It now runs against a mount with a deliberately small `max_body_size` and a fixture sized from that constant, with an assertion that fails if the fixture ever stops exceeding it.
- `mcpKeepsEveryItem` skipped any set carrying a condition, justified as "visible == callable". That is wrong in the direction that matters: list filtering deliberately skips CEL, so a condition cannot exclude a name at list time, and retaining the filter buffered the whole response to prune nothing. The helper now models `mcpListItemAllowed` exactly — and for the same reason an unrelated `denied_methods` entry no longer keeps the filter either.
- The `CBPResults.MCPDecision` contract said "nil when no rule-set applied", which the absence deny falsified. Audit consumers read that contract.
- The unauth guard failed closed but silently; it now warns, because the branch firing means one specific thing an operator should learn from logs.
- Benchmarks for what MCP policies cost per request: the absence deny is +34 ns over baseline, structural gates ~126 ns, pattern matching ~0.77 ns per pattern, and CEL is 84% of a governed call. A contract costs nothing to traffic it does not govern.

## Verification

`go test ./... -count=1` green. Full e2e suite green (20 packages).
