### PR TITLE
feat(policy): gate resource subscriptions, in both protocol eras

### DIFF
--- a/core/policy_jsonrpc.go
+++ b/core/policy_jsonrpc.go
@@ -28,6 +28,11 @@ const maxJSONDepth = 32
 // tools/call only (raw bytes per argument key so callers can do their
 // own type discrimination); nil for any other method.
 //
+// URIs is populated for subscriptions/listen only, from
+// params.notifications.resourceSubscriptions — the resource URIs whose
+// update notifications the caller is asking to receive. nil for any other
+// method, and for a listen that subscribes only to list-changed events.
+//
 // RawParams retains the verbatim params bytes for matcher-internal use.
 // It is descriptor-only and MUST NOT be copied to MCPDecision, the
 // audit record, or the client response.
@@ -35,6 +40,7 @@ type JSONRPCRequest struct {
 	Method    string
 	Name      string
 	Arguments map[string]json.RawMessage
+	URIs      []string
 	RawParams json.RawMessage
 }
 
@@ -86,7 +92,9 @@ func (e *ParseError) Error() string {
 //   - Nesting deeper than maxJSONDepth inside params.
 //   - method-specific shape mismatches: tools/call without params.name
 //     or with non-object params.arguments, resources/read without
-//     params.uri, prompts/get without params.name.
+//     params.uri, prompts/get without params.name,
+//     subscriptions/listen with a non-array or over-long
+//     params.notifications.resourceSubscriptions.
 //
 // Callers are responsible for bounding the input size (Content-Length
 // and io.LimitReader at the handler boundary) — this function does NOT
@@ -273,12 +281,114 @@ func extractMethodShape(req *JSONRPCRequest) *ParseError {
 	switch strings.ToLower(req.Method) {
 	case "tools/call":
 		return extractToolsCall(req)
-	case "resources/read":
+	case "resources/read", "resources/subscribe":
 		return extractByParamKey(req, "uri")
 	case "prompts/get":
 		return extractByParamKey(req, "name")
+	case "subscriptions/listen":
+		return extractSubscriptionsListen(req)
 	}
 	return nil
+}
+
+// maxResourceSubscriptions caps how many URIs one subscriptions/listen may
+// name. Each one is matched against the resources family's deny- and
+// allow-lists, so an unbounded array is an unbounded amount of pattern
+// matching bought with a single request. Far above any real client: the
+// go-sdk opens one listen stream per session.
+const maxResourceSubscriptions = 256
+
+// extractSubscriptionsListen populates URIs from
+// params.notifications.resourceSubscriptions, the resource URIs whose update
+// notifications the caller wants pushed on the stream it is opening.
+//
+// Everything here is optional, because a listen has legitimate shapes that
+// name no resource at all — subscribing only to tools/prompts/resources
+// list-changed events. Absent params, absent notifications, or an absent
+// array all yield nil URIs, and the request is then governed by the method
+// gate alone. A present-but-wrong type is a different matter and fails
+// closed, matching extractToolsCall's strictness: the alternative is
+// silently ignoring a field that decides what the caller gets to watch.
+func extractSubscriptionsListen(req *JSONRPCRequest) *ParseError {
+	if len(req.RawParams) == 0 {
+		return nil
+	}
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(req.RawParams, &top); err != nil {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: "subscriptions/listen params must be an object"}
+	}
+
+	notifRaw, ok, perr := lookupParamKey(top, "notifications", "subscriptions/listen")
+	if perr != nil {
+		return perr
+	}
+	if !ok || string(notifRaw) == "null" {
+		return nil
+	}
+	var notif map[string]json.RawMessage
+	if err := json.Unmarshal(notifRaw, &notif); err != nil {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: "subscriptions/listen params.notifications must be an object"}
+	}
+
+	subsRaw, ok, perr := lookupParamKey(notif, "resourceSubscriptions", "subscriptions/listen")
+	if perr != nil {
+		return perr
+	}
+	if !ok || string(subsRaw) == "null" {
+		return nil
+	}
+	var uris []string
+	if err := json.Unmarshal(subsRaw, &uris); err != nil {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: "subscriptions/listen params.notifications.resourceSubscriptions must be an array of strings"}
+	}
+	// Checked after decoding rather than before: the array has already been
+	// tokenised by the duplicate-key walk and is bounded by the handler's body
+	// cap, so the allocation is not the cost this guards. What it bounds is the
+	// per-URI matching against every rule-set's resource patterns below.
+	if len(uris) > maxResourceSubscriptions {
+		return &ParseError{Kind: ErrKindMalformedParams, Msg: "subscriptions/listen names too many resource subscriptions"}
+	}
+	for _, u := range uris {
+		if u == "" {
+			return &ParseError{Kind: ErrKindMalformedParams, Msg: "subscriptions/listen resource subscription must be non-empty"}
+		}
+	}
+	req.URIs = uris
+	return nil
+}
+
+// lookupParamKey finds key in a decoded params object, accepting any casing,
+// and reports an ambiguity when more than one spelling is present.
+//
+// The reason is that Warden judges the body and then forwards it verbatim.
+// Go's encoding/json matches object keys to struct fields case-insensitively,
+// so an upstream built on it — the go-sdk included — honours "Arguments" and
+// "Notifications" exactly as it honours the canonical spelling. An
+// exact-match lookup here would read neither, and for the fields that are
+// optional that means the gate silently passes something the upstream then
+// acts on. Matching the same way the decoder downstream will is what closes
+// that; two spellings at once is unresolvable, since the decoder picks one by
+// map order, so it fails closed.
+//
+// This mirrors the reasoning already applied to method names above: be more
+// permissive in what is recognised, so a case-mismatch cannot route around
+// the policy.
+func lookupParamKey(obj map[string]json.RawMessage, key, method string) (json.RawMessage, bool, *ParseError) {
+	var found json.RawMessage
+	var seen bool
+	for k, v := range obj {
+		if !strings.EqualFold(k, key) {
+			continue
+		}
+		if seen {
+			return nil, false, &ParseError{
+				Kind: ErrKindMalformedParams,
+				Msg:  method + " params has more than one spelling of " + key,
+			}
+		}
+		found, seen = v, true
+	}
+	return found, seen, nil
 }
 
 // extractToolsCall populates Name from params.name (required, non-empty
@@ -293,7 +403,10 @@ func extractToolsCall(req *JSONRPCRequest) *ParseError {
 		return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call params must be an object"}
 	}
 
-	nameRaw, ok := top["name"]
+	nameRaw, ok, perr := lookupParamKey(top, "name", "tools/call")
+	if perr != nil {
+		return perr
+	}
 	if !ok {
 		return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call missing params.name"}
 	}
@@ -306,7 +419,15 @@ func extractToolsCall(req *JSONRPCRequest) *ParseError {
 	}
 	req.Name = name
 
-	if argsRaw, ok := top["arguments"]; ok {
+	// arguments is optional, which is what makes reading it case-insensitively
+	// load-bearing rather than cosmetic: MatchArgs feeds the CEL activation's
+	// call.args and the param gates, so a spelling Warden cannot see is a
+	// condition evaluated against arguments that were never there.
+	argsRaw, ok, perr := lookupParamKey(top, "arguments", "tools/call")
+	if perr != nil {
+		return perr
+	}
+	if ok {
 		var args map[string]json.RawMessage
 		if err := json.Unmarshal(argsRaw, &args); err != nil {
 			return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call params.arguments must be an object"}
@@ -329,7 +450,10 @@ func extractByParamKey(req *JSONRPCRequest, key string) *ParseError {
 		return &ParseError{Kind: ErrKindMalformedParams, Msg: req.Method + " params must be an object"}
 	}
 
-	raw, ok := top[key]
+	raw, ok, perr := lookupParamKey(top, key, req.Method)
+	if perr != nil {
+		return perr
+	}
 	if !ok {
 		return &ParseError{Kind: ErrKindMalformedParams, Msg: req.Method + " missing params." + key}
 	}

--- a/core/policy_jsonrpc_test.go
+++ b/core/policy_jsonrpc_test.go
@@ -512,3 +512,228 @@ func BenchmarkParseJSONRPCStrict_UnknownTopLevel(b *testing.B) {
 		}
 	}
 }
+
+// =============================================================================
+// subscriptions/listen resource subscriptions
+// =============================================================================
+
+func TestParseJSONRPCStrict_SubscriptionsListen(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			name: "resource subscriptions extracted",
+			body: `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{"notifications":{"resourceSubscriptions":["repo://a","repo://b"]}},"id":1}`,
+			want: []string{"repo://a", "repo://b"},
+		},
+		{
+			// A list-changed-only listen names no resource. Legitimate and
+			// common — it is what the go-sdk opens when a client registers a
+			// list-changed handler — and it is governed by the method gate
+			// alone.
+			name: "list-changed only yields no URIs",
+			body: `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{"notifications":{"toolsListChanged":true}},"id":1}`,
+			want: nil,
+		},
+		{
+			name: "notifications absent",
+			body: `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{},"id":1}`,
+			want: nil,
+		},
+		{
+			name: "notifications null",
+			body: `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{"notifications":null},"id":1}`,
+			want: nil,
+		},
+		{
+			name: "resourceSubscriptions null",
+			body: `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{"notifications":{"resourceSubscriptions":null}},"id":1}`,
+			want: nil,
+		},
+		{
+			name: "params absent entirely",
+			body: `{"jsonrpc":"2.0","method":"subscriptions/listen","id":1}`,
+			want: nil,
+		},
+		{
+			name: "empty array",
+			body: `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{"notifications":{"resourceSubscriptions":[]}},"id":1}`,
+			want: []string{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqs, err := ParseJSONRPCStrict([]byte(tc.body))
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if len(reqs[0].URIs) != len(tc.want) {
+				t.Fatalf("URIs = %v, want %v", reqs[0].URIs, tc.want)
+			}
+			for i := range tc.want {
+				if reqs[0].URIs[i] != tc.want[i] {
+					t.Errorf("URIs[%d] = %q, want %q", i, reqs[0].URIs[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// A present-but-wrong-typed subscription list fails closed rather than being
+// silently ignored: the field decides what the caller gets to watch, so
+// dropping it would grant a stream nobody gated.
+func TestParseJSONRPCStrict_SubscriptionsListen_FailsClosed(t *testing.T) {
+	oversized := make([]string, maxResourceSubscriptions+1)
+	for i := range oversized {
+		oversized[i] = `"repo://x"`
+	}
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"params not an object", `{"jsonrpc":"2.0","method":"subscriptions/listen","params":[1,2],"id":1}`},
+		{"notifications not an object", `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{"notifications":"all"},"id":1}`},
+		{"subscriptions not an array", `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{"notifications":{"resourceSubscriptions":"repo://a"}},"id":1}`},
+		{"subscription element not a string", `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{"notifications":{"resourceSubscriptions":[{"uri":"repo://a"}]}},"id":1}`},
+		{"empty subscription URI", `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{"notifications":{"resourceSubscriptions":["repo://a",""]}},"id":1}`},
+		{
+			// One request must not buy an unbounded amount of pattern
+			// matching against the resources family.
+			name: "too many subscriptions",
+			body: `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{"notifications":{"resourceSubscriptions":[` +
+				strings.Join(oversized, ",") + `]}},"id":1}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseJSONRPCStrict([]byte(tc.body))
+			if err == nil {
+				t.Fatalf("expected a parse error, got none")
+			}
+			if err.Kind != ErrKindMalformedParams {
+				t.Errorf("Kind = %q, want %q", err.Kind, ErrKindMalformedParams)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Case-variant key smuggling
+// =============================================================================
+
+// Warden judges the body and then forwards it verbatim, and Go's
+// encoding/json matches object keys to struct fields case-insensitively — so
+// an upstream built on it honours "Arguments" and "Notifications" exactly as
+// it honours the canonical spelling. Reading only the exact spelling would
+// mean the gate never sees what the upstream acts on. For the OPTIONAL fields
+// that is a silent bypass rather than a denial, which is what makes it sharp.
+func TestParseJSONRPCStrict_CaseVariantKeysAreRead(t *testing.T) {
+	cases := []struct {
+		name  string
+		body  string
+		check func(t *testing.T, req JSONRPCRequest)
+	}{
+		{
+			name: "tools/call Arguments",
+			body: `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"deploy","Arguments":{"env":"prod"}},"id":1}`,
+			check: func(t *testing.T, req JSONRPCRequest) {
+				if got := string(req.Arguments["env"]); got != `"prod"` {
+					t.Errorf("arguments.env = %s, want %q — a CEL condition would judge nothing", got, `"prod"`)
+				}
+			},
+		},
+		{
+			name: "tools/call NAME",
+			body: `{"jsonrpc":"2.0","method":"tools/call","params":{"NAME":"deploy"},"id":1}`,
+			check: func(t *testing.T, req JSONRPCRequest) {
+				if req.Name != "deploy" {
+					t.Errorf("Name = %q, want deploy", req.Name)
+				}
+			},
+		},
+		{
+			name: "listen Notifications",
+			body: `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{"Notifications":{"resourceSubscriptions":["repo://secret"]}},"id":1}`,
+			check: func(t *testing.T, req JSONRPCRequest) {
+				if len(req.URIs) != 1 || req.URIs[0] != "repo://secret" {
+					t.Errorf("URIs = %v, want [repo://secret] — the subscription would go ungated", req.URIs)
+				}
+			},
+		},
+		{
+			name: "listen ResourceSubscriptions",
+			body: `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{"notifications":{"ResourceSubscriptions":["repo://secret"]}},"id":1}`,
+			check: func(t *testing.T, req JSONRPCRequest) {
+				if len(req.URIs) != 1 {
+					t.Errorf("URIs = %v, want one URI", req.URIs)
+				}
+			},
+		},
+		{
+			name: "resources/read URI",
+			body: `{"jsonrpc":"2.0","method":"resources/read","params":{"URI":"repo://secret"},"id":1}`,
+			check: func(t *testing.T, req JSONRPCRequest) {
+				if req.Name != "repo://secret" {
+					t.Errorf("Name = %q, want repo://secret", req.Name)
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqs, err := ParseJSONRPCStrict([]byte(tc.body))
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			tc.check(t, reqs[0])
+		})
+	}
+}
+
+// Two spellings at once is unresolvable — Go's decoder picks one by map
+// order — so it fails closed rather than gating whichever Warden happened to
+// read. The duplicate-key walk does not catch these: they are distinct keys.
+func TestParseJSONRPCStrict_AmbiguousCaseVariantsFailClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"two spellings of arguments", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"x","arguments":{"env":"dev"},"Arguments":{"env":"prod"}},"id":1}`},
+		{"two spellings of name", `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"safe","Name":"dangerous"},"id":1}`},
+		{"two spellings of notifications", `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{"notifications":{"toolsListChanged":true},"NOTIFICATIONS":{"resourceSubscriptions":["repo://secret"]}},"id":1}`},
+		{"two spellings of resourceSubscriptions", `{"jsonrpc":"2.0","method":"subscriptions/listen","params":{"notifications":{"resourceSubscriptions":[],"ResourceSubscriptions":["repo://secret"]}},"id":1}`},
+		{"two spellings of uri", `{"jsonrpc":"2.0","method":"resources/read","params":{"uri":"repo://public","URI":"repo://secret"},"id":1}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseJSONRPCStrict([]byte(tc.body))
+			if err == nil {
+				t.Fatalf("expected a parse error, got none")
+			}
+			if err.Kind != ErrKindMalformedParams {
+				t.Errorf("Kind = %q, want %q", err.Kind, ErrKindMalformedParams)
+			}
+		})
+	}
+}
+
+// resources/subscribe is the legacy-era route to the same
+// notifications/resources/updated stream subscriptions/listen carries, so its
+// URI must reach the descriptor for the resources family to gate it.
+func TestParseJSONRPCStrict_ResourcesSubscribe(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","method":"resources/subscribe","params":{"uri":"repo://myorg/api"},"id":1}`)
+	reqs, err := ParseJSONRPCStrict(body)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if reqs[0].Name != "repo://myorg/api" {
+		t.Errorf("Name = %q, want repo://myorg/api", reqs[0].Name)
+	}
+
+	if _, err := ParseJSONRPCStrict([]byte(`{"jsonrpc":"2.0","method":"resources/subscribe","params":{},"id":1}`)); err == nil {
+		t.Errorf("a subscribe with no uri must fail closed")
+	}
+}

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -87,6 +87,21 @@ const (
 // without establishing one.
 const mcpMethodServerDiscover = "server/discover"
 
+// mcpMethodSubscriptionsListen opens a stream of server notifications. It is
+// name-bearing in a shape of its own: not one name, but a list of resource
+// URIs in params.notifications.resourceSubscriptions, each gated against the
+// resources family.
+const mcpMethodSubscriptionsListen = "subscriptions/listen"
+
+// mcpMethodResourcesSubscribe is the legacy-era way to obtain the same
+// notifications/resources/updated stream that subscriptions/listen carries in
+// 2026-07-28. It names one URI in params.uri and belongs to the resources
+// family for the same reason: subscribing to a resource's update stream leaks
+// its existence and the timing of every change, so it answers to the grant
+// that governs reading it. Warden fronts both eras, so gating only the modern
+// spelling would leave the leak reachable one method name over.
+const mcpMethodResourcesSubscribe = "resources/subscribe"
+
 // ErrMCPPolicyDenied carries the MCPDecision that produced a deny so
 // the HTTP response layer can render the OAuth-shaped 403 body and the
 // WWW-Authenticate header. Unwraps to sdklogical.ErrPermissionDenied
@@ -140,7 +155,7 @@ func nameListForMethod(set *CBPMCPRules, method string) (denyList, allowList []s
 	switch method {
 	case mcpMethodToolsCall:
 		return set.DeniedTools, set.AllowedTools
-	case mcpMethodResourcesRead:
+	case mcpMethodResourcesRead, mcpMethodResourcesSubscribe:
 		return set.DeniedResources, set.AllowedResources
 	case mcpMethodPromptsGet:
 		return set.DeniedPrompts, set.AllowedPrompts
@@ -153,6 +168,11 @@ func nameListForMethod(set *CBPMCPRules, method string) (denyList, allowList []s
 // survives iff a tools/call for it would pass, and likewise resources/list →
 // resources/read and prompts/list → prompts/get. A method absent from this map
 // is not a filterable list method.
+//
+// resources/subscribe is name-bearing under the same family but deliberately
+// absent as a target: a listed resource survives filtering iff a read of it
+// would pass, and checking a subscribe instead would prune listings by the
+// wrong gate.
 var mcpListMethodToCall = map[string]string{
 	"tools/list":     mcpMethodToolsCall,
 	"resources/list": mcpMethodResourcesRead,
@@ -499,7 +519,7 @@ func isLifecycleMethod(method string) bool {
 // this predicate — not "is a list present" — drives the gate.
 func isNameBearingMethod(method string) bool {
 	switch method {
-	case mcpMethodToolsCall, mcpMethodResourcesRead, mcpMethodPromptsGet:
+	case mcpMethodToolsCall, mcpMethodResourcesRead, mcpMethodResourcesSubscribe, mcpMethodPromptsGet:
 		return true
 	}
 	return false
@@ -558,6 +578,39 @@ func evaluateMCPGates(set *CBPMCPRules, method, name string) *logical.MCPDecisio
 	return nil
 }
 
+// evaluateMCPResourceSubscriptions gates the resource URIs a
+// subscriptions/listen asks to watch, against the same deny- and allow-lists
+// that govern resources/read. Returns a deny decision for the first URI that
+// fails, or nil when every URI passes — including when the call names none,
+// which is a list-changed-only listen and is governed by the method gate
+// alone.
+//
+// The refusing URI is stamped as Name so audit can say which one it was.
+// Unlike the name gate, which stamps the value it compared, this stamps the
+// URI verbatim from the wire — matching is case-folded, and an audit record
+// should show what the caller actually sent.
+func evaluateMCPResourceSubscriptions(set *CBPMCPRules, method string, call *logical.MCPCall) *logical.MCPDecision {
+	if call == nil || len(call.URIs) == 0 || method != mcpMethodSubscriptionsListen {
+		return nil
+	}
+	for _, uri := range call.URIs {
+		luri := strings.ToLower(uri)
+		if m := matchMCPAny(luri, set.DeniedResources); m != "" {
+			return &logical.MCPDecision{
+				Method: method, Name: uri, Decision: "deny",
+				RuleType: mcpRuleTypeDeniedResources, MatchedRule: m,
+			}
+		}
+		if m := matchMCPAny(luri, set.AllowedResources); m == "" {
+			return &logical.MCPDecision{
+				Method: method, Name: uri, Decision: "deny",
+				RuleType: mcpRuleTypeAllowedResources,
+			}
+		}
+	}
+	return nil
+}
+
 // evaluateMCPSetForCall runs one rule-set against the canonicalised
 // method, name, and call. Returns the set's MCPDecision (always non-
 // nil) — either an allow with the matching pattern stamped, or a
@@ -568,6 +621,31 @@ func evaluateMCPSetForCall(set *CBPMCPRules, method, name string, call *logical.
 	// a binding deny; nil means the structured gates passed and the CEL
 	// gate + allow-stamp below decide.
 	if d := evaluateMCPGates(set, method, name); d != nil {
+		return d
+	}
+
+	// Resource-subscription gate. A subscriptions/listen names the resource
+	// URIs whose update notifications it wants pushed, and the server then
+	// sends notifications/resources/updated for each. Gating only
+	// resources/read would let a caller denied read on a URI still watch it:
+	// the content never arrives, but its existence and the timing of every
+	// change do. So each URI answers to the resources family exactly as a
+	// read would — deny-by-default included, which is what makes a contract
+	// with no resources{} block refuse a URI-bearing listen. The legacy-era
+	// resources/subscribe reaches the same stream naming one URI in
+	// params.uri, and is gated by the ordinary name gate instead.
+	//
+	// Note the OR is per call, not per URI: a listen naming [a, b] where one
+	// contract grants only a and another only b denies, though two separate
+	// listens would each succeed. Fail-closed, and the alternative — assembling
+	// a grant from fragments of different contracts — is not something a
+	// contract author can reason about.
+	//
+	// Runs after the structural gates and before CEL, so a listen the method
+	// gate already refused never reaches it. Living inside the per-set
+	// function preserves cross-set OR for free: another set that grants the
+	// URIs still allows the call.
+	if d := evaluateMCPResourceSubscriptions(set, method, call); d != nil {
 		return d
 	}
 
@@ -622,7 +700,7 @@ func mcpDenyRuleTypeForName(method string) string {
 	switch method {
 	case mcpMethodToolsCall:
 		return mcpRuleTypeDeniedTools
-	case mcpMethodResourcesRead:
+	case mcpMethodResourcesRead, mcpMethodResourcesSubscribe:
 		return mcpRuleTypeDeniedResources
 	case mcpMethodPromptsGet:
 		return mcpRuleTypeDeniedPrompts
@@ -636,7 +714,7 @@ func mcpAllowRuleTypeForName(method string) string {
 	switch method {
 	case mcpMethodToolsCall:
 		return mcpRuleTypeAllowedTools
-	case mcpMethodResourcesRead:
+	case mcpMethodResourcesRead, mcpMethodResourcesSubscribe:
 		return mcpRuleTypeAllowedResources
 	case mcpMethodPromptsGet:
 		return mcpRuleTypeAllowedPrompts

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -61,6 +61,7 @@ func synthesizeMCPDescriptorFromBody(body []byte) *logical.MCPRequestDescriptor 
 			Method:     r.Method,
 			Name:       r.Name,
 			MatchArgs:  classifyArgs(r.Arguments),
+			URIs:       r.URIs,
 			BatchIndex: i,
 		}
 	}
@@ -86,6 +87,22 @@ func mustCBPWithMCP(t testing.TB, cbpRules, mcpRules string) *CBP {
 	if mcpRules != "" {
 		mcp := testParseMCPPolicy(t, mcpRules)
 		mcp.Name = "mcp-contract"
+		policies = append(policies, mcp)
+	}
+	cbp, err := NewCBP(testContext(), policies)
+	require.NoError(t, err)
+	return cbp
+}
+
+// mustCBPWithMCPPolicies compiles one capability document and several named
+// MCP documents into a single CBP, which is how a token carrying more than
+// one contract on the same path evaluates: the rule-sets OR together.
+func mustCBPWithMCPPolicies(t testing.TB, cbpRules string, mcpRules map[string]string) *CBP {
+	t.Helper()
+	policies := []*Policy{testParsePolicy(t, cbpRules)}
+	for name, rules := range mcpRules {
+		mcp := testParseMCPPolicy(t, rules)
+		mcp.Name = name
 		policies = append(policies, mcp)
 	}
 	cbp, err := NewCBP(testContext(), policies)
@@ -1327,5 +1344,203 @@ path "mcp/gateway/*" {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = cbp.AllowOperation(ctx, req, nil, false)
+	}
+}
+
+// =============================================================================
+// subscriptions/listen resource-subscription gate
+// =============================================================================
+
+const listenContract = `
+path "mcp/gateway/*" {
+  methods { allowed = ["subscriptions/listen"] }
+  resources { allowed = ["repo://myorg/*"] }
+}
+`
+
+func listenBody(uris ...string) string {
+	quoted := make([]string, len(uris))
+	for i, u := range uris {
+		quoted[i] = `"` + u + `"`
+	}
+	return `{"jsonrpc":"2.0","method":"subscriptions/listen","id":1,"params":{"notifications":{"resourceSubscriptions":[` +
+		strings.Join(quoted, ",") + `]}}}`
+}
+
+func TestMCPEval_ListenURI_AllowedByResourcesFamily(t *testing.T) {
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, listenContract)
+	req := newMCPRequest(t, "mcp/gateway/", listenBody("repo://myorg/api", "repo://myorg/web"))
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.True(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "allow", res.MCPDecision.Decision)
+}
+
+// The leak this closes: a caller denied resources/read on a URI could still
+// subscribe to its update stream. The content never arrives, but the
+// resource's existence and the timing of every change do.
+func TestMCPEval_ListenURI_OutsideAllowListDenies(t *testing.T) {
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, listenContract)
+	req := newMCPRequest(t, "mcp/gateway/", listenBody("repo://myorg/api", "repo://other/secret"))
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeAllowedResources, res.MCPDecision.RuleType)
+	assert.Equal(t, "repo://other/secret", res.MCPDecision.Name, "audit must name the URI that refused")
+}
+
+func TestMCPEval_ListenURI_DeniedResourcesWins(t *testing.T) {
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["subscriptions/listen"] }
+  resources {
+    allowed = ["repo://myorg/*"]
+    denied  = ["repo://myorg/secrets*"]
+  }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", listenBody("repo://myorg/secrets/db"))
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeDeniedResources, res.MCPDecision.RuleType)
+	assert.Equal(t, "repo://myorg/secrets*", res.MCPDecision.MatchedRule)
+}
+
+// A listen that names no resource subscribes only to list-changed events.
+// It carries no resource access, so it passes under a contract with no
+// resources{} block at all — the method gate is the whole of its governance.
+func TestMCPEval_ListenWithoutURIs_PassesWithNoResourcesBlock(t *testing.T) {
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["subscriptions/listen"] }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", `{
+		"jsonrpc": "2.0",
+		"method":  "subscriptions/listen",
+		"id":      1,
+		"params":  {"notifications": {"toolsListChanged": true}}
+	}`)
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.True(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, "allow", res.MCPDecision.Decision)
+}
+
+// The breaking half, stated as a test: methods { allowed = ["*"] } with no
+// resources{} block used to let a listen carry any URI. Deny-by-default in
+// the resources family now refuses it.
+func TestMCPEval_ListenWithURIs_DeniesWithNoResourcesBlock(t *testing.T) {
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["*"] }
+}
+`)
+	req := newMCPRequest(t, "mcp/gateway/", listenBody("repo://myorg/api"))
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeAllowedResources, res.MCPDecision.RuleType)
+}
+
+// The gate lives inside the per-set function, so cross-set OR survives: a
+// second contract granting the URIs allows the call even though the first
+// refuses it.
+func TestMCPEval_ListenURI_CrossSetOR(t *testing.T) {
+	cbp := mustCBPWithMCPPolicies(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, map[string]string{
+		"narrow": `
+path "mcp/gateway/*" {
+  methods { allowed = ["subscriptions/listen"] }
+  resources { allowed = ["repo://myorg/*"] }
+}
+`,
+		"wide": `
+path "mcp/gateway/*" {
+  methods { allowed = ["subscriptions/listen"] }
+  resources { allowed = ["repo://*"] }
+}
+`,
+	})
+	req := newMCPRequest(t, "mcp/gateway/", listenBody("repo://other/thing"))
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.True(t, res.Allowed, "a set that grants the URI must still allow the listen")
+}
+
+// Only subscriptions/listen carries subscription URIs. A descriptor that
+// somehow carries them on another method must not have them silently gated
+// under it — the resources family governs resources/read by its own name
+// gate, which is a different path.
+func TestMCPEval_ResourceSubscriptionGate_OnlyAppliesToListen(t *testing.T) {
+	set := &CBPMCPRules{AllowedResources: []string{"repo://myorg/*"}}
+	call := &logical.MCPCall{Method: "tools/call", URIs: []string{"repo://other/x"}}
+
+	assert.Nil(t, evaluateMCPResourceSubscriptions(set, mcpMethodToolsCall, call))
+	assert.NotNil(t, evaluateMCPResourceSubscriptions(set, mcpMethodSubscriptionsListen, call))
+}
+
+// The legacy-era route to the same update stream. Gating only the modern
+// spelling would leave the leak reachable one method name over, and Warden
+// fronts both eras by design.
+func TestMCPEval_ResourcesSubscribe_AnswersToResourcesFamily(t *testing.T) {
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["resources/subscribe"] }
+  resources { allowed = ["repo://myorg/*"] }
+}
+`)
+
+	allowed := newMCPRequest(t, "mcp/gateway/", `{"jsonrpc":"2.0","method":"resources/subscribe","params":{"uri":"repo://myorg/api"},"id":1}`)
+	res := cbp.AllowOperation(testContext(), allowed, nil, false)
+	assert.True(t, res.Allowed)
+
+	denied := newMCPRequest(t, "mcp/gateway/", `{"jsonrpc":"2.0","method":"resources/subscribe","params":{"uri":"repo://other/secret"},"id":1}`)
+	res = cbp.AllowOperation(testContext(), denied, nil, false)
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeAllowedResources, res.MCPDecision.RuleType)
+}
+
+// A resources/list response is pruned by what a read would allow, not by what
+// a subscribe would — adding subscribe to the list-method map would prune
+// listings by the wrong gate.
+func TestMCPEval_ResourcesSubscribe_DoesNotDriveListFiltering(t *testing.T) {
+	assert.Equal(t, mcpMethodResourcesRead, mcpListMethodToCall["resources/list"])
+	for _, call := range mcpListMethodToCall {
+		assert.NotEqual(t, mcpMethodResourcesSubscribe, call)
 	}
 }

--- a/core/request_handler_mcp.go
+++ b/core/request_handler_mcp.go
@@ -127,6 +127,7 @@ func (c *Core) extractMCPDescriptor(_ context.Context, req *logical.Request, bac
 			Method:     r.Method,
 			Name:       r.Name,
 			MatchArgs:  classifyArgs(r.Arguments),
+			URIs:       r.URIs,
 			BatchIndex: i,
 		}
 	}

--- a/core/request_handler_mcp_test.go
+++ b/core/request_handler_mcp_test.go
@@ -376,3 +376,46 @@ func TestClassifyArgs_NilVsEmpty(t *testing.T) {
 		t.Errorf("classifyArgs(empty) len = %d, want 0", len(got))
 	}
 }
+
+// The extractor is mirrored by a test-local helper in policy_mcp_eval_test.go,
+// so a field the production mapping forgets can still look gated in every
+// evaluator test. This asserts the production path itself, and it matters most
+// for URIs: dropping them yields nil, which is the legitimate
+// list-changed-only shape and therefore ALLOWS — a silent fail-open, unlike
+// Name, whose loss denies at the name gate.
+func TestExtractMCPDescriptor_CarriesSubscriptionURIs(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","method":"subscriptions/listen","id":1,"params":{"notifications":{"resourceSubscriptions":["repo://a","repo://b"]}}}`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+
+	c.extractMCPDescriptor(context.Background(), req, b)
+
+	desc := req.MCPDescriptor
+	if desc == nil || desc.ParseErr != nil {
+		t.Fatalf("descriptor = %+v, want populated with no ParseErr", desc)
+	}
+	if len(desc.Calls) != 1 {
+		t.Fatalf("Calls len = %d, want 1", len(desc.Calls))
+	}
+	got := desc.Calls[0].URIs
+	if len(got) != 2 || got[0] != "repo://a" || got[1] != "repo://b" {
+		t.Errorf("URIs = %v, want [repo://a repo://b]", got)
+	}
+}
+
+// A listen naming no resource must reach the evaluator as nil, not as an
+// empty-but-present slice — that is the shape the gate reads as
+// "list-changed only, method gate decides".
+func TestExtractMCPDescriptor_ListenWithoutSubscriptions(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","method":"subscriptions/listen","id":1,"params":{"notifications":{"toolsListChanged":true}}}`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+
+	c.extractMCPDescriptor(context.Background(), req, b)
+
+	if got := req.MCPDescriptor.Calls[0].URIs; got != nil {
+		t.Errorf("URIs = %v, want nil", got)
+	}
+}

--- a/logical/mcp_descriptor.go
+++ b/logical/mcp_descriptor.go
@@ -27,10 +27,18 @@ type MCPRequestDescriptor struct {
 // params.arguments) so the matcher's denied_params / allowed_params
 // can gate on individual argument values. For other methods MatchArgs
 // is nil.
+//
+// URIs is populated only for subscriptions/listen, from
+// params.notifications.resourceSubscriptions, and carries the resource
+// URIs whose update notifications the caller asked to receive. The
+// matcher gates each one against the resources family, so subscribing
+// to a resource's update stream requires the same grant as reading it.
+// nil for other methods, and for a listen that names no resource.
 type MCPCall struct {
 	Method     string
 	Name       string
 	MatchArgs  map[string]ParamValue
+	URIs       []string
 	BatchIndex int
 }
 
@@ -112,7 +120,9 @@ func (d *MCPRequestDescriptor) Clone() *MCPRequestDescriptor {
 
 // Clone returns a deep copy of the MCPCall. MatchArgs is a map of
 // value-typed ParamValue, so a length-preserving copy of the map
-// breaks aliasing.
+// breaks aliasing; URIs is a slice and needs the same treatment, or
+// the audit layer's copy would share backing array with the live
+// request.
 func (c MCPCall) Clone() MCPCall {
 	out := MCPCall{
 		Method:     c.Method,
@@ -124,6 +134,10 @@ func (c MCPCall) Clone() MCPCall {
 		for k, v := range c.MatchArgs {
 			out.MatchArgs[k] = v
 		}
+	}
+	if c.URIs != nil {
+		out.URIs = make([]string, len(c.URIs))
+		copy(out.URIs, c.URIs)
 	}
 	return out
 }

--- a/logical/mcp_descriptor_test.go
+++ b/logical/mcp_descriptor_test.go
@@ -1,0 +1,58 @@
+package logical
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The audit layer deep-copies the descriptor so an async writer cannot
+// observe a concurrent handler's mutations. A slice field copied by
+// assignment would share its backing array and defeat that — the reason the
+// clone discipline is spelled out on these types.
+func TestMCPCall_Clone_BreaksSliceAliasing(t *testing.T) {
+	orig := MCPCall{
+		Method:    "subscriptions/listen",
+		URIs:      []string{"repo://a", "repo://b"},
+		MatchArgs: map[string]ParamValue{"env": {Kind: ParamString, Str: "prod"}},
+	}
+
+	clone := orig.Clone()
+	require.Equal(t, orig.URIs, clone.URIs)
+
+	clone.URIs[0] = "repo://mutated"
+	assert.Equal(t, "repo://a", orig.URIs[0], "clone shares the URIs backing array")
+
+	clone.MatchArgs["env"] = ParamValue{Kind: ParamString, Str: "dev"}
+	assert.Equal(t, "prod", orig.MatchArgs["env"].Str, "clone shares the MatchArgs map")
+}
+
+func TestMCPCall_Clone_NilSliceStaysNil(t *testing.T) {
+	clone := MCPCall{Method: "tools/list"}.Clone()
+
+	assert.Nil(t, clone.URIs, "a listen that names no resource must not gain an empty slice")
+	assert.Nil(t, clone.MatchArgs)
+}
+
+func TestMCPRequestDescriptor_Clone_BreaksSliceAliasing(t *testing.T) {
+	orig := &MCPRequestDescriptor{
+		Calls: []MCPCall{{Method: "subscriptions/listen", URIs: []string{"repo://a"}}},
+	}
+
+	clone := orig.Clone()
+	clone.Calls[0].URIs[0] = "repo://mutated"
+
+	assert.Equal(t, "repo://a", orig.Calls[0].URIs[0],
+		"the descriptor clone must reach the URIs inside each call")
+}
+
+func TestMCPRequestDescriptor_Clone_NilAndParseErr(t *testing.T) {
+	var nilDesc *MCPRequestDescriptor
+	assert.Nil(t, nilDesc.Clone())
+
+	orig := &MCPRequestDescriptor{ParseErr: &MCPParseError{Kind: MCPParseKindMalformedParams, Msg: "bad"}}
+	clone := orig.Clone()
+	clone.ParseErr.Msg = "mutated"
+	assert.Equal(t, "bad", orig.ParseErr.Msg)
+}


### PR DESCRIPTION
**Stack 2/8** — MCP 2026-07-28 alignment. Base: `feat/mcp-server-discover` (#590).

## The leak

`subscriptions/listen` params carry `notifications.resourceSubscriptions: ["uri", ...]`, and the server then pushes `notifications/resources/updated` for each. Warden's resources family gated only `resources/read` — so a caller denied read on a URI could still subscribe to its update stream. The content never arrives, but the resource's **existence** and the **timing of every change** do.

Each subscribed URI now answers to the resources family exactly as a read does. Both halves apply, per URI, in the family's usual order: a URI matching `denied_resources` refuses the call, and a URI matching nothing in `allowed_resources` refuses it too — so a contract carrying no `resources{}` block refuses every URI, which is deny-by-default working as designed rather than a special case.

## Three layers

**Parser.** `JSONRPCRequest.URIs`, from a `subscriptions/listen` case in `extractMethodShape`. Everything about the field is optional, because a listen has legitimate shapes that name no resource — subscribing only to list-changed events is what the go-sdk opens when a client registers a list-changed handler. Absent params, absent `notifications`, null, or an absent array all yield nil URIs. A present-but-wrong type fails closed. The list length is capped so one request cannot buy unbounded matching against the family.

**Descriptor.** `MCPCall.URIs`, copied in **both** clones — a slice assigned rather than copied would share its backing array with the live request and defeat the audit layer's deep copy. An aliasing test pins each.

**Evaluator.** Runs inside `evaluateMCPSetForCall`, after the structural gates and before CEL, so a listen the method gate already refused never reaches it. Living inside the per-set function preserves cross-set OR for free. The OR is per call, not per URI, and that is now said out loud.

## Two holes the same reasoning exposed

Found in review; closed here rather than left for the era to age out.

**Case-variant key smuggling.** Warden judges the body and forwards it verbatim, and Go's `encoding/json` matches object keys case-insensitively — so an upstream built on it, the go-sdk included, honours `"Notifications"` and `"Arguments"` exactly as it honours the canonical spelling. Reading only the exact spelling meant the gate never saw what the upstream acted on. For a *required* field that fails closed; for the optional ones it was a silent bypass:

```json
{"name":"deploy","Arguments":{"env":"prod"}}
```

left `MatchArgs` nil, so the CEL activation's `call.args` judged arguments that were never there — defeating the condition in Warden's own documented example. Params are now looked up the way the decoder downstream will look them up, and two spellings at once fail closed, since the decoder resolves that by map order.

**`resources/subscribe`.** The legacy era reaches the identical `notifications/resources/updated` stream by naming one URI in `params.uri`. It was in no method table at all, so gating only the modern spelling would have left the leak reachable one method name over on every mount fronting a legacy upstream — which this repo supports by design. It is now name-bearing under the resources family, and deliberately **not** a target in `mcpListMethodToCall`: a listed resource survives filtering iff a *read* of it would pass, and checking a subscribe instead would prune listings by the wrong gate.

## Untouched on purpose

`mcpListItemAllowed` and `attachMCPListFilter`: a listen response is a notification stream, not a list result, and the URIs are gated request-side. `subscriptions/listen` is likewise not in `isLifecycleMethod` — it grants a data stream.

## Verification

Full suite clean; `BenchmarkAllowOperation_*` unmoved. Parser cases (absent / null / wrong-type / oversized / empty-element), evaluator cases (denied URI, allowed, cross-set OR, no-resources-block), clone-aliasing tests, and the case-variant and `resources/subscribe` tables. Covered end to end in stack 7.

## Not marked breaking

The `mcp` grammar has never shipped in a tagged release. A contract written against `main` that allows `["*"]` methods with no `resources{}` block will now refuse URI-bearing listens and every `resources/subscribe` — the intended reading of deny-by-default.
