### PR TITLE
fix(listener): stop the response deadline severing every request over ~10s

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -703,11 +703,15 @@ func initListeners(httpHandler http.Handler, c *core.Core, conf *config.Config, 
 	for _, lnConfig := range conf.Listeners {
 		switch lnConfig.Type {
 		case listenerTypeTCP, listenerTypeUnix:
+			readTimeout, writeTimeout, idleTimeout := lnConfig.HTTPTimeouts()
 			apiCfg := api.ApiListenerConfig{
 				Logger:         logger.WithSystem(subsystemListener),
 				Address:        lnConfig.Address,
 				TLSDisable:     lnConfig.TLSDisable,
 				TrustedProxies: lnConfig.TrustedProxies,
+				ReadTimeout:    readTimeout,
+				WriteTimeout:   writeTimeout,
+				IdleTimeout:    idleTimeout,
 			}
 
 			typeLabel := lnConfig.Type

--- a/config/config.go
+++ b/config/config.go
@@ -475,6 +475,29 @@ type ListenerBlock struct {
 	TLSSPIFFE               bool   `hcl:"tls_spiffe,optional"`
 	TLSSPIFFESocket         string `hcl:"tls_spiffe_socket,optional"`          // Workload API endpoint; empty => SPIFFE_ENDPOINT_SOCKET
 	TLSSPIFFEStartupTimeout string `hcl:"tls_spiffe_startup_timeout,optional"` // max wait/retry for the first SVID at boot (duration; default 10s)
+
+	// HTTP server deadlines. Empty means the listener's built-in default,
+	// which is the value each carried before they became configurable.
+	//
+	// These govern the control plane only. The read and write deadlines are
+	// absolute from the moment request headers are read, so they bound a
+	// handler's whole execution rather than merely the write of its
+	// response; proxied gateway traffic therefore clears both per-connection
+	// and answers to the mount's own timeout instead.
+	HTTPReadTimeout  string `hcl:"http_read_timeout,optional"`  // duration; default 5s
+	HTTPWriteTimeout string `hcl:"http_write_timeout,optional"` // duration; default 10s
+	HTTPIdleTimeout  string `hcl:"http_idle_timeout,optional"`  // duration; default 1m
+}
+
+// HTTPTimeouts parses the listener's HTTP deadline fields. validateConfig
+// rejects an unparseable or non-positive value at load, so a zero returned
+// here means the field was left empty and the listener applies its
+// built-in default.
+func (l ListenerBlock) HTTPTimeouts() (read, write, idle time.Duration) {
+	read, _ = time.ParseDuration(l.HTTPReadTimeout)
+	write, _ = time.ParseDuration(l.HTTPWriteTimeout)
+	idle, _ = time.ParseDuration(l.HTTPIdleTimeout)
+	return read, write, idle
 }
 
 // LoadConfig reads a single HCL config file and returns a validated *Config.
@@ -659,6 +682,27 @@ func validateConfig(config *Config) error {
 	// SPIFFE serving is an alternative TLS mode, mutually exclusive with the
 	// file-based cert/key fields.
 	for i, ln := range config.Listeners {
+		// HTTP deadlines apply in every TLS mode, so they are checked before
+		// the mode switch. Zero is not accepted: net/http reads it as "no
+		// deadline at all", which an operator setting an explicit value is
+		// never asking for — leave the key out to get the default.
+		for _, f := range []struct{ name, value string }{
+			{"http_read_timeout", ln.HTTPReadTimeout},
+			{"http_write_timeout", ln.HTTPWriteTimeout},
+			{"http_idle_timeout", ln.HTTPIdleTimeout},
+		} {
+			if f.value == "" {
+				continue
+			}
+			d, err := time.ParseDuration(f.value)
+			if err != nil {
+				return fmt.Errorf("listener[%d]: invalid %s %q: %w", i, f.name, f.value, err)
+			}
+			if d <= 0 {
+				return fmt.Errorf("listener[%d]: %s must be positive, got %s", i, f.name, d)
+			}
+		}
+
 		spiffeSubKeySet := ln.TLSSPIFFESocket != "" || ln.TLSSPIFFEStartupTimeout != ""
 		switch {
 		case ln.TLSDisable:

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -332,6 +333,125 @@ listener "tcp" {
 	assert.True(t, ln.TLSSPIFFE)
 	assert.Equal(t, "unix:///run/spire/agent.sock", ln.TLSSPIFFESocket)
 	assert.Equal(t, "20s", ln.TLSSPIFFEStartupTimeout)
+}
+
+func TestLoadConfig_ListenerHTTPTimeouts(t *testing.T) {
+	tests := []struct {
+		name    string
+		extra   string
+		wantErr string // substring; "" means expect success
+	}{
+		{
+			name: "all three set — ok",
+			extra: `
+listener "tcp" {
+  address            = ":8520"
+  tls_disable        = true
+  http_read_timeout  = "10s"
+  http_write_timeout = "30s"
+  http_idle_timeout  = "2m"
+}
+`,
+		},
+		{
+			name: "unset — ok, listener applies its defaults",
+			extra: `
+listener "tcp" {
+  address     = ":8521"
+  tls_disable = true
+}
+`,
+		},
+		{
+			name: "unparseable write timeout — error",
+			extra: `
+listener "tcp" {
+  address            = ":8522"
+  tls_disable        = true
+  http_write_timeout = "soon"
+}
+`,
+			wantErr: "invalid http_write_timeout",
+		},
+		{
+			// Zero is net/http's "no deadline at all", which is never what an
+			// operator writing an explicit value is asking for.
+			name: "zero read timeout — error",
+			extra: `
+listener "tcp" {
+  address           = ":8523"
+  tls_disable       = true
+  http_read_timeout = "0s"
+}
+`,
+			wantErr: "http_read_timeout must be positive",
+		},
+		{
+			name: "negative idle timeout — error",
+			extra: `
+listener "tcp" {
+  address           = ":8524"
+  tls_disable       = true
+  http_idle_timeout = "-1m"
+}
+`,
+			wantErr: "http_idle_timeout must be positive",
+		},
+		{
+			// The deadlines are independent of the TLS mode, so they must be
+			// validated on a SPIFFE listener too — not only in the default arm.
+			name: "invalid timeout on a SPIFFE listener — still rejected",
+			extra: `
+listener "tcp" {
+  address           = ":8525"
+  tls_spiffe        = true
+  http_idle_timeout = "later"
+}
+`,
+			wantErr: "invalid http_idle_timeout",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := loadFromHCL(t, minimalConfigHCL+tt.extra)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+// TestLoadConfig_ListenerHTTPTimeoutsDecode guards the HCL tag names and the
+// accessor initListeners uses: an empty field must yield zero, which the
+// listener reads as "use the built-in default".
+func TestLoadConfig_ListenerHTTPTimeoutsDecode(t *testing.T) {
+	body := `
+storage "postgres" {
+  connection_url = "postgres://u:p@db:5432/warden"
+}
+
+listener "tcp" {
+  address            = ":8530"
+  tls_disable        = true
+  http_read_timeout  = "10s"
+  http_write_timeout = "30s"
+}
+`
+	cfg, err := loadFromHCL(t, body)
+	require.NoError(t, err)
+	require.Len(t, cfg.Listeners, 1)
+	ln := cfg.Listeners[0]
+	assert.Equal(t, "10s", ln.HTTPReadTimeout)
+	assert.Equal(t, "30s", ln.HTTPWriteTimeout)
+	assert.Empty(t, ln.HTTPIdleTimeout)
+
+	read, write, idle := ln.HTTPTimeouts()
+	assert.Equal(t, 10*time.Second, read)
+	assert.Equal(t, 30*time.Second, write)
+	assert.Zero(t, idle, "an unset field must not manufacture a deadline")
 }
 
 func TestLoadConfig_ClusterAddrValidation(t *testing.T) {

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -841,6 +841,35 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 	} else {
 		req.Streamed = true
 
+		// Shed the listener's write deadline for the whole of this request. It
+		// is armed when request headers are read and absolute from that
+		// moment, so on a streaming path it caps the proxied call itself: a
+		// response over it dies with a bare EOF and no status, and a stream is
+		// truncated mid-flight. The mount's own timeout is the real ceiling
+		// for this traffic. Control-plane requests take the branch above and
+		// keep their caps.
+		if err := logical.ClearStreamWriteDeadline(req.ResponseWriter); err != nil {
+			c.logger.Warn("could not clear connection write deadline for streaming request",
+				logger.Err(err),
+				logger.String("path", req.Path),
+			)
+		}
+
+		// The read deadline gets a window rather than a clear, because the
+		// body buffering below runs BEFORE the caller is authenticated: the
+		// stream-body parser and the MCP extractor both read the body, and
+		// the mount timeout that would otherwise bound them is not armed
+		// until the backend handler runs. Clearing it here would let an
+		// unauthenticated client dribble a body forever, holding a goroutine
+		// and a buffer with nothing to push back. The window is generous
+		// enough for a legitimately slow upload of a capped body and is
+		// removed as soon as the body is in hand.
+		//
+		// This is also why the clear cannot live in the providers' gateway
+		// handlers, where the plan first put it: by the time one runs, the
+		// body has already been read under whatever deadline was in force.
+		c.setStreamReadWindow(req, time.Now().Add(streamBodyBufferTimeout))
+
 		// Set AuditPath for consistent audit logging between request and response entries.
 		// For streaming requests, this is the path relative to the mount point
 		// (e.g., "role/operator/gateway/v1/...") before routing transforms req.Path.
@@ -876,6 +905,13 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 		// downstream proxy reads it unchanged. Non-MCP backends fail
 		// the type assertion and skip the extractor entirely.
 		c.extractMCPDescriptor(ctx, req, matchingBackend)
+
+		// The body is in hand, so the window closes: from here the response
+		// may stream for as long as the mount allows, and an armed read
+		// deadline would tear it down even while idle — net/http reads the
+		// connection in the background once the body is drained and cancels
+		// the request context when that read fails.
+		c.setStreamReadWindow(req, time.Time{})
 
 		// Resolve the secondary (user) auth config once, before extraction:
 		// whether this mount is a protected resource decides how the extractor
@@ -1171,6 +1207,27 @@ func (c *Core) PopulateTokenEntry(ctx context.Context, req *logical.Request) err
 		req.SetTokenEntry(te)
 	}
 	return nil
+}
+
+// streamBodyBufferTimeout bounds the pre-authentication body buffering on a
+// streaming path — the stream-body parser and the MCP extractor. It is the
+// only thing standing between an unauthenticated client and a goroutine plus
+// a max_body_size buffer held open indefinitely, since the mount timeout is
+// not armed until the backend handler runs. Generous enough that a capped
+// body on a slow link finishes comfortably.
+const streamBodyBufferTimeout = 60 * time.Second
+
+// setStreamReadWindow moves the connection read deadline for a streaming
+// request; the zero time removes it. Failure is logged, not fatal: the
+// request is still correct without the adjustment, it is merely bounded by
+// whatever the listener armed.
+func (c *Core) setStreamReadWindow(req *logical.Request, deadline time.Time) {
+	if err := logical.SetStreamReadDeadline(req.ResponseWriter, deadline); err != nil {
+		c.logger.Warn("could not adjust connection read deadline for streaming request",
+			logger.Err(err),
+			logger.String("path", req.Path),
+		)
+	}
 }
 
 // isStreamingRequest checks if the request path is a streaming path

--- a/core/request_handler_test.go
+++ b/core/request_handler_test.go
@@ -1872,6 +1872,121 @@ func (m *mockStreamBodyParserBackend) ShouldParseStreamBody(_ *http.Request) boo
 	return m.parseStreamBody
 }
 
+// deadlineRecordingWriter records the connection deadlines set on it.
+// httptest.ResponseRecorder supports neither, so it cannot tell "cleared"
+// apart from "never attempted".
+type deadlineRecordingWriter struct {
+	http.ResponseWriter
+	read  []time.Time
+	write []time.Time
+}
+
+func newDeadlineRecordingWriter() *deadlineRecordingWriter {
+	return &deadlineRecordingWriter{ResponseWriter: httptest.NewRecorder()}
+}
+
+func (d *deadlineRecordingWriter) SetReadDeadline(t time.Time) error {
+	d.read = append(d.read, t)
+	return nil
+}
+
+func (d *deadlineRecordingWriter) SetWriteDeadline(t time.Time) error {
+	d.write = append(d.write, t)
+	return nil
+}
+
+// bodyReadRecordingBackend records the deadlines in force at the moment the
+// request body is buffered, which is the ordering the fix depends on and
+// which asserting only the end state would not catch.
+type bodyReadRecordingBackend struct {
+	*mockStreamBodyParserBackend
+	w             *deadlineRecordingWriter
+	readAtBuffer  []time.Time
+	writeAtBuffer []time.Time
+}
+
+func (b *bodyReadRecordingBackend) ShouldParseStreamBody(r *http.Request) bool {
+	b.readAtBuffer = append([]time.Time{}, b.w.read...)
+	b.writeAtBuffer = append([]time.Time{}, b.w.write...)
+	return b.mockStreamBodyParserBackend.ShouldParseStreamBody(r)
+}
+
+// TestHandleNonLoginRequest_StreamingClearsConnectionDeadlines pins the fix
+// for the listener deadlines severing proxied traffic, including the ordering
+// it turns on: the write deadline goes immediately, while the read deadline
+// is held to a finite window across the pre-authentication body buffering and
+// only removed once the body is in hand. Clearing the read deadline up front
+// would leave an unauthenticated dribbler unbounded; leaving it armed would
+// tear down an idle stream.
+func TestHandleNonLoginRequest_StreamingClearsConnectionDeadlines(t *testing.T) {
+	core := createTestCore(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	w := newDeadlineRecordingWriter()
+	backend := &bodyReadRecordingBackend{
+		mockStreamBodyParserBackend: &mockStreamBodyParserBackend{parseStreamBody: true},
+		w:                           w,
+	}
+	entry := &MountEntry{
+		Path:        "vault/",
+		Type:        "vault",
+		Class:       mountClassProvider,
+		UUID:        "vault-deadline-uuid",
+		Accessor:    "vault_deadline",
+		NamespaceID: namespace.RootNamespaceID,
+		namespace:   namespace.RootNamespace,
+	}
+	view := &mockBarrierView{prefix: "provider/vault-deadline-uuid/"}
+	require.NoError(t, core.router.Mount("vault/", backend, entry, view))
+
+	t.Run("streaming request sheds the write deadline and windows the read", func(t *testing.T) {
+		httpReq := httptest.NewRequest(http.MethodPost, "/v1/vault/gateway/v1/pki/issue/my-role", strings.NewReader(`{"key":"value"}`))
+		httpReq.Header.Set("Content-Type", "application/json")
+		req := &logical.Request{
+			Path:           "vault/gateway/v1/pki/issue/my-role",
+			Operation:      logical.CreateOperation,
+			HTTPRequest:    httpReq,
+			ResponseWriter: logical.NewStatusRecordingWriter(w),
+		}
+
+		// Authorization fails after this point; the deadline work is all
+		// ahead of it.
+		_, _, _ = core.handleNonLoginRequest(ctx, req)
+
+		require.True(t, req.Streamed)
+
+		require.Len(t, w.write, 1, "the write deadline truncates a proxied response mid-flight")
+		assert.True(t, w.write[0].IsZero())
+
+		require.Len(t, w.read, 2, "the read deadline is windowed across the buffering, then removed")
+		assert.False(t, w.read[0].IsZero(), "an unauthenticated dribbler must stay bounded while the body is read")
+		assert.True(t, w.read[1].IsZero(), "an armed read deadline tears down an idle stream")
+
+		// The ordering is the point: at the moment the body was buffered the
+		// window was already in force and had not yet been lifted.
+		require.Len(t, backend.writeAtBuffer, 1, "the write deadline must be gone before the body is read")
+		require.Len(t, backend.readAtBuffer, 1, "the body must be read inside the window, not after it lifts")
+		assert.False(t, backend.readAtBuffer[0].IsZero())
+	})
+
+	t.Run("control-plane request keeps its caps", func(t *testing.T) {
+		w := newDeadlineRecordingWriter()
+		httpReq := httptest.NewRequest(http.MethodGet, "/v1/sys/seal-status", nil)
+		req := &logical.Request{
+			Path:           "sys/seal-status",
+			Operation:      logical.ReadOperation,
+			HTTPRequest:    httpReq,
+			ResponseWriter: logical.NewStatusRecordingWriter(w),
+		}
+
+		_, _, _ = core.handleNonLoginRequest(ctx, req)
+
+		assert.False(t, req.Streamed)
+		assert.Empty(t, w.write, "clearing the write deadline for the whole API would remove the control plane's bound")
+		assert.Empty(t, w.read)
+	})
+}
+
 // TestHandleNonLoginRequest_StreamingBodyParsing tests opt-in body parsing for streaming requests
 func TestHandleNonLoginRequest_StreamingBodyParsing(t *testing.T) {
 	core := createTestCore(t)

--- a/core/sys_mcp.go
+++ b/core/sys_mcp.go
@@ -1,15 +1,19 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
 )
 
@@ -42,6 +46,61 @@ const mcpServerVersion = "1.0.0"
 // so credential detection (detectIntrospectCredentialFormat) needs the
 // request threaded through the context.
 type mcpRequestKey struct{}
+
+// maxSysMCPBody caps a discovery request body. The two tools this endpoint
+// exposes take an empty input and a single skill name, so anything near this
+// is already pathological; the cap exists so buffering the body cannot be
+// turned into a memory cost.
+const maxSysMCPBody = 1 << 20 // 1 MiB
+
+// sysMCPTimeout is this endpoint's answer to a gateway mount's
+// listen_timeout: the ceiling on one discovery request once the listener's
+// deadlines have been shed.
+//
+// It has to exist. The endpoint authorizes on the presented identity inside
+// each tool handler, so the SDK accepts and holds a subscriptions/listen
+// stream before any credential is checked — with no ceiling, unauthenticated
+// callers could park goroutines and connections here indefinitely. It is
+// generous because a listen stream is meant to live: Warden's tool list never
+// changes, so such a stream only ever idles, and a client that wants another
+// reconnects.
+const sysMCPTimeout = 10 * time.Minute
+
+// errSysMCPBodyTooLarge marks the oversize case so the handler can answer 413
+// rather than folding it in with a read failure.
+var errSysMCPBodyTooLarge = errors.New("sys/mcp request body too large")
+
+// bufferMCPRequestBody reads r's body into memory and puts it back, so the
+// request can be handed to a handler that may hold the response open
+// indefinitely without a connection read deadline still being armed. A body
+// over the cap is refused rather than truncated — a truncated JSON-RPC body
+// would surface as a confusing parse error.
+// sysMCPContext builds the context one discovery request runs under: the
+// caller's namespace and the raw request threaded through for the tool
+// handlers, bounded by sysMCPTimeout. The caller must call the returned
+// cancel.
+func sysMCPContext(r *http.Request, ns *namespace.Namespace) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(r.Context(), sysMCPTimeout)
+	ctx = namespace.ContextWithNamespace(ctx, ns)
+	ctx = withMCPRequest(ctx, r)
+	return ctx, cancel
+}
+
+func bufferMCPRequestBody(r *http.Request) error {
+	if r.Body == nil {
+		return nil
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxSysMCPBody+1))
+	_ = r.Body.Close()
+	if err != nil {
+		return err
+	}
+	if len(body) > maxSysMCPBody {
+		return errSysMCPBodyTooLarge
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	return nil
+}
 
 func withMCPRequest(ctx context.Context, r *http.Request) context.Context {
 	return context.WithValue(ctx, mcpRequestKey{}, r)
@@ -105,8 +164,35 @@ func (c *Core) MCPServerHandler() http.Handler {
 		// Authorization header and the forwarded client cert — the listener's
 		// certForwardingMiddleware injected the latter before routing — so
 		// stashing r preserves both for detectIntrospectCredentialFormat.
-		ctx := namespace.ContextWithNamespace(r.Context(), ns)
-		ctx = withMCPRequest(ctx, r)
+		// JSONResponse does not make every response here a buffered one: the
+		// SDK forces SSE for subscriptions/listen, which has no synchronous
+		// result and stays open until the client cancels, and a v1.7.0 client
+		// opens one during Connect whenever it registers a list-changed
+		// handler. Under the listener's deadlines such a stream is severed
+		// seconds in — and not only by the write deadline: once the body is
+		// drained, an armed read deadline cancels the request context, which
+		// is exactly what the SDK blocks on.
+		//
+		// The deadlines cannot be shed reactively, on seeing the response
+		// declare itself an event stream, because the SDK sets that
+		// Content-Type on the header map and then blocks without writing a
+		// byte. So read the body first — under the deadlines the listener
+		// armed, which is what bounds a dribbling client — and shed them
+		// before handing over to a handler that may never return.
+		if err := bufferMCPRequestBody(r); err != nil {
+			if errors.Is(err, errSysMCPBodyTooLarge) {
+				http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			http.Error(w, "could not read request body", http.StatusBadRequest)
+			return
+		}
+		if err := logical.ClearStreamDeadlines(w); err != nil {
+			c.logger.Warn("could not clear connection deadlines for sys/mcp", logger.Err(err))
+		}
+
+		ctx, cancel := sysMCPContext(r, ns)
+		defer cancel()
 		streamable.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/core/sys_mcp_test.go
+++ b/core/sys_mcp_test.go
@@ -13,11 +13,13 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/stephnangue/warden/internal/namespace"
 	"github.com/stephnangue/warden/listener"
 )
 
@@ -325,4 +327,82 @@ func TestMCPServer_GetSkill_Errors(t *testing.T) {
 			assert.Contains(t, txt.Text, tc.want)
 		})
 	}
+}
+
+// TestMCPServerHandler_ShedsConnectionDeadlines pins the ordering the
+// discovery endpoint depends on. The SDK forces SSE for subscriptions/listen
+// and then blocks in hangResponse without writing a byte, so the deadlines
+// cannot be shed reactively on seeing an event-stream Content-Type — by the
+// time anything is written they have already fired, and an armed read
+// deadline cancels the very context the SDK is blocked on. The body is read
+// first, under the deadlines the listener armed, so a dribbling client stays
+// bounded; only then are they shed.
+func TestMCPServerHandler_ShedsConnectionDeadlines(t *testing.T) {
+	c := createTestCore(t)
+	w := newDeadlineRecordingWriter()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+	r := httptest.NewRequest(http.MethodPost, "/v1/sys/mcp", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Accept", "application/json, text/event-stream")
+
+	c.MCPServerHandler().ServeHTTP(w, r)
+
+	require.Len(t, w.read, 1, "an armed read deadline tears down an idle listen stream")
+	require.Len(t, w.write, 1, "an armed write deadline severs the stream on its first notification")
+	assert.True(t, w.read[0].IsZero())
+	assert.True(t, w.write[0].IsZero())
+}
+
+// Buffering the body must leave it readable by the SDK, or every discovery
+// call would fail as an empty request.
+func TestMCPServerHandler_BufferedBodyStillReaches(t *testing.T) {
+	c := createTestCore(t)
+	rec := httptest.NewRecorder()
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`
+	r := httptest.NewRequest(http.MethodPost, "/v1/sys/mcp", strings.NewReader(body))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Accept", "application/json, text/event-stream")
+
+	c.MCPServerHandler().ServeHTTP(rec, r)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), "list_roles", "the buffered body must reach the SDK unchanged")
+}
+
+func TestMCPServerHandler_RejectsOversizedBody(t *testing.T) {
+	c := createTestCore(t)
+	rec := httptest.NewRecorder()
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/sys/mcp", strings.NewReader(strings.Repeat("a", maxSysMCPBody+1)))
+	r.Header.Set("Content-Type", "application/json")
+
+	c.MCPServerHandler().ServeHTTP(rec, r)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+// Shedding the listener's deadlines leaves this endpoint with no ceiling of
+// its own, and it accepts a subscriptions/listen stream before any credential
+// is checked — so it must impose one, the way a gateway mount imposes
+// listen_timeout. Without it an unauthenticated caller could park goroutines
+// and connections here indefinitely.
+func TestSysMCPContext_ImposesItsOwnCeiling(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/v1/sys/mcp", strings.NewReader("{}"))
+
+	ctx, cancel := sysMCPContext(r, namespace.RootNamespace)
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok, "the SDK blocks on this context; with no deadline nothing ends a stalled request")
+	assert.InDelta(t, sysMCPTimeout, time.Until(deadline), float64(5*time.Second))
+
+	// The namespace and raw request must survive the wrapping — the tool
+	// handlers resolve mounts through the first and recover the caller's
+	// credentials from the second.
+	ns, err := namespace.FromContext(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, namespace.RootNamespaceID, ns.ID)
+	assert.Same(t, r, mcpRequestFromContext(ctx))
 }

--- a/http/handler.go
+++ b/http/handler.go
@@ -18,12 +18,18 @@ import (
 	"github.com/stephnangue/warden/core"
 	"github.com/stephnangue/warden/listener"
 	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
 )
 
 const (
 	// defaultForwardingTimeout is the maximum time for a forwarded request to
 	// the active node before timing out, when not explicitly configured.
 	defaultForwardingTimeout = 60 * time.Second
+
+	// sysMCPPath is Warden's own MCP discovery endpoint. It is the one
+	// control-plane route that can answer with an open-ended SSE stream
+	// (subscriptions/listen), so the standby forwarder treats it specially.
+	sysMCPPath = "/v1/sys/mcp"
 )
 
 // HandlerProperties contains configuration for the HTTP handler
@@ -91,7 +97,7 @@ func Handler(props *HandlerProperties) http.Handler {
 	// capabilities (list_roles, get_skill). Registered before the /v1/sys/
 	// catch-all. Not in standbyAllowedPaths: it reads live mount/skill/
 	// introspection state, so standby nodes forward it to the active node.
-	mux.Handle("/v1/sys/mcp", handleSysMCP(core, log))
+	mux.Handle(sysMCPPath, handleSysMCP(core, log))
 
 	// System backend endpoints - catch-all for /v1/sys/
 	// Handles providers, auth, namespaces, credentials, etc.
@@ -405,6 +411,49 @@ func wrapGenericHandler(c *core.Core, handler http.Handler, log *logger.GatedLog
 	})
 }
 
+// isForwardedGatewayRequest reports whether r is provider gateway traffic —
+// what Warden proxies to an upstream, as opposed to its own control plane.
+//
+// Two shapes qualify, because a standby sees the request before core has
+// canonicalised it. The path shape matches the segment rule the providers'
+// own patterns use ("gateway" and "gateway/..."), so "/v1/mcp/gateway" and
+// "/v1/mcp/role/agent/gateway/foo" qualify while a mount named
+// "gateway-config" does not. The header shape catches header-routed clients:
+// wrapGenericHandler only prepends "/v1" to those, and the
+// "<mount>/role/<role>/gateway/<api>" path is synthesised later, on the
+// active node — so a header-routed request reaches here carrying the bare
+// upstream path and no gateway segment at all.
+//
+// sys/ is excluded outright: it is control plane whatever its last segment
+// happens to be, and X-Warden-Provider is rejected on it upstream of here.
+func isForwardedGatewayRequest(r *http.Request) bool {
+	// The origin-root well-known documents are resolved and forwarded ahead
+	// of the X-Warden-Provider rewrite, so they are the one shape that
+	// reaches here carrying the header without having been through it. A
+	// client that sets the header as a connection-wide default would
+	// otherwise have its discovery fetch classified as gateway traffic.
+	if isOIDCIssuerPath(r.URL.Path) || isPRMPath(r.URL.Path) {
+		return false
+	}
+	if strings.HasPrefix(r.URL.Path, "/v1/sys/") || r.URL.Path == "/v1/sys" {
+		return false
+	}
+	if r.Header.Get("X-Warden-Provider") != "" {
+		return true
+	}
+	for rest := r.URL.Path; rest != ""; {
+		i := strings.Index(rest, "/gateway")
+		if i < 0 {
+			return false
+		}
+		rest = rest[i+len("/gateway"):]
+		if rest == "" || rest[0] == '/' {
+			return true
+		}
+	}
+	return false
+}
+
 // forwardToActive forwards a request to the active node via the shared
 // reverse proxy. Falls back to a 307 redirect if the proxy is unavailable.
 func forwardToActive(c *core.Core, forwarder *standbyForwarder, w http.ResponseWriter, r *http.Request) {
@@ -418,6 +467,27 @@ func forwardToActive(c *core.Core, forwarder *standbyForwarder, w http.ResponseW
 
 	if clusterAddr != "" {
 		if proxy := forwarder.getProxy(clusterAddr, leaderAddr); proxy != nil {
+			// Traffic proxied from a standby is written on the standby's own
+			// listener, with the standby's deadlines armed. The active node
+			// clears its own when it takes the streaming branch, but that says
+			// nothing about this connection — without the same clear here an
+			// HA stream still dies at the standby's http_write_timeout.
+			//
+			// Gateway traffic and the MCP discovery endpoint both qualify:
+			// whatever the former proxies may run long, streaming or not, and
+			// the latter answers subscriptions/listen with an open-ended SSE
+			// stream. Both deadlines go, not just the write one — once the
+			// body is forwarded, an armed read deadline cancels the request
+			// context and tears down an idle stream. Everything else forwards
+			// under the standby's caps.
+			if isForwardedGatewayRequest(r) || r.URL.Path == sysMCPPath {
+				if err := logical.ClearStreamDeadlines(w); err != nil {
+					c.Logger().Warn("could not clear connection deadlines for forwarded request",
+						logger.Err(err),
+						logger.String("path", r.URL.Path),
+					)
+				}
+			}
 			proxy.ServeHTTP(w, r)
 			metrics.MeasureSince([]string{"ha", "forward", "duration"}, start)
 			metrics.IncrCounter([]string{"ha", "forward", "success"}, 1)

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -1044,3 +1044,59 @@ func TestWrapGenericHandler_StandbyAllowedPath(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Equal(t, "yes", w.Header().Get("X-Inner"))
 }
+
+// TestIsForwardedGatewayRequest pins which forwarded traffic sheds the
+// standby's connection deadlines. Too narrow and an HA stream dies at the
+// standby's http_write_timeout; too broad and forwarded control-plane calls
+// silently lose their cap.
+func TestIsForwardedGatewayRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		provider string // X-Warden-Provider
+		want     bool
+	}{
+		{name: "gateway root", path: "/v1/mcp/gateway", want: true},
+		{name: "gateway slash", path: "/v1/mcp/gateway/", want: true},
+		{name: "gateway suffix", path: "/v1/mcp/gateway/tools", want: true},
+		{name: "role-embedded gateway", path: "/v1/mcp/role/agent/gateway/", want: true},
+		{name: "git smart-HTTP", path: "/v1/github/gateway/repos/o/r/git-upload-pack", want: true},
+
+		// Header-routed clients never carry a gateway segment: the standby
+		// only prepends /v1, and core synthesises the canonical gateway path
+		// on the active node. Classifying on the path alone would leave every
+		// header-routed HA stream dying at the standby's write deadline.
+		{name: "header-routed, no gateway segment", path: "/v1/chat/completions", provider: "openai/", want: true},
+		{name: "header-routed git", path: "/v1/myorg/myrepo.git/info/refs", provider: "github/", want: true},
+
+		{name: "health", path: "/v1/sys/health", want: false},
+		{name: "login", path: "/v1/auth/cert/login", want: false},
+		{name: "policy read", path: "/v1/sys/policies/mcp/github-tools", want: false},
+		// sys/ is control plane whatever its last segment is, and
+		// X-Warden-Provider is rejected on it before forwarding.
+		{name: "sys path ending in gateway", path: "/v1/sys/policies/acl/gateway", want: false},
+		{name: "sys/mcp", path: "/v1/sys/mcp", want: false},
+		// A mount whose name merely begins with "gateway" is not a gateway
+		// path — the match is on the whole segment.
+		{name: "gateway-prefixed mount", path: "/v1/gateway-config/read", want: false},
+		{name: "gatewayish segment", path: "/v1/mcp/gatewayish/foo", want: false},
+		{name: "empty", path: "", want: false},
+
+		// The well-known documents are forwarded before the header rewrite
+		// runs, so a client carrying X-Warden-Provider as a connection-wide
+		// default must not have its discovery fetch read as gateway traffic.
+		{name: "oidc discovery with stray header", path: "/.well-known/openid-configuration", provider: "openai/", want: false},
+		{name: "jwks with stray header", path: "/oidc/jwks", provider: "openai/", want: false},
+		{name: "prm subtree with stray header", path: "/.well-known/oauth-protected-resource/mcp/gateway", provider: "mcp/", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, "http://warden.example.com/", nil)
+			r.URL.Path = tt.path
+			if tt.provider != "" {
+				r.Header.Set("X-Warden-Provider", tt.provider)
+			}
+			assert.Equal(t, tt.want, isForwardedGatewayRequest(r))
+		})
+	}
+}

--- a/listener/api/listener.go
+++ b/listener/api/listener.go
@@ -15,6 +15,15 @@ import (
 	"github.com/stephnangue/warden/logger"
 )
 
+// Built-in HTTP server deadlines, applied when the corresponding
+// ApiListenerConfig field is zero. These are the values the listener carried
+// before they became configurable.
+const (
+	DefaultReadTimeout  = 5 * time.Second
+	DefaultWriteTimeout = 10 * time.Second
+	DefaultIdleTimeout  = time.Minute
+)
+
 type ApiListener struct {
 	logger      *logger.GatedLogger
 	server      *http.Server
@@ -33,6 +42,20 @@ type ApiListenerConfig struct {
 	TLSDisable           bool     // default false => TLS on; requires TLSCertFile + TLSKeyFile
 	TLSRequireClientCert *bool    // nil = default (true when TLSClientCAFile set)
 	TrustedProxies       []string // CIDR ranges for LB cert forwarding
+
+	// ReadTimeout, WriteTimeout and IdleTimeout override the built-in HTTP
+	// server deadlines. Zero means use the default (5s read, 10s write,
+	// 1m idle).
+	//
+	// Read and write are armed when request headers are read and are
+	// absolute from that moment, so they cap the handler's whole execution
+	// rather than the response write alone. Streaming and proxied paths
+	// clear both per-connection via http.ResponseController — see
+	// logical.ClearStreamDeadlines — so these values govern the control
+	// plane, not gateway traffic.
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+	IdleTimeout  time.Duration
 
 	// TLSConfig, when non-nil, is used verbatim as the server's TLS config and
 	// supersedes the file-based TLS fields above (TLSCertFile/TLSKeyFile and the
@@ -56,12 +79,25 @@ func NewApiListener(cfg ApiListenerConfig, httpHandler http.Handler) (*ApiListen
 	handler = middleware.RequestID(handler)
 	handler = middleware.Recoverer(handler)
 
+	readTimeout := cfg.ReadTimeout
+	if readTimeout == 0 {
+		readTimeout = DefaultReadTimeout
+	}
+	writeTimeout := cfg.WriteTimeout
+	if writeTimeout == 0 {
+		writeTimeout = DefaultWriteTimeout
+	}
+	idleTimeout := cfg.IdleTimeout
+	if idleTimeout == 0 {
+		idleTimeout = DefaultIdleTimeout
+	}
+
 	server := &http.Server{
 		Addr:         cfg.Address,
 		Handler:      handler,
-		IdleTimeout:  time.Minute,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  idleTimeout,
+		ReadTimeout:  readTimeout,
+		WriteTimeout: writeTimeout,
 	}
 
 	switch {

--- a/listener/api/listener_test.go
+++ b/listener/api/listener_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/logger"
+	"github.com/stephnangue/warden/logical"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -557,4 +558,139 @@ func getFreePort(t *testing.T) int {
 	port := ln.Addr().(*net.TCPAddr).Port
 	ln.Close()
 	return port
+}
+
+// =============================================================================
+// HTTP deadline configuration
+// =============================================================================
+
+func TestNewApiListener_TimeoutDefaults(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+
+	ln, err := NewApiListener(ApiListenerConfig{
+		Logger:     log,
+		Address:    "127.0.0.1:0",
+		TLSDisable: true,
+	}, http.DefaultServeMux)
+
+	require.NoError(t, err)
+	assert.Equal(t, DefaultReadTimeout, ln.server.ReadTimeout)
+	assert.Equal(t, DefaultWriteTimeout, ln.server.WriteTimeout)
+	assert.Equal(t, DefaultIdleTimeout, ln.server.IdleTimeout)
+}
+
+func TestNewApiListener_TimeoutOverrides(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+
+	ln, err := NewApiListener(ApiListenerConfig{
+		Logger:       log,
+		Address:      "127.0.0.1:0",
+		TLSDisable:   true,
+		ReadTimeout:  11 * time.Second,
+		WriteTimeout: 22 * time.Second,
+		IdleTimeout:  33 * time.Second,
+	}, http.DefaultServeMux)
+
+	require.NoError(t, err)
+	assert.Equal(t, 11*time.Second, ln.server.ReadTimeout)
+	assert.Equal(t, 22*time.Second, ln.server.WriteTimeout)
+	assert.Equal(t, 33*time.Second, ln.server.IdleTimeout)
+}
+
+// TestApiListener_WriteTimeoutSeversSlowHandler pins the bug this knob was
+// added for: the write deadline is armed when request headers are read and is
+// absolute from that moment, so it kills a handler that runs longer than it —
+// the client gets a bare transport error, never a status. Reproducing this
+// against the shipped 10s default took ~13 seconds of wall clock, which is
+// most of why it survived; with the timeout configurable it is sub-second.
+func TestApiListener_WriteTimeoutSeversSlowHandler(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(600 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "too late")
+	})
+
+	addr := fmt.Sprintf("127.0.0.1:%d", getFreePort(t))
+	ln, err := NewApiListener(ApiListenerConfig{
+		Logger:       log,
+		Address:      addr,
+		TLSDisable:   true,
+		WriteTimeout: 200 * time.Millisecond,
+	}, handler)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go ln.Start(ctx)
+	defer ln.Stop()
+	waitForListener(t, addr)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("http://%s/slow", addr))
+	if err == nil {
+		resp.Body.Close()
+		t.Fatalf("expected the write deadline to sever the response, got %d", resp.StatusCode)
+	}
+	assert.NotErrorIs(t, err, context.DeadlineExceeded, "the client timed out, not the server deadline")
+}
+
+// TestApiListener_ClearedDeadlineSurvivesSlowHandler is the other half: a
+// handler that sheds the deadlines the way streaming and proxied paths do
+// completes normally past the same configured write timeout.
+func TestApiListener_ClearedDeadlineSurvivesSlowHandler(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Reported through the response rather than require.NoError: this
+		// runs on the server's goroutine, where a failed require would
+		// abort the wrong stack.
+		if err := logical.ClearStreamDeadlines(w); err != nil {
+			http.Error(w, "clear failed: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		time.Sleep(600 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "in time")
+	})
+
+	addr := fmt.Sprintf("127.0.0.1:%d", getFreePort(t))
+	ln, err := NewApiListener(ApiListenerConfig{
+		Logger:       log,
+		Address:      addr,
+		TLSDisable:   true,
+		WriteTimeout: 200 * time.Millisecond,
+	}, handler)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go ln.Start(ctx)
+	defer ln.Stop()
+	waitForListener(t, addr)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("http://%s/slow", addr))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "in time", string(body))
+}
+
+// waitForListener blocks until addr accepts a TCP connection, so a test does
+// not race the listener goroutine's bind.
+func waitForListener(t *testing.T, addr string) {
+	t.Helper()
+	for i := 0; i < 100; i++ {
+		conn, err := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("listener at %s never came up", addr)
 }

--- a/logical/response_writer.go
+++ b/logical/response_writer.go
@@ -1,8 +1,10 @@
 package logical
 
 import (
+	"errors"
 	"net/http"
 	"sync/atomic"
+	"time"
 )
 
 // StatusRecordingWriter wraps http.ResponseWriter to capture the status code
@@ -54,4 +56,70 @@ func (w *StatusRecordingWriter) Flush() {
 	if f, ok := w.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
+}
+
+// ClearStreamDeadlines removes both per-connection deadlines the HTTP server
+// armed when it read this request's headers. See SetStreamReadDeadline and
+// ClearStreamWriteDeadline for what each one does and why streaming traffic
+// cannot live under them.
+//
+// Callers that still have an unread request body should prefer clearing the
+// write deadline alone and holding a bounded read window over the read, so a
+// dribbling client stays bounded.
+func ClearStreamDeadlines(w http.ResponseWriter) error {
+	if err := SetStreamReadDeadline(w, time.Time{}); err != nil {
+		return err
+	}
+	return ClearStreamWriteDeadline(w)
+}
+
+// ClearStreamWriteDeadline removes the per-connection write deadline.
+//
+// It is absolute from the moment request headers were read, so it bounds the
+// whole handler rather than the write of a response: a proxied call that runs
+// longer than it dies with a bare EOF — no status, no body — and a response
+// that streams past it is truncated mid-flight. Neither is meaningful for
+// traffic Warden forwards to an upstream, whose real ceiling is the mount's
+// own timeout.
+//
+// Returns nil both when the deadline was cleared and when the writer does not
+// support deadlines at all (httptest.ResponseRecorder in tests) — a writer
+// with no connection behind it has none to shed. Any other error is the
+// caller's to log.
+func ClearStreamWriteDeadline(w http.ResponseWriter) error {
+	if w == nil {
+		return nil
+	}
+	err := http.NewResponseController(w).SetWriteDeadline(time.Time{})
+	if err != nil && !errors.Is(err, http.ErrNotSupported) {
+		return err
+	}
+	return nil
+}
+
+// SetStreamReadDeadline moves the per-connection read deadline; the zero time
+// removes it.
+//
+// The read deadline severs a slow upload mid-body — a large tools/call over a
+// slow link, a git push — and it does more than that on a long-lived
+// response: once the handler has drained the body, net/http reads the
+// connection in the background and cancels the request context when that read
+// fails, so an armed read deadline tears down an idle SSE stream even though
+// nothing is being read. Both are reasons a stream cannot keep it.
+//
+// Removing it outright is not free either: it is what bounds a client that
+// dribbles a request body, and on a streaming path that body is buffered
+// before the caller is authenticated. Hold a finite window across that
+// buffering and clear it afterwards, rather than clearing it up front.
+//
+// Errors are reported on the same terms as ClearStreamWriteDeadline.
+func SetStreamReadDeadline(w http.ResponseWriter, deadline time.Time) error {
+	if w == nil {
+		return nil
+	}
+	err := http.NewResponseController(w).SetReadDeadline(deadline)
+	if err != nil && !errors.Is(err, http.ErrNotSupported) {
+		return err
+	}
+	return nil
 }

--- a/logical/response_writer_deadline_test.go
+++ b/logical/response_writer_deadline_test.go
@@ -1,0 +1,111 @@
+package logical
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deadlineRecorder is a ResponseWriter that records the deadlines set on it,
+// standing in for a real connection. httptest.ResponseRecorder supports
+// neither, so it cannot distinguish "cleared" from "never attempted".
+type deadlineRecorder struct {
+	http.ResponseWriter
+	readSet  []time.Time
+	writeSet []time.Time
+	setErr   error
+}
+
+func newDeadlineRecorder() *deadlineRecorder {
+	return &deadlineRecorder{ResponseWriter: httptest.NewRecorder()}
+}
+
+func (d *deadlineRecorder) SetReadDeadline(t time.Time) error {
+	if d.setErr != nil {
+		return d.setErr
+	}
+	d.readSet = append(d.readSet, t)
+	return nil
+}
+
+func (d *deadlineRecorder) SetWriteDeadline(t time.Time) error {
+	if d.setErr != nil {
+		return d.setErr
+	}
+	d.writeSet = append(d.writeSet, t)
+	return nil
+}
+
+func TestClearStreamDeadlines_ClearsBoth(t *testing.T) {
+	rec := newDeadlineRecorder()
+
+	require.NoError(t, ClearStreamDeadlines(rec))
+
+	require.Len(t, rec.readSet, 1, "the read deadline governs a slow upload and must be cleared too")
+	require.Len(t, rec.writeSet, 1)
+	assert.True(t, rec.readSet[0].IsZero())
+	assert.True(t, rec.writeSet[0].IsZero())
+}
+
+// A writer with no connection behind it has no deadline to shed, so
+// ErrNotSupported is not a failure — httptest.ResponseRecorder takes this
+// path throughout the test suite.
+func TestClearStreamDeadlines_UnsupportedIsNotAnError(t *testing.T) {
+	assert.NoError(t, ClearStreamDeadlines(httptest.NewRecorder()))
+	assert.NoError(t, ClearStreamDeadlines(nil))
+}
+
+func TestClearStreamDeadlines_ReportsRealErrors(t *testing.T) {
+	rec := newDeadlineRecorder()
+	rec.setErr = errors.New("connection gone")
+
+	assert.ErrorContains(t, ClearStreamDeadlines(rec), "connection gone")
+}
+
+// ClearStreamDeadlines must see through the wrapper the HTTP layer puts on
+// every request's writer, or the clear would silently reach nothing.
+func TestClearStreamDeadlines_ThroughStatusRecordingWriter(t *testing.T) {
+	rec := newDeadlineRecorder()
+
+	require.NoError(t, ClearStreamDeadlines(NewStatusRecordingWriter(rec)))
+
+	assert.Len(t, rec.readSet, 1)
+	assert.Len(t, rec.writeSet, 1)
+}
+
+// Clearing the write deadline alone is what a caller with an unread request
+// body wants: the response is uncapped while a dribbling client stays bounded
+// by the read deadline the listener armed.
+func TestClearStreamWriteDeadline_LeavesTheReadDeadlineArmed(t *testing.T) {
+	rec := newDeadlineRecorder()
+
+	require.NoError(t, ClearStreamWriteDeadline(rec))
+
+	require.Len(t, rec.writeSet, 1)
+	assert.True(t, rec.writeSet[0].IsZero())
+	assert.Empty(t, rec.readSet, "the body has not been read yet; its bound must stay")
+}
+
+func TestSetStreamReadDeadline(t *testing.T) {
+	rec := newDeadlineRecorder()
+	window := time.Now().Add(time.Minute)
+
+	require.NoError(t, SetStreamReadDeadline(rec, window))
+	require.NoError(t, SetStreamReadDeadline(rec, time.Time{}))
+
+	require.Len(t, rec.readSet, 2)
+	assert.Equal(t, window, rec.readSet[0])
+	assert.True(t, rec.readSet[1].IsZero(), "the zero time removes the deadline")
+	assert.Empty(t, rec.writeSet)
+}
+
+func TestSetStreamReadDeadline_UnsupportedIsNotAnError(t *testing.T) {
+	assert.NoError(t, SetStreamReadDeadline(httptest.NewRecorder(), time.Now()))
+	assert.NoError(t, SetStreamReadDeadline(nil, time.Now()))
+	assert.NoError(t, ClearStreamWriteDeadline(nil))
+}

--- a/provider/mcp/provider.go
+++ b/provider/mcp/provider.go
@@ -7,16 +7,25 @@ import (
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/logical"
 	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 )
 
-// DefaultMCPTimeout caps a single MCP session. MCP responses can stream over
-// SSE for many tool calls, so the default sits well above the per-request
-// shapes that govern REST providers; operators raise this for longer sessions.
-// The value matches mcp_aws (the other MCP provider) so operators learn one
-// timeout knob across every MCP mount.
-const DefaultMCPTimeout = 10 * time.Minute
+// DefaultMCPTimeout caps a single call other than subscriptions/listen —
+// a tool call, a listing, a resource read. Open-ended streaming is no longer
+// its job: listen_timeout took that over, so this is a unary ceiling and
+// nothing more, and it dropped from ten minutes to sixty seconds when it
+// stopped having to cover a subscription.
+//
+// A ceiling is not a delay, but a long one multiplies how long a stalled
+// call holds its goroutine and both connections, and the transport caps
+// neither the number of upstream connections nor a peer that sends headers
+// and then dribbles. A tool that genuinely runs for minutes is meant to
+// report progress and be polled, not to hold a request open; mounts that
+// front one anyway raise timeout explicitly. The value matches mcp_aws so
+// operators learn one timeout knob across every MCP mount.
+const DefaultMCPTimeout = 60 * time.Second
 
 // Spec defines the generic mcp provider configuration for the httpproxy
 // framework.
@@ -54,6 +63,28 @@ var Spec = &httpproxy.ProviderSpec{
 	// here would break one-shot JSON clients.
 
 	ShouldEnforceMCPPolicy: shouldEnforceMCPPolicy,
+
+	// A subscriptions/listen stream is open-ended by design and answers to
+	// listen_timeout; every other call keeps the unary ceiling above.
+	SelectTimeout: httpproxy.SelectListenTimeout,
+	ExtraConfigFields: map[string]*framework.FieldSchema{
+		httpproxy.ListenTimeoutKey: httpproxy.ListenTimeoutField(),
+	},
+	OnConfigRead: func(state map[string]any) map[string]any {
+		return map[string]any{
+			httpproxy.ListenTimeoutKey: httpproxy.ReadListenTimeout(state).String(),
+		}
+	},
+	OnConfigWrite: func(d *framework.FieldData, state map[string]any) (map[string]any, error) {
+		if err := httpproxy.WriteListenTimeout(d, state); err != nil {
+			return nil, err
+		}
+		return state, nil
+	},
+	OnInitialize: func(config map[string]any, state map[string]any) map[string]any {
+		httpproxy.InitializeListenTimeout(config, state)
+		return state
+	},
 }
 
 // extractBearerToken injects the minted credential as Authorization: Bearer.
@@ -198,8 +229,13 @@ buffering or parsing is performed on them.
 Configuration:
 - mcp_url: MCP server base URL (required; no default)
 - max_body_size: Maximum request body size (default: 10MB, max: 100MB)
-- timeout: Session timeout (default: 10m). Raise for long agent sessions
-    that keep an SSE stream open across many tool calls.
+- timeout: Deadline for a single call — a tool call, a listing, a resource
+    read (default: 60s). Raise it for a mount fronting a genuinely slow tool;
+    it is also how long a hung call on this mount keeps its goroutine and its
+    two connections alive.
+- listen_timeout: Deadline for a subscriptions/listen stream (default: 10m).
+    Raise it for long-lived subscriptions. It governs that method only: a
+    long-running tool call streaming progress is still capped by timeout.
 - auto_auth_path: Auth mount path for implicit authentication (e.g.,
     'auth/jwt/')
 - default_role: Fallback role when not specified by header or URL path

--- a/provider/mcp/provider_test.go
+++ b/provider/mcp/provider_test.go
@@ -5,9 +5,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -152,4 +155,56 @@ func TestSpec(t *testing.T) {
 	// No default Accept: MCP clients negotiate their own, and forcing one would
 	// break a one-shot JSON client.
 	assert.Empty(t, Spec.DefaultAccept)
+}
+
+// The listen_timeout hooks are what make the mount's second deadline
+// reachable at all: the field must be declared, survive a write, be read back
+// in the shape that gets persisted, and come back from persisted config on
+// restart. A gap in any one of them leaves the mount silently on the default.
+func TestSpec_ListenTimeoutWiring(t *testing.T) {
+	require.NotNil(t, Spec.SelectTimeout, "without the hook every call takes the unary timeout")
+	require.Contains(t, Spec.ExtraConfigFields, httpproxy.ListenTimeoutKey)
+	require.NotNil(t, Spec.OnConfigWrite)
+	require.NotNil(t, Spec.OnConfigRead)
+	require.NotNil(t, Spec.OnInitialize)
+
+	schema := map[string]*framework.FieldSchema{
+		httpproxy.ListenTimeoutKey: Spec.ExtraConfigFields[httpproxy.ListenTimeoutKey],
+	}
+
+	state, err := Spec.OnConfigWrite(
+		&framework.FieldData{Raw: map[string]any{httpproxy.ListenTimeoutKey: "2h"}, Schema: schema},
+		map[string]any{},
+	)
+	require.NoError(t, err)
+
+	// OnConfigRead's output is both the config-read response and what gets
+	// persisted, so the string form has to round-trip back through
+	// OnInitialize.
+	read := Spec.OnConfigRead(state)
+	assert.Equal(t, "2h0m0s", read[httpproxy.ListenTimeoutKey])
+
+	restored := Spec.OnInitialize(read, map[string]any{})
+	assert.Equal(t, 2*time.Hour, httpproxy.ReadListenTimeout(restored))
+}
+
+func TestSpec_ListenTimeoutRejectsNonPositive(t *testing.T) {
+	schema := map[string]*framework.FieldSchema{
+		httpproxy.ListenTimeoutKey: Spec.ExtraConfigFields[httpproxy.ListenTimeoutKey],
+	}
+
+	_, err := Spec.OnConfigWrite(
+		&framework.FieldData{Raw: map[string]any{httpproxy.ListenTimeoutKey: "0s"}, Schema: schema},
+		map[string]any{},
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "greater than 0")
+}
+
+// The two MCP providers deliberately share their timeout defaults so
+// operators learn one knob across every MCP mount.
+func TestSpec_UnaryTimeoutIsNotTheStreamingCeiling(t *testing.T) {
+	assert.Equal(t, DefaultMCPTimeout, Spec.DefaultTimeout)
+	assert.Less(t, DefaultMCPTimeout, httpproxy.DefaultListenTimeout,
+		"a unary call must be bounded more tightly than an open-ended subscription")
 }

--- a/provider/mcp/skill.md
+++ b/provider/mcp/skill.md
@@ -79,9 +79,12 @@ JWT expired (typical TTL 5–60 min) — refresh it in the client config.
 - **Streamable HTTP / SSE flows through transparently.** The server's framing
   comes back unchanged, and the `Mcp-Session-Id` response header round-trips
   automatically so follow-up requests reach the same upstream session.
-- **Session timeout is mount-wide.** The mount's `timeout` config caps an entire
-  SSE session (default 10 minutes). For longer sessions, ask the operator to
-  raise it.
+- **Two mount-wide deadlines, picked by method.** `timeout` caps a single call —
+  a tool call, a listing, a resource read (default 60 seconds).
+  `listen_timeout` caps a `subscriptions/listen` stream (default 10 minutes),
+  and only that method: a long-running tool call streaming progress is still
+  bounded by `timeout`. Ask the operator to raise whichever one your workload
+  actually hits.
 - **Static-key upstreams that expect a non-`Authorization` header** (e.g.
   `x-api-key`) are not served by this provider — they need a dedicated one.
 - **Not in scope:** client-initiated OAuth (Dynamic Client Registration, PRM

--- a/provider/mcp_aws/gateway.go
+++ b/provider/mcp_aws/gateway.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/logger"
 	"github.com/stephnangue/warden/logical"
+	"github.com/stephnangue/warden/provider/sdk/httpproxy"
 	"github.com/stephnangue/warden/provider/sdk/mcpfilter"
 	"github.com/stephnangue/warden/provider/sdk/sigv4"
 )
@@ -64,11 +65,22 @@ func (b *mcpAWSBackend) handleGateway(ctx context.Context, req *logical.Request)
 		return
 	}
 
+	// Pick the deadline by request shape. A notification stream — modern
+	// subscriptions/listen, or the legacy standalone SSE GET — is open-ended
+	// by design and takes listen_timeout; everything else, a batch and the
+	// session-closing DELETE included, takes the unary timeout. Giving the
+	// whole mount the subscription's ceiling instead would let any hung call
+	// hold its goroutine and both connections just as long.
+	timeout := snap.timeout
+	if httpproxy.OpensNotificationStream(req) && snap.listenTimeout > 0 {
+		timeout = snap.listenTimeout
+	}
+
 	// Apply the timeout BEFORE reading the body so a slow client upload
 	// can't stall a worker indefinitely.
-	if snap.timeout > 0 {
+	if timeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, snap.timeout)
+		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 		r = r.WithContext(ctx)
 		req.HTTPRequest = r

--- a/provider/mcp_aws/gateway_test.go
+++ b/provider/mcp_aws/gateway_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -369,4 +370,94 @@ func TestHandleGateway_FiltersToolsList(t *testing.T) {
 	out := rec.Body.String()
 	assert.Contains(t, out, "get_x")
 	assert.NotContains(t, out, "delete_x", "denied tool must be pruned from the mcp_aws tools/list response")
+}
+
+// --- shape-aware deadline ---
+
+// mcp_aws implements MCPPolicyEnforced directly rather than going through
+// httpproxy's spec hooks, so its deadline selection is its own code path and
+// needs its own coverage.
+func TestHandleGateway_ListenTakesTheListenTimeout(t *testing.T) {
+	srv, _ := newCapturingUpstream(t)
+	defer srv.Close()
+
+	b := setupBackend(t)
+	configureBackendForUpstream(t, b, srv)
+	b.SetTimeout(30 * time.Second)
+	b.mu.Lock()
+	b.listenTimeout = time.Hour
+	b.mu.Unlock()
+
+	req, _ := makeMCPRequest("/gateway/", `{"jsonrpc":"2.0","id":1,"method":"subscriptions/listen"}`, stsCredential())
+	req.MCPDescriptor = &logical.MCPRequestDescriptor{
+		Calls: []logical.MCPCall{{Method: "subscriptions/listen"}},
+	}
+
+	b.handleGateway(context.Background(), req)
+
+	assert.Greater(t, remainingDeadline(t, req), 55*time.Minute,
+		"a subscriptions/listen stream must answer to listen_timeout, not the unary ceiling")
+}
+
+func TestHandleGateway_UnaryKeepsTheMountTimeout(t *testing.T) {
+	srv, _ := newCapturingUpstream(t)
+	defer srv.Close()
+
+	for _, tc := range []struct {
+		name  string
+		calls []logical.MCPCall
+	}{
+		{"tools/call", []logical.MCPCall{{Method: "tools/call", Name: "get_x"}}},
+		{"batch containing a listen", []logical.MCPCall{
+			{Method: "tools/call", BatchIndex: 0},
+			{Method: "subscriptions/listen", BatchIndex: 1},
+		}},
+		{"empty sentinel — the body-less GET/DELETE verbs", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := setupBackend(t)
+			configureBackendForUpstream(t, b, srv)
+			b.SetTimeout(30 * time.Second)
+			b.mu.Lock()
+			b.listenTimeout = time.Hour
+			b.mu.Unlock()
+
+			req, _ := makeMCPRequest("/gateway/", `{"jsonrpc":"2.0","id":1,"method":"tools/call"}`, stsCredential())
+			req.MCPDescriptor = &logical.MCPRequestDescriptor{Calls: tc.calls}
+
+			b.handleGateway(context.Background(), req)
+
+			assert.LessOrEqual(t, remainingDeadline(t, req), 30*time.Second)
+		})
+	}
+}
+
+// A provider with no MCP descriptor at all — nothing parsed this request as
+// MCP — must keep the mount timeout untouched.
+func TestHandleGateway_NoDescriptorKeepsTheMountTimeout(t *testing.T) {
+	srv, _ := newCapturingUpstream(t)
+	defer srv.Close()
+
+	b := setupBackend(t)
+	configureBackendForUpstream(t, b, srv)
+	b.SetTimeout(30 * time.Second)
+	b.mu.Lock()
+	b.listenTimeout = time.Hour
+	b.mu.Unlock()
+
+	req, _ := makeMCPRequest("/gateway/", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, stsCredential())
+
+	b.handleGateway(context.Background(), req)
+
+	assert.LessOrEqual(t, remainingDeadline(t, req), 30*time.Second)
+}
+
+// remainingDeadline reads the deadline handleGateway armed on the outgoing
+// request. The cancel func has already fired by the time the handler returns,
+// but a context's Deadline outlives its cancellation.
+func remainingDeadline(t *testing.T, req *logical.Request) time.Duration {
+	t.Helper()
+	dl, ok := req.HTTPRequest.Context().Deadline()
+	require.True(t, ok, "handleGateway must arm a deadline on the proxied request")
+	return time.Until(dl)
 }

--- a/provider/mcp_aws/path_config.go
+++ b/provider/mcp_aws/path_config.go
@@ -31,9 +31,10 @@ func (b *mcpAWSBackend) pathConfig() *framework.Path {
 			},
 			"timeout": {
 				Type:        framework.TypeDurationSecond,
-				Description: "Session timeout duration (default: 10m)",
+				Description: "Deadline for a single call other than subscriptions/listen (default: 60s)",
 				Default:     DefaultMCPAWSTimeout.String(),
 			},
+			httpproxy.ListenTimeoutKey: httpproxy.ListenTimeoutField(),
 			"auto_auth_path": {
 				Type:        framework.TypeString,
 				Description: "Path to auth mount for implicit authentication (e.g., 'auth/jwt/'). Required.",
@@ -84,6 +85,7 @@ func (b *mcpAWSBackend) handleConfigRead(_ context.Context, _ *logical.Request, 
 		"region":          b.region,
 		"max_body_size":   b.MaxBodySize(),
 		"timeout":         b.Timeout().String(),
+		"listen_timeout":  b.listenTimeout.String(),
 		"auto_auth_path":  tc.AutoAuthPath,
 		"default_role":    tc.DefaultAuthRole,
 		"user_auth_path":  tc.UserAuthPath,
@@ -109,12 +111,24 @@ func (b *mcpAWSBackend) handleConfigWrite(ctx context.Context, _ *logical.Reques
 	conf := b.snapshotForMerge()
 
 	for _, k := range []string{
-		"mcp_aws_url", "region", "max_body_size", "timeout",
+		"mcp_aws_url", "region", "max_body_size", "timeout", httpproxy.ListenTimeoutKey,
 		"auto_auth_path", "default_role", "user_auth_path", "user_auth_role",
 		"tls_skip_verify", "ca_data",
 	} {
 		if val, ok := d.GetOk(k); ok {
 			conf[k] = val
+		}
+	}
+
+	// Reject a non-positive listen_timeout rather than letting the parse fall
+	// back to the default: an operator asking for "0" is asking for something
+	// the mount cannot give, and silently substituting ten minutes hides that.
+	if val, ok := d.GetOk(httpproxy.ListenTimeoutKey); ok {
+		if secs, isInt := val.(int); !isInt || secs <= 0 {
+			return &logical.Response{
+				StatusCode: http.StatusBadRequest,
+				Err:        logical.ErrBadRequest(httpproxy.ListenTimeoutKey + " must be greater than 0"),
+			}, nil
 		}
 	}
 
@@ -171,6 +185,7 @@ func (b *mcpAWSBackend) snapshotForMerge() map[string]any {
 		"region":          b.configRegion,
 		"max_body_size":   b.MaxBodySize(),
 		"timeout":         b.Timeout().String(),
+		"listen_timeout":  b.listenTimeout.String(),
 		"auto_auth_path":  tc.AutoAuthPath,
 		"default_role":    tc.DefaultAuthRole,
 		"user_auth_path":  tc.UserAuthPath,

--- a/provider/mcp_aws/provider.go
+++ b/provider/mcp_aws/provider.go
@@ -65,9 +65,11 @@ func (b *mcpAWSBackend) ShouldEnforceMCPPolicy(req *logical.Request) (bool, int6
 // DefaultMCPAWSURL is the GA endpoint for AWS's hosted MCP Server.
 const DefaultMCPAWSURL = "https://aws-mcp.us-east-1.api.aws/mcp"
 
-// DefaultMCPAWSTimeout caps a single MCP session. MCP responses may stream
-// over SSE across many tool calls, so the default matches the generic mcp provider.
-const DefaultMCPAWSTimeout = 10 * time.Minute
+// DefaultMCPAWSTimeout caps a single call other than subscriptions/listen.
+// Streaming subscriptions answer to listen_timeout instead, so this is a
+// unary ceiling; it matches the generic mcp provider so operators learn one
+// knob across every MCP mount.
+const DefaultMCPAWSTimeout = 60 * time.Second
 
 // mcpAWSBackend is the streaming backend for mcp_aws.
 //
@@ -95,7 +97,11 @@ type mcpAWSBackend struct {
 	configRegion string
 	// region is the resolved signing region: coalesce(configRegion, URL-inferred).
 	// This is the value passed to sigv4.ResignRequest.
-	region        string
+	region string
+	// listenTimeout is the deadline for a subscriptions/listen stream. Held
+	// here rather than on the embedded StreamingBackend, which carries only
+	// the one mount-wide timeout.
+	listenTimeout time.Duration
 	tlsSkipVerify bool
 	caData        string
 }
@@ -187,6 +193,7 @@ func Factory(ctx context.Context, conf *logical.BackendConfig) (logical.Backend,
 	// Defaults until Initialize loads persisted config.
 	b.SetMaxBodySize(framework.DefaultMaxBodySize)
 	b.SetTimeout(DefaultMCPAWSTimeout)
+	b.listenTimeout = httpproxy.DefaultListenTimeout
 	if u, err := url.Parse(DefaultMCPAWSURL); err == nil {
 		b.upstreamURL = u
 		_, b.region = serviceAndRegion(u)
@@ -262,12 +269,14 @@ func (b *mcpAWSBackend) applyParsedConfig(conf map[string]any) (map[string]any, 
 	if timeout == 0 {
 		timeout = DefaultMCPAWSTimeout
 	}
+	listenTimeout := httpproxy.ParseListenTimeout(conf)
 
 	persist := map[string]any{
 		"mcp_aws_url":     u.String(),
 		"region":          configRegion,
 		"max_body_size":   maxBody,
 		"timeout":         timeout.String(),
+		"listen_timeout":  listenTimeout.String(),
 		"auto_auth_path":  parsed.AutoAuthPath,
 		"default_role":    parsed.DefaultAuthRole,
 		"user_auth_path":  parsed.UserAuthPath,
@@ -280,6 +289,7 @@ func (b *mcpAWSBackend) applyParsedConfig(conf map[string]any) (map[string]any, 
 	b.upstreamURL = u
 	b.configRegion = configRegion
 	b.region = resolvedRegion
+	b.listenTimeout = listenTimeout
 	b.tlsSkipVerify = parsed.TLSSkipVerify
 	b.caData = parsed.CAData
 	b.mu.Unlock()
@@ -343,21 +353,26 @@ type backendSnapshot struct {
 	region      string
 	maxBody     int64
 	timeout     time.Duration
-	transport   http.RoundTripper
+	// listenTimeout caps a subscriptions/listen stream, which is open-ended
+	// by design; every other call takes timeout above.
+	listenTimeout time.Duration
+	transport     http.RoundTripper
 }
 
 func (b *mcpAWSBackend) snapshot() backendSnapshot {
 	b.mu.RLock()
 	upstream := b.upstreamURL
 	region := b.region
+	listenTimeout := b.listenTimeout
 	b.mu.RUnlock()
 	// Framework-side fields are atomic; no lock needed.
 	return backendSnapshot{
-		upstreamURL: upstream,
-		region:      region,
-		maxBody:     b.MaxBodySize(),
-		timeout:     b.Timeout(),
-		transport:   b.Transport(),
+		upstreamURL:   upstream,
+		region:        region,
+		maxBody:       b.MaxBodySize(),
+		timeout:       b.Timeout(),
+		listenTimeout: listenTimeout,
+		transport:     b.Transport(),
 	}
 }
 
@@ -398,7 +413,13 @@ Configuration:
                   via DNS-label inference; required for hosts that don't
                   (GovCloud, China partition, custom test hosts).
 - max_body_size:  Maximum request body size (default: 10MB, max: 100MB)
-- timeout:        Session timeout (default: 10m)
+- timeout:        Deadline for a single call — a tool call, a listing, a
+                  resource read (default: 60s). It is also how long a hung
+                  call on this mount keeps its goroutine and its two
+                  connections alive.
+- listen_timeout: Deadline for a subscriptions/listen stream (default: 10m).
+                  It governs that method only: a long-running tool call
+                  streaming progress is still capped by timeout.
 - auto_auth_path: Auth mount path for implicit authentication (required)
 - default_role:   Fallback role when not specified by header or URL path
 `

--- a/provider/mcp_aws/provider_test.go
+++ b/provider/mcp_aws/provider_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"sync"
 	"testing"
+	"time"
 
 	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
 	"github.com/stretchr/testify/assert"
@@ -372,4 +373,102 @@ func TestConfigWrite_ExplicitRegionWins(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 200, resp.StatusCode)
 	assert.Equal(t, "us-west-2", b.region)
+}
+
+// --- listen_timeout ---
+
+// mcp_aws persists and reloads its own config rather than using httpproxy's
+// spec hooks, so the new field needs its own round-trip: a write must reach
+// the backend, be readable back, and survive a restart.
+func TestConfigWrite_ListenTimeoutRoundTrip(t *testing.T) {
+	b := setupBackend(t)
+	storage := newInmemStorage()
+	b.StorageView = storage
+
+	path := b.pathConfig()
+	fd := makeFieldData(path, map[string]any{
+		"mcp_aws_url":    "https://aws-mcp.us-east-1.api.aws/mcp",
+		"auto_auth_path": "auth/cert/",
+		"listen_timeout": "2h",
+	})
+	resp, err := b.handleConfigWrite(context.Background(), nil, fd)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	b.mu.RLock()
+	applied := b.listenTimeout
+	b.mu.RUnlock()
+	assert.Equal(t, 2*time.Hour, applied)
+
+	readResp, err := b.handleConfigRead(context.Background(), nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "2h0m0s", readResp.Data["listen_timeout"])
+
+	// Restart: a fresh backend must come back on the configured value, not
+	// the default.
+	fresh := setupBackend(t)
+	fresh.StorageView = storage
+	require.NoError(t, fresh.Initialize(context.Background()))
+	fresh.mu.RLock()
+	defer fresh.mu.RUnlock()
+	assert.Equal(t, 2*time.Hour, fresh.listenTimeout)
+}
+
+// A partial update must not silently reset the other deadline — the merge
+// base carries listen_timeout forward.
+func TestConfigWrite_ListenTimeoutSurvivesUnrelatedUpdate(t *testing.T) {
+	b := setupBackend(t)
+	path := b.pathConfig()
+
+	resp, err := b.handleConfigWrite(context.Background(), nil, makeFieldData(path, map[string]any{
+		"mcp_aws_url":    "https://aws-mcp.us-east-1.api.aws/mcp",
+		"auto_auth_path": "auth/cert/",
+		"listen_timeout": "45m",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	resp, err = b.handleConfigWrite(context.Background(), nil, makeFieldData(path, map[string]any{
+		"auto_auth_path": "auth/cert/",
+		"default_role":   "s3-reader",
+	}))
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.StatusCode)
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	assert.Equal(t, 45*time.Minute, b.listenTimeout)
+}
+
+func TestConfigWrite_ListenTimeoutRejectsNonPositive(t *testing.T) {
+	b := setupBackend(t)
+	path := b.pathConfig()
+
+	resp, err := b.handleConfigWrite(context.Background(), nil, makeFieldData(path, map[string]any{
+		"mcp_aws_url":    "https://aws-mcp.us-east-1.api.aws/mcp",
+		"auto_auth_path": "auth/cert/",
+		"listen_timeout": "0s",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, 400, resp.StatusCode, "substituting the default would hide the operator's mistake")
+}
+
+// A mount configured before listen_timeout existed comes up with the default
+// rather than a zero deadline, which would mean "no ceiling at all".
+func TestInitialize_ListenTimeoutDefaultsForOlderConfig(t *testing.T) {
+	storage := newInmemStorage()
+	entry, _ := sdklogical.StorageEntryJSON("config", map[string]any{
+		"mcp_aws_url":    "https://aws-mcp.us-east-1.api.aws/mcp",
+		"timeout":        "5m",
+		"auto_auth_path": "auth/cert/",
+	})
+	require.NoError(t, storage.Put(context.Background(), entry))
+
+	b := setupBackend(t)
+	b.StorageView = storage
+	require.NoError(t, b.Initialize(context.Background()))
+
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	assert.Equal(t, httpproxy.DefaultListenTimeout, b.listenTimeout)
 }

--- a/provider/mcp_aws/skill.md
+++ b/provider/mcp_aws/skill.md
@@ -88,8 +88,10 @@ convention. A `401` means the JWT expired (typical TTL 5–60 min) — refresh i
   (malformed JSON-RPC, duplicate keys, oversized body) also fail closed.
 - **Streamable HTTP / SSE flows through transparently.** The `Mcp-Session-Id`
   response header round-trips so follow-up requests reach the same session.
-- **Session timeout is mount-wide** (default 10 minutes); ask the operator to
-  raise it for longer sessions.
+- **Two mount-wide deadlines, picked by method.** `timeout` caps a single call
+  (default 60 seconds); `listen_timeout` caps a `subscriptions/listen` stream
+  (default 10 minutes), and only that method. Ask the operator to raise
+  whichever one your workload actually hits.
 - **STS credentials are short-lived.** A signed request is valid 15 minutes from
   `X-Amz-Date`; tool calls beyond that fail with a SigV4 expiration error rather
   than refreshing — restart the session for very long operations.

--- a/provider/sdk/httpproxy/gateway.go
+++ b/provider/sdk/httpproxy/gateway.go
@@ -20,18 +20,26 @@ func (b *proxyBackend) handleGateway(ctx context.Context, req *logical.Request) 
 	// Framework-side fields are atomic — read directly.
 	timeout := b.Timeout()
 	maxBody := b.MaxBodySize()
-	// Provider-local fields still need the RLock.
+	// Provider-local fields still need the RLock. extraState comes out of the
+	// same snapshot the spec hooks below read; it must not be mutated here.
 	b.mu.RLock()
 	providerURL := b.providerURL
 	proxy := b.Proxy
+	state := b.extraState
 	b.mu.RUnlock()
+
+	// A spec may pick a different deadline for this request shape than the
+	// mount-wide one — an MCP subscription is open-ended where a tool call is
+	// not. Zero means "keep the mount timeout".
+	if b.spec.SelectTimeout != nil {
+		if d := b.spec.SelectTimeout(req, state); d > 0 {
+			timeout = d
+		}
+	}
 
 	credExtractor := b.spec.ExtractCredentials
 	var dispatch Dispatch
 	if b.spec.ResolveUpstream != nil {
-		b.mu.RLock()
-		state := b.extraState
-		b.mu.RUnlock()
 		if d, ok := b.spec.ResolveUpstream(req.HTTPRequest, providerURL, state); ok {
 			dispatch = d
 			if d.UpstreamURL != "" {

--- a/provider/sdk/httpproxy/httpproxy_test.go
+++ b/provider/sdk/httpproxy/httpproxy_test.go
@@ -1440,3 +1440,124 @@ func TestCloneExtraState(t *testing.T) {
 		assert.False(t, hasC, "original must not gain new keys")
 	})
 }
+
+// =============================================================================
+// SelectTimeout — per-request deadline by request shape
+// =============================================================================
+
+// selectTimeoutProbe stands up a backend whose credential extractor reports
+// the deadline actually in force. The extractor runs after handleGateway has
+// applied the timeout to the outgoing request, so it observes the deadline
+// the proxied call will really live under.
+func selectTimeoutProbe(t *testing.T, spec *ProviderSpec) (*proxyBackend, *time.Duration) {
+	t.Helper()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	var seen time.Duration
+	spec.DefaultURL = upstream.URL
+	spec.ExtractCredentials = func(req *logical.Request) (map[string]string, error) {
+		if dl, ok := req.HTTPRequest.Context().Deadline(); ok {
+			seen = time.Until(dl)
+		}
+		return map[string]string{"Authorization": "Bearer test"}, nil
+	}
+
+	pb := setupBackend(t, spec).(*proxyBackend)
+	pb.providerURL = upstream.URL
+	pb.SetTimeout(30 * time.Second)
+	return pb, &seen
+}
+
+func gatewayCall(pb *proxyBackend, calls ...string) {
+	desc := &logical.MCPRequestDescriptor{}
+	for i, m := range calls {
+		desc.Calls = append(desc.Calls, logical.MCPCall{Method: m, BatchIndex: i})
+	}
+	pb.handleGateway(context.Background(), &logical.Request{
+		HTTPRequest:    httptest.NewRequest("POST", "/v1/test/gateway/", nil),
+		ResponseWriter: httptest.NewRecorder(),
+		MCPDescriptor:  desc,
+	})
+}
+
+func TestHandleGateway_SelectTimeout_ListenTakesTheLongerDeadline(t *testing.T) {
+	spec := testSpec()
+	spec.SelectTimeout = SelectListenTimeout
+	pb, seen := selectTimeoutProbe(t, spec)
+	pb.extraState = map[string]any{ListenTimeoutKey: time.Hour}
+
+	gatewayCall(pb, "subscriptions/listen")
+
+	assert.Greater(t, *seen, 55*time.Minute,
+		"a subscriptions/listen stream must answer to listen_timeout, not the unary ceiling")
+}
+
+// This is the row that fails if the shape-aware deadline is ever collapsed
+// back into a single knob: a hung tool call on the same mount must still die
+// at the unary timeout, whatever listen_timeout says.
+func TestHandleGateway_SelectTimeout_UnaryKeepsTheMountTimeout(t *testing.T) {
+	spec := testSpec()
+	spec.SelectTimeout = SelectListenTimeout
+	pb, seen := selectTimeoutProbe(t, spec)
+	pb.extraState = map[string]any{ListenTimeoutKey: time.Hour}
+
+	gatewayCall(pb, "tools/call")
+
+	assert.Greater(t, *seen, 20*time.Second)
+	assert.LessOrEqual(t, *seen, 30*time.Second)
+}
+
+// A batch is not characterised by one of its elements, and the body-less
+// GET/DELETE sentinel carries no method at all. Both take the unary ceiling.
+func TestHandleGateway_SelectTimeout_BatchAndSentinelKeepTheMountTimeout(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		calls []string
+	}{
+		{"batch containing a listen", []string{"tools/call", "subscriptions/listen"}},
+		{"empty sentinel", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := testSpec()
+			spec.SelectTimeout = SelectListenTimeout
+			pb, seen := selectTimeoutProbe(t, spec)
+			pb.extraState = map[string]any{ListenTimeoutKey: time.Hour}
+
+			gatewayCall(pb, tc.calls...)
+
+			assert.LessOrEqual(t, *seen, 30*time.Second)
+		})
+	}
+}
+
+// Every non-MCP provider leaves the hook unset and must be untouched.
+func TestHandleGateway_SelectTimeout_UnsetHookIsANoOp(t *testing.T) {
+	spec := testSpec()
+	require.Nil(t, spec.SelectTimeout)
+	pb, seen := selectTimeoutProbe(t, spec)
+
+	pb.handleGateway(context.Background(), &logical.Request{
+		HTTPRequest:    httptest.NewRequest("POST", "/v1/test/gateway/", nil),
+		ResponseWriter: httptest.NewRecorder(),
+	})
+
+	assert.Greater(t, *seen, 20*time.Second)
+	assert.LessOrEqual(t, *seen, 30*time.Second)
+}
+
+// Returning 0 is the hook's "keep the mount timeout" answer, and must not be
+// mistaken for "no deadline".
+func TestHandleGateway_SelectTimeout_ZeroKeepsTheMountTimeout(t *testing.T) {
+	spec := testSpec()
+	spec.SelectTimeout = func(*logical.Request, map[string]any) time.Duration { return 0 }
+	pb, seen := selectTimeoutProbe(t, spec)
+
+	gatewayCall(pb, "subscriptions/listen")
+
+	assert.Greater(t, *seen, 20*time.Second)
+	assert.LessOrEqual(t, *seen, 30*time.Second)
+}

--- a/provider/sdk/httpproxy/mcp_listen_timeout.go
+++ b/provider/sdk/httpproxy/mcp_listen_timeout.go
@@ -1,0 +1,159 @@
+package httpproxy
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// listenMethod is the MCP method that opens an open-ended notification
+// stream. Comparison is case-insensitive to match how the policy matcher
+// reads a method off the wire.
+const listenMethod = "subscriptions/listen"
+
+// ListenTimeoutKey is the config field and state key holding the per-mount
+// deadline for subscriptions/listen calls.
+const ListenTimeoutKey = "listen_timeout"
+
+// DefaultListenTimeout caps one subscriptions/listen stream. A listen stream
+// is meant to stay open for as long as the client wants notifications, so
+// this sits far above any unary shape. The value preserves the streaming
+// ceiling MCP mounts had when the mount timeout was the only knob.
+const DefaultListenTimeout = 10 * time.Minute
+
+// ListenTimeoutField returns the FieldSchema for the listen_timeout config
+// field. MCP providers spread this into their config fields under
+// ListenTimeoutKey.
+func ListenTimeoutField() *framework.FieldSchema {
+	return &framework.FieldSchema{
+		Type: framework.TypeDurationSecond,
+		Description: "Deadline for a subscriptions/listen stream (default: 10m). " +
+			"Every other call answers to timeout instead, so a long-running " +
+			"tool call is not covered by this value.",
+		Default: DefaultListenTimeout.String(),
+	}
+}
+
+// ParseListenTimeout reads listen_timeout from a persisted or mount config
+// map, in either the string form it is written back as or the numeric
+// seconds form a config write produces. Falls back to the default when the
+// key is absent or does not yield a positive duration.
+func ParseListenTimeout(conf map[string]any) time.Duration {
+	v, ok := conf[ListenTimeoutKey]
+	if !ok {
+		return DefaultListenTimeout
+	}
+	switch t := v.(type) {
+	case time.Duration:
+		if t > 0 {
+			return t
+		}
+	case string:
+		if d, err := time.ParseDuration(t); err == nil && d > 0 {
+			return d
+		}
+	case int:
+		if t > 0 {
+			return time.Duration(t) * time.Second
+		}
+	case int64:
+		if t > 0 {
+			return time.Duration(t) * time.Second
+		}
+	case float64:
+		if t > 0 {
+			return time.Duration(t) * time.Second
+		}
+	}
+	return DefaultListenTimeout
+}
+
+// ReadListenTimeout returns the listen_timeout held in a backend's extra
+// state, applying the default when unset. Providers call this from
+// ProviderSpec.OnConfigRead — where the string form is what gets persisted
+// and shown — and from their SelectTimeout hook.
+func ReadListenTimeout(state map[string]any) time.Duration {
+	d, _ := state[ListenTimeoutKey].(time.Duration)
+	if d <= 0 {
+		return DefaultListenTimeout
+	}
+	return d
+}
+
+// WriteListenTimeout validates an incoming listen_timeout from a config
+// write and stores the accepted value in state. State is left untouched
+// when the value is rejected, and when the field is absent from the write
+// payload this is a no-op. Providers call this from
+// ProviderSpec.OnConfigWrite.
+func WriteListenTimeout(d *framework.FieldData, state map[string]any) error {
+	val, ok := d.GetOk(ListenTimeoutKey)
+	if !ok {
+		return nil
+	}
+	secs, ok := val.(int)
+	if !ok {
+		return fmt.Errorf("%s must be a duration", ListenTimeoutKey)
+	}
+	if secs <= 0 {
+		return fmt.Errorf("%s must be greater than 0", ListenTimeoutKey)
+	}
+	state[ListenTimeoutKey] = time.Duration(secs) * time.Second
+	return nil
+}
+
+// InitializeListenTimeout loads listen_timeout from persisted config into
+// state. Providers call this from ProviderSpec.OnInitialize.
+func InitializeListenTimeout(config map[string]any, state map[string]any) {
+	state[ListenTimeoutKey] = ParseListenTimeout(config)
+}
+
+// OpensNotificationStream reports whether req opens an open-ended stream of
+// server notifications, in either protocol era.
+//
+// Modern era: a single subscriptions/listen call. The method comes off the
+// MCP descriptor core attached before the backend handler ran, so it is known
+// without touching the body again. Everything else on that side is false, and
+// deliberately: a batch cannot be characterised by one of its elements, and a
+// nil descriptor means this request was never parsed as MCP.
+//
+// Legacy era: the standalone SSE GET. It is subscriptions/listen's
+// predecessor and equally open-ended, but it carries no body, so it reaches
+// the backend as the empty sentinel with no method to read — the verb is the
+// only thing that identifies it. Without this branch a legacy notification
+// stream would answer to the unary ceiling, which is far below what it needs.
+func OpensNotificationStream(req *logical.Request) bool {
+	if req == nil {
+		return false
+	}
+	if req.HTTPRequest != nil && req.HTTPRequest.Method == http.MethodGet {
+		return true
+	}
+	if req.MCPDescriptor == nil {
+		return false
+	}
+	calls := req.MCPDescriptor.Calls
+	if len(calls) != 1 {
+		return false
+	}
+	return strings.EqualFold(calls[0].Method, listenMethod)
+}
+
+// SelectListenTimeout is the ProviderSpec.SelectTimeout implementation MCP
+// providers share: the mount's listen_timeout for a request that opens a
+// notification stream, and zero — meaning "keep the mount timeout" — for
+// every other shape.
+//
+// The split is the point. A subscription is open-ended and needs hours; a
+// tools/call is not, and giving the whole mount the subscription's ceiling
+// would let any hung call hold its goroutine and both connections for just
+// as long.
+func SelectListenTimeout(req *logical.Request, state map[string]any) time.Duration {
+	if !OpensNotificationStream(req) {
+		return 0
+	}
+	return ReadListenTimeout(state)
+}

--- a/provider/sdk/httpproxy/mcp_listen_timeout_test.go
+++ b/provider/sdk/httpproxy/mcp_listen_timeout_test.go
@@ -1,0 +1,184 @@
+package httpproxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stephnangue/warden/framework"
+	"github.com/stephnangue/warden/logical"
+)
+
+// listenReq builds a POST carrying the given JSON-RPC methods, which is the
+// only shape that produces parsed calls.
+func listenReq(methods ...string) *logical.Request {
+	calls := make([]logical.MCPCall, len(methods))
+	for i, m := range methods {
+		calls[i] = logical.MCPCall{Method: m, BatchIndex: i}
+	}
+	return verbReq(http.MethodPost, &logical.MCPRequestDescriptor{Calls: calls})
+}
+
+func verbReq(method string, desc *logical.MCPRequestDescriptor) *logical.Request {
+	return &logical.Request{
+		HTTPRequest:   httptest.NewRequest(method, "/v1/mcp/gateway/", nil),
+		MCPDescriptor: desc,
+	}
+}
+
+func TestOpensNotificationStream(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *logical.Request
+		want bool
+	}{
+		{"single listen", listenReq("subscriptions/listen"), true},
+		{
+			// The matcher lowercases a method before comparing, so the
+			// deadline picker must agree with it rather than admit a shape
+			// the gate would have treated as a listen.
+			name: "listen, odd casing",
+			req:  listenReq("Subscriptions/Listen"),
+			want: true,
+		},
+		{"tools/call", listenReq("tools/call"), false},
+		{
+			// A batch cannot be characterised by one of its elements: the
+			// unary ceiling is the safe reading.
+			name: "batch containing a listen",
+			req:  listenReq("tools/call", "subscriptions/listen"),
+			want: false,
+		},
+		{"batch of one listen", listenReq("subscriptions/listen", "subscriptions/listen"), false},
+		{
+			// A POST the backend declined to enforce on — a non-JSON
+			// Content-Type. No method to read, so no exemption.
+			name: "empty sentinel on a POST",
+			req:  verbReq(http.MethodPost, &logical.MCPRequestDescriptor{}),
+			want: false,
+		},
+		{
+			// The legacy standalone SSE stream. It carries no body, so it
+			// arrives as the empty sentinel and the verb is all there is to
+			// go on — but it is as open-ended as subscriptions/listen, and
+			// capping it at the unary ceiling would sever the legacy era's
+			// only notification channel.
+			name: "legacy SSE GET",
+			req:  verbReq(http.MethodGet, &logical.MCPRequestDescriptor{}),
+			want: true,
+		},
+		{
+			// DELETE closes a session. It shares the sentinel with the GET
+			// but is a one-shot, so it keeps the unary ceiling.
+			name: "session-closing DELETE",
+			req:  verbReq(http.MethodDelete, &logical.MCPRequestDescriptor{}),
+			want: false,
+		},
+		{
+			name: "parse error",
+			req: &logical.Request{MCPDescriptor: &logical.MCPRequestDescriptor{
+				ParseErr: &logical.MCPParseError{Kind: logical.MCPParseKindMalformedJSONRPC},
+			}},
+			want: false,
+		},
+		{"no descriptor — every non-MCP provider", &logical.Request{}, false},
+		{"nil request", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, OpensNotificationStream(tt.req))
+		})
+	}
+}
+
+// SelectListenTimeout returning 0 is what keeps the mount timeout in force;
+// only a listen may lift it.
+func TestSelectListenTimeout(t *testing.T) {
+	state := map[string]any{ListenTimeoutKey: 2 * time.Hour}
+
+	assert.Equal(t, 2*time.Hour, SelectListenTimeout(listenReq("subscriptions/listen"), state))
+	assert.Zero(t, SelectListenTimeout(listenReq("tools/call"), state))
+	assert.Zero(t, SelectListenTimeout(listenReq("tools/call", "subscriptions/listen"), state))
+	assert.Zero(t, SelectListenTimeout(&logical.Request{}, state))
+
+	// The legacy SSE GET is a notification stream too.
+	assert.Equal(t, 2*time.Hour, SelectListenTimeout(verbReq(http.MethodGet, nil), state))
+	assert.Zero(t, SelectListenTimeout(verbReq(http.MethodDelete, nil), state))
+
+	// An unconfigured mount still gets the default rather than falling back
+	// to the unary ceiling.
+	assert.Equal(t, DefaultListenTimeout, SelectListenTimeout(listenReq("subscriptions/listen"), map[string]any{}))
+}
+
+func TestParseListenTimeout(t *testing.T) {
+	tests := []struct {
+		name string
+		conf map[string]any
+		want time.Duration
+	}{
+		{"absent", map[string]any{}, DefaultListenTimeout},
+		{"string, as persisted", map[string]any{ListenTimeoutKey: "1h30m"}, 90 * time.Minute},
+		{"seconds, as a config write yields", map[string]any{ListenTimeoutKey: 45}, 45 * time.Second},
+		{"seconds as float, as JSON storage yields", map[string]any{ListenTimeoutKey: float64(45)}, 45 * time.Second},
+		{"duration", map[string]any{ListenTimeoutKey: 3 * time.Hour}, 3 * time.Hour},
+		{"unparseable string", map[string]any{ListenTimeoutKey: "soon"}, DefaultListenTimeout},
+		{"zero", map[string]any{ListenTimeoutKey: 0}, DefaultListenTimeout},
+		{"negative", map[string]any{ListenTimeoutKey: "-5m"}, DefaultListenTimeout},
+		{"wrong type", map[string]any{ListenTimeoutKey: true}, DefaultListenTimeout},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ParseListenTimeout(tt.conf))
+		})
+	}
+}
+
+func TestReadListenTimeout(t *testing.T) {
+	assert.Equal(t, DefaultListenTimeout, ReadListenTimeout(map[string]any{}))
+	assert.Equal(t, DefaultListenTimeout, ReadListenTimeout(map[string]any{ListenTimeoutKey: time.Duration(0)}))
+	assert.Equal(t, 5*time.Minute, ReadListenTimeout(map[string]any{ListenTimeoutKey: 5 * time.Minute}))
+}
+
+func TestWriteListenTimeout(t *testing.T) {
+	schema := map[string]*framework.FieldSchema{ListenTimeoutKey: ListenTimeoutField()}
+
+	fieldData := func(raw map[string]any) *framework.FieldData {
+		return &framework.FieldData{Raw: raw, Schema: schema}
+	}
+
+	t.Run("absent leaves state alone", func(t *testing.T) {
+		state := map[string]any{}
+		require.NoError(t, WriteListenTimeout(fieldData(map[string]any{}), state))
+		assert.Empty(t, state)
+	})
+
+	t.Run("accepted value is stored as a duration", func(t *testing.T) {
+		state := map[string]any{}
+		require.NoError(t, WriteListenTimeout(fieldData(map[string]any{ListenTimeoutKey: "1h"}), state))
+		assert.Equal(t, time.Hour, state[ListenTimeoutKey])
+	})
+
+	t.Run("non-positive is rejected and state is untouched", func(t *testing.T) {
+		state := map[string]any{ListenTimeoutKey: time.Hour}
+		err := WriteListenTimeout(fieldData(map[string]any{ListenTimeoutKey: "0s"}), state)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "greater than 0")
+		assert.Equal(t, time.Hour, state[ListenTimeoutKey], "a rejected write must not half-apply")
+	})
+}
+
+func TestInitializeListenTimeout(t *testing.T) {
+	state := map[string]any{}
+	InitializeListenTimeout(map[string]any{ListenTimeoutKey: "15m"}, state)
+	assert.Equal(t, 15*time.Minute, state[ListenTimeoutKey])
+
+	// A mount persisted before the field existed still comes up with a
+	// working ceiling.
+	state = map[string]any{}
+	InitializeListenTimeout(map[string]any{}, state)
+	assert.Equal(t, DefaultListenTimeout, state[ListenTimeoutKey])
+}

--- a/provider/sdk/httpproxy/provider.go
+++ b/provider/sdk/httpproxy/provider.go
@@ -196,6 +196,22 @@ type ProviderSpec struct {
 	// the framework's stream-body parser would consume the body before
 	// the MCP extractor runs.
 	ShouldEnforceMCPPolicy func(req *logical.Request) bool
+
+	// SelectTimeout optionally picks a per-request deadline in place of the
+	// mount's timeout, from whatever the gateway already knows about the
+	// request — for MCP providers, the parsed method on req.MCPDescriptor.
+	//
+	// Return 0 for "use the mount timeout"; that is also the behaviour when
+	// the hook is unset, so a provider that does not set it is untouched.
+	// state is the backend's extraState, handed off under the same read-lock
+	// snapshot as ResolveUpstream and subject to the same rule: read it,
+	// never mutate it.
+	//
+	// This exists so one mount can bound an open-ended subscription and an
+	// ordinary call differently. Raising the mount timeout to hold a stream
+	// open would instead give every hung call on the mount that same
+	// ceiling.
+	SelectTimeout func(req *logical.Request, state map[string]any) time.Duration
 }
 
 // proxyBackend is the concrete backend type created by NewFactory.


### PR DESCRIPTION
## The bug

`listener/api/listener.go` hardcoded `WriteTimeout: 10 * time.Second` on the one `http.Server` carrying all API and gateway traffic. Go arms that deadline when request headers are read and it is **absolute from that moment**, so it caps the handler's entire execution, not merely the response write. Nothing extended it, and it was not configurable from HCL.

Reproduced against the real `NewApiListener` with its shipped config:

| Case | Result |
|---|---|
| Handler takes 2s | `200`, body returned — fine |
| Handler takes 13s | transport error at 13.002s: bare `EOF` |
| SSE stream, 14 one-second ticks | cut at 11.011s after 10 ticks: `unexpected EOF` |

A non-streaming response over ~10s dies with **no status, no body, no 504** — the client cannot distinguish it from a network fault. A stream is truncated mid-flight.

**The blast radius is every provider.** `openai`, `anthropic`, `mistral` and `cohere` each independently set `DefaultTimeout = 120 * time.Second`, commented "default request timeout for AI inference". None of them was reachable: the listener capped them at ten seconds, so the `timeout` config key did nothing above that value on any mount. The e2e suite is green because every stub responds instantly.

`ReadTimeout: 5s` is the same bug inbound, and worse than it looks. It severs a slow proxied upload mid-body — a git push, a large `tools/call` over a slow link. And on a long-lived response it does something less obvious: once the handler has drained the body, net/http reads the connection in the background and **cancels the request context** when that read fails, so an armed read deadline tears down an idle SSE stream even though nothing is being read.

## What this changes

### 1. Configurable listener deadlines

`http_read_timeout`, `http_write_timeout` and `http_idle_timeout` on the listener block, validated as positive durations, plumbed through `api.ApiListenerConfig` and `initListeners`. Zero keeps today's values, so nothing moves without an operator asking.

This is also what makes the bug testable at unit speed: the regression test sets a 200ms write timeout and sleeps past it, where reproducing it against the hardcoded value took ~13 seconds of wall clock. That is most of why this survived.

### 2. Streaming traffic sheds the deadlines — in the one place that can

The write deadline goes for the whole request. The read deadline gets a **finite window** rather than a clear, because the body buffering happens *before* the caller is authenticated — the stream-body parser and the MCP extractor both read it, and the mount timeout that would otherwise bound them is not armed until the backend handler runs. Clearing it outright there would let an unauthenticated client dribble a body forever, holding a goroutine and a buffer with nothing to push back. The window closes once the body is in hand.

That ordering is why neither can live in the providers' gateway handlers, where the plan first put them: by the time one runs, the body has already been read under whatever deadline was in force. One site in `core/request_handler.go` covers httpproxy, mcp_aws and git; control-plane requests take the other branch and keep their caps.

The standby forwarder clears them too — a forwarded stream is written on the standby's own listener, with the standby's deadlines armed. Gateway traffic is identified by path **or by `X-Warden-Provider`**: header-routed requests reach a standby with no `gateway` segment at all, since core synthesises the canonical path on the active node.

### 3. `/v1/sys/mcp` is not exempt

Warden's own discovery endpoint runs the SDK in JSON mode, but the SDK forces SSE for `subscriptions/listen`, and a v1.7.0 client opens one during `Connect` whenever a list-changed handler is registered.

The deadlines cannot be shed reactively on seeing an event-stream `Content-Type`: the SDK sets that on the header map and then blocks in `hangResponse` without writing a byte, so there is nothing to observe until the first notification — by which point both deadlines have fired. The endpoint buffers the request body first (capped, under the deadlines the listener armed, which is what bounds a dribbling client), then sheds them, then imposes a ceiling of its own — it accepts a listen stream *before* any credential is checked, and a route with no ceiling is somewhere strangers can park goroutines.

### 4. A deadline picked by request shape, not a raised mount timeout

With the listener deadline gone, the mount `timeout` becomes the real ceiling — and it is a single knob wrapping both a 200ms `tools/call` and an indefinite `subscriptions/listen`. Raising it to hold a stream open would give every *hung* call on that mount the same ceiling.

A new `SelectTimeout` spec hook picks the deadline from what the gateway already knows:

| Request | Ceiling |
|---|---|
| `subscriptions/listen`, or the legacy standalone SSE `GET` | `listen_timeout` (default 10m) |
| tool call, listing, batch, session-closing `DELETE`, non-JSON POST | `timeout` (default 60s) |
| nil descriptor — every non-MCP provider | untouched |

The legacy SSE `GET` carries no body, so it reaches the backend as the empty sentinel with no method to read; the verb is the only thing that identifies it. Without that branch the legacy era's only notification channel would answer to the unary ceiling.

`timeout` is deliberately **not** renamed: it lives on `framework.StreamingBackend` and is a documented key on every provider — alicloud, azure, github, slack, vault.

## Breaking change

The default `timeout` on `mcp` and `mcp_aws` drops from **10 minutes to 60 seconds**, for newly created mounts only — an existing mount persisted its resolved value at first `Initialize` and keeps it.

It now caps a single call rather than a session: `subscriptions/listen` and the legacy SSE GET answer to the new `listen_timeout`, which defaults to the previous 10 minutes, so today's effective streaming ceiling is preserved exactly. A mount fronting a tool that legitimately runs longer than a minute, or one whose calls block on server-initiated sampling round-trips, must set `timeout` explicitly.

A long-running tool call streaming progress notifications is still capped by `timeout`, not `listen_timeout`. That is the intended split — a unary call should be bounded more tightly than an open-ended subscription — and the provider help text and both skill docs say so.

## Usage

```hcl
listener "tcp" {
  address            = "0.0.0.0:8400"
  tls_cert_file      = "/etc/warden/tls/cert.pem"
  tls_key_file       = "/etc/warden/tls/key.pem"
  http_read_timeout  = "10s"
  http_write_timeout = "30s"   # control plane only; gateway streams are exempt
  http_idle_timeout  = "2m"
}
```

```bash
warden provider enable mcp -path=github-mcp -json '{
  "description": "GitHub MCP"
}'

warden write github-mcp/config <<'EOF'
{
  "mcp_url":        "https://api.githubcopilot.com/mcp",
  "timeout":        "60s",
  "listen_timeout": "1h",
  "max_body_size":  10485760
}
EOF
```

## Verification

`go build ./...`, `go vet`, and `go test ./... -count=1` are clean. `-race` is clean on all seven touched packages (`core`, `logical`, `http`, `listener/api`, `provider/sdk/httpproxy`, `provider/mcp`, `provider/mcp_aws`).

Tests worth naming, each pinning a distinct regression:

- `TestApiListener_WriteTimeoutSeversSlowHandler` / `..._ClearedDeadlineSurvivesSlowHandler` — reproduce the bug and its fix sub-second.
- `TestHandleNonLoginRequest_StreamingClearsConnectionDeadlines` — asserts the **ordering**: write deadline gone, read window armed and not yet lifted, at the moment the body is buffered. Moving the clear later would fail it.
- `TestMCPServerHandler_ShedsConnectionDeadlines` / `..._BufferedBodyStillReaches` / `TestSysMCPContext_ImposesItsOwnCeiling`.
- `TestHandleGateway_SelectTimeout_*` — listen vs unary vs batch vs sentinel vs unset hook vs zero return. The unary row is what fails if the shape-aware deadline is ever collapsed back into one knob.
- `TestIsForwardedGatewayRequest` — including header-routed traffic with no gateway segment, and the well-known documents that must not be misread as gateway traffic.

## Deliberately deferred

An **idle** deadline reset on each flush. "No bytes for five minutes" is the real signal for a dead stream, where "open for two hours" is a healthy one — but it needs wrapping the response writer and calling `SetWriteDeadline` per flush. Worth doing if streams become common.

Also noted for the release-prep doc pass: the site docs still state the 10m default in six places, and no provider's `Configuration:` help block lists `user_auth_path` / `user_auth_role` (a pre-existing repo-wide gap, not specific to this change).
