### PR TITLE
feat(policy): exempt server/discover from the MCP method gate

### DIFF
--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -81,6 +81,12 @@ const (
 	mcpMethodPromptsGet    = "prompts/get"
 )
 
+// mcpMethodServerDiscover is the 2026-07-28 revision's MUST-implement
+// discovery RPC, which a modern client sends as the first request of every
+// HTTP connection. It replaces initialize's role at the head of a session
+// without establishing one.
+const mcpMethodServerDiscover = "server/discover"
+
 // ErrMCPPolicyDenied carries the MCPDecision that produced a deny so
 // the HTTP response layer can render the OAuth-shaped 403 body and the
 // WWW-Authenticate header. Unwraps to sdklogical.ErrPermissionDenied
@@ -461,9 +467,28 @@ func evaluateMCPCall(sets []*CBPMCPRules, call *logical.MCPCall, act *celActivat
 // improving the security posture. An explicit denied_methods entry still
 // blocks them, because the deny gate runs first. method is expected
 // lowercased.
+//
+// The set spans two protocol eras. initialize and ping open and maintain a
+// session in the legacy revisions; server/discover is what the 2026-07-28
+// revision sends instead, as the first request of every HTTP connection.
+// Without the exemption a modern client is forced into a legacy downgrade to
+// initialize on every mount, or fails outright against an upstream that
+// speaks only the modern revision. It discloses protocol versions, coarse
+// capabilities and serverInfo — never tool, resource or prompt names — so
+// exempting it leaks nothing the gate was protecting.
+//
+// subscriptions/listen is deliberately NOT here despite also being new in
+// 2026-07-28: it opens a stream of server notifications, which is data
+// access, and its resource URIs answer to the resources family.
+//
+// Neither is this an exemption from absence-deny. A path with no MCP
+// contract in scope refuses every MCP-shaped request, these included, before
+// any gate runs — otherwise a caller holding no contract could probe which
+// mounts exist. The fix there is attaching a contract, not widening this.
 func isLifecycleMethod(method string) bool {
 	return method == "initialize" ||
 		method == "ping" ||
+		method == mcpMethodServerDiscover ||
 		strings.HasPrefix(method, "notifications/")
 }
 
@@ -490,7 +515,8 @@ func isNameBearingMethod(method string) bool {
 // Deny-by-default: an empty allowed_methods denies every non-lifecycle
 // method, and an empty allowed_<family> denies every tool/resource/prompt.
 // Operators open a mount with allowed_* = ["*"]. Session-lifecycle methods
-// (initialize, ping, notifications/*) are exempt from the method gate.
+// (initialize, ping, server/discover, notifications/*) are exempt from the
+// method gate.
 func evaluateMCPGates(set *CBPMCPRules, method, name string) *logical.MCPDecision {
 	// (a) Missing method → deny. The body-authoritative parser rejects an
 	// empty method as malformed_jsonrpc before we get here, so this branch

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -176,7 +176,12 @@ path "mcp/gateway/*" {
   tools { allowed = ["*"] }
 }
 `)
-	for _, method := range []string{"initialize", "ping", "notifications/initialized"} {
+	// server/discover joins the set from the 2026-07-28 revision: a modern
+	// client sends it as the first request of every HTTP connection, so
+	// without the exemption every one of them is forced into a legacy
+	// downgrade to initialize — or fails outright against a modern-only
+	// upstream.
+	for _, method := range []string{"initialize", "ping", "notifications/initialized", "server/discover"} {
 		body := `{"jsonrpc":"2.0","method":"` + method + `","id":1}`
 		if strings.HasPrefix(method, "notifications/") {
 			body = `{"jsonrpc":"2.0","method":"` + method + `"}` // notification, no id
@@ -284,6 +289,50 @@ path "mcp/gateway/*" {
 	assert.Equal(t, "deny", res.MCPDecision.Decision)
 	assert.Equal(t, "tools/call", res.MCPDecision.MatchedRule)
 	assert.Equal(t, mcpRuleTypeDeniedMethods, res.MCPDecision.RuleType)
+}
+
+func TestMCPEval_ServerDiscover_ExplicitDenyStillBlocks(t *testing.T) {
+	// The exemption only rescues server/discover from deny-by-default. An
+	// operator who names it in denied_methods still blocks it, because the
+	// deny gate runs first — that ordering is what makes the exemption narrow
+	// enough to be safe.
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods {
+    allowed = ["tools/list"]
+    denied  = ["server/discover"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", `{"jsonrpc":"2.0","method":"server/discover","id":1}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeDeniedMethods, res.MCPDecision.RuleType)
+	assert.Equal(t, "server/discover", res.MCPDecision.MatchedRule)
+}
+
+func TestMCPEval_ServerDiscover_AbsenceDenyStillRefuses(t *testing.T) {
+	// The lifecycle exemption is not an exemption from absence-deny. On a
+	// path with a capability grant but no contract, server/discover is
+	// refused like everything else — otherwise a caller holding no MCP
+	// contract could probe which mounts exist by watching which ones answer.
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", `{"jsonrpc":"2.0","method":"server/discover","id":1}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeNoMCPPolicy, res.MCPDecision.RuleType)
 }
 
 func TestMCPEval_NoMCPPolicy_Denies(t *testing.T) {


### PR DESCRIPTION
**Stack 1/8** — MCP 2026-07-28 alignment. Base: `main`.

## The problem

`server/discover` is the 2026-07-28 revision's MUST-implement discovery RPC, and the go-sdk client sends it as **the first request of every HTTP connection**. It was not in `isLifecycleMethod`, so deny-by-default refused it — forcing every modern client into a legacy downgrade to `initialize`, or failing outright against an upstream that speaks only the modern revision.

## The change

One line of behaviour: `server/discover` joins `initialize`, `ping` and `notifications/*` in the exempt set, behind a named constant. The set now spans two protocol eras, and the comment says so — `initialize` opens a session in the legacy revisions; `server/discover` is what the modern revision sends at the head of a connection *without* establishing one.

It discloses protocol versions, coarse capabilities and `serverInfo` — never tool, resource or prompt names — so exempting it leaks nothing the gate was protecting.

## Two things it deliberately does not change

Both are load-bearing, and both are now pinned by tests rather than left to be re-derived:

**`denied_methods` still wins.** The deny gate runs *before* the exemption, so an operator can still block it by name. The exemption only rescues it from deny-by-default — which is what keeps it narrow enough to be safe, and it came for free.

**Absence-deny still refuses it.** A path with a capability grant but no MCP contract denies every MCP-shaped request with `no_mcp_policy` before any gate runs. Exempting lifecycle methods there would let a caller holding no contract probe which mounts exist by watching which ones answer. The fix for a legitimate caller is attaching a contract, not widening this.

`subscriptions/listen` is also new in 2026-07-28 and is deliberately left out: it opens a stream of server notifications, which is data access. Stack 2 gates those.

## Effect on policy authoring

```hcl
path "github-mcp/gateway/*" {
  methods { allowed = ["tools/list", "tools/call"] }
  tools   { allowed = ["get_repository", "list_issues"] }
}
```

`server/discover` needs no `allowed` entry, exactly as `initialize` / `ping` / `notifications/*` need none. `denied = ["server/discover"]` still blocks it.

## Verification

`go build ./...`, `go vet`, `go test ./... -count=1` clean.

- `TestMCPEval_LifecycleMethods_ExemptFromMethodGate` — added to the existing table; allowed under a contract that allow-lists only `tools/list`, stamped `(lifecycle)`.
- `TestMCPEval_ServerDiscover_ExplicitDenyStillBlocks`
- `TestMCPEval_ServerDiscover_AbsenceDenyStillRefuses`

`BenchmarkAllowOperation_*` unchanged against its baselines — the exemption adds one string comparison to a path that already ran three.

Covered end to end in stack 7 (`TestMCPEra_ServerDiscover*`), including the modern-client/legacy-upstream fallback.

## Not marked breaking

The `mcp` document grammar has never shipped in a tagged release, so no contract in the wild changes meaning.
