### PR TITLE
feat(policy): validate MCP transport headers against the body

### DIFF
--- a/core/policy_jsonrpc.go
+++ b/core/policy_jsonrpc.go
@@ -33,6 +33,10 @@ const maxJSONDepth = 32
 // update notifications the caller is asking to receive. nil for any other
 // method, and for a listen that subscribes only to list-changed events.
 //
+// RawID retains the id verbatim so an error response can echo it, and
+// IDPresent distinguishes a request from a notification — JSON-RPC allows
+// a null id, which is present-but-null and not the same as absent.
+//
 // RawParams retains the verbatim params bytes for matcher-internal use.
 // It is descriptor-only and MUST NOT be copied to MCPDecision, the
 // audit record, or the client response.
@@ -41,7 +45,13 @@ type JSONRPCRequest struct {
 	Name      string
 	Arguments map[string]json.RawMessage
 	URIs      []string
+	RawID     json.RawMessage
+	IDPresent bool
 	RawParams json.RawMessage
+
+	// MetaProtocolVersion is the revision the body itself declares in
+	// params._meta, empty when it declares none.
+	MetaProtocolVersion string
 }
 
 // ParseErrorKind enumerates structural-failure deny reasons. Each kind
@@ -224,12 +234,13 @@ func parseJSONRPCRequest(dec *json.Decoder) (*JSONRPCRequest, *ParseError) {
 			}
 			req.RawParams = v
 		case "id":
-			// JSON-RPC 2.0 permits string, number, or null. We don't
-			// inspect the id; just consume the next value to advance
-			// the decoder. validateJSONValue ensures structural
-			// soundness if the id happens to be a complex value (some
-			// MCP clients have been seen wrapping ids in objects —
-			// reject those uniformly).
+			// JSON-RPC 2.0 permits string, number, or null. The value is
+			// retained verbatim rather than inspected: an error response
+			// must echo the id exactly as it arrived, and its presence is
+			// what separates a request from a notification.
+			// validateJSONValue ensures structural soundness if the id
+			// happens to be a complex value (some MCP clients have been
+			// seen wrapping ids in objects — reject those uniformly).
 			var v json.RawMessage
 			if err := dec.Decode(&v); err != nil {
 				return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
@@ -237,6 +248,8 @@ func parseJSONRPCRequest(dec *json.Decoder) (*JSONRPCRequest, *ParseError) {
 			if perr := validateJSONValue(v, 1); perr != nil {
 				return nil, perr
 			}
+			req.RawID = v
+			req.IDPresent = true
 		default:
 			return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "unknown top-level key"}
 		}
@@ -254,11 +267,82 @@ func parseJSONRPCRequest(dec *json.Decoder) (*JSONRPCRequest, *ParseError) {
 		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "missing method field"}
 	}
 
-	if perr := extractMethodShape(req); perr != nil {
+	// Decode params once and share the result. Every shape extractor below
+	// needs the same object, and the _meta peek cannot be gated on a
+	// cheap scan of the raw bytes: a key spelled "_meta" decodes to
+	// "_meta" while the wire bytes contain no such string, so any
+	// byte-level pre-check is a bypass rather than an optimisation.
+	paramsObj, paramsIsObject := decodeParamsObject(req.RawParams)
+
+	if perr := extractMetaProtocolVersion(req, paramsObj); perr != nil {
+		return nil, perr
+	}
+
+	if perr := extractMethodShape(req, paramsObj, paramsIsObject); perr != nil {
 		return nil, perr
 	}
 
 	return req, nil
+}
+
+// decodeParamsObject decodes params into a key/value map. Reports false when
+// params is absent or is not a JSON object — the shape extractors that
+// require an object raise their own error for that, since what counts as
+// malformed differs per method.
+func decodeParamsObject(raw json.RawMessage) (map[string]json.RawMessage, bool) {
+	if len(raw) == 0 {
+		return nil, false
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, false
+	}
+	return obj, true
+}
+
+// metaProtocolVersionKey is the reserved _meta key carrying the protocol
+// revision a client believes it is speaking. It lives inside params, so it
+// reaches the strict parser without tripping the unknown-top-level-key
+// rejection.
+const metaProtocolVersionKey = "io.modelcontextprotocol/protocolVersion"
+
+// extractMetaProtocolVersion peeks params._meta for the client's declared
+// protocol revision, so the header validator can cross-check the transport
+// header against what the body itself claims.
+//
+// A shape that cannot carry a readable version — _meta not an object, or the
+// version not a string — is treated as declaring nothing rather than as an
+// error. Nothing downstream can read such a value as a version either, so
+// there is nothing to cross-check and no reason to start refusing legacy
+// bodies that the reference implementation silently ignores.
+func extractMetaProtocolVersion(req *JSONRPCRequest, top map[string]json.RawMessage) *ParseError {
+	if top == nil {
+		return nil
+	}
+	metaRaw, ok, perr := lookupParamKey(top, "_meta", req.Method)
+	if perr != nil {
+		return perr
+	}
+	if !ok || string(metaRaw) == "null" {
+		return nil
+	}
+	var meta map[string]json.RawMessage
+	if err := json.Unmarshal(metaRaw, &meta); err != nil {
+		return nil
+	}
+	verRaw, ok, perr := lookupParamKey(meta, metaProtocolVersionKey, req.Method)
+	if perr != nil {
+		return perr
+	}
+	if !ok || string(verRaw) == "null" {
+		return nil
+	}
+	var ver string
+	if err := json.Unmarshal(verRaw, &ver); err != nil {
+		return nil
+	}
+	req.MetaProtocolVersion = ver
+	return nil
 }
 
 // extractMethodShape populates Name and (for tools/call) Arguments
@@ -277,16 +361,16 @@ func parseJSONRPCRequest(dec *json.Decoder) (*JSONRPCRequest, *ParseError) {
 // its own case-sensitive method dispatch and will typically reject
 // the mixed-case form — so the request denies either at our policy
 // or at the upstream, never silently succeeding.
-func extractMethodShape(req *JSONRPCRequest) *ParseError {
+func extractMethodShape(req *JSONRPCRequest, top map[string]json.RawMessage, isObject bool) *ParseError {
 	switch strings.ToLower(req.Method) {
 	case "tools/call":
-		return extractToolsCall(req)
+		return extractToolsCall(req, top, isObject)
 	case "resources/read", "resources/subscribe":
-		return extractByParamKey(req, "uri")
+		return extractByParamKey(req, top, isObject, "uri")
 	case "prompts/get":
-		return extractByParamKey(req, "name")
+		return extractByParamKey(req, top, isObject, "name")
 	case "subscriptions/listen":
-		return extractSubscriptionsListen(req)
+		return extractSubscriptionsListen(req, top, isObject)
 	}
 	return nil
 }
@@ -309,12 +393,11 @@ const maxResourceSubscriptions = 256
 // gate alone. A present-but-wrong type is a different matter and fails
 // closed, matching extractToolsCall's strictness: the alternative is
 // silently ignoring a field that decides what the caller gets to watch.
-func extractSubscriptionsListen(req *JSONRPCRequest) *ParseError {
+func extractSubscriptionsListen(req *JSONRPCRequest, top map[string]json.RawMessage, isObject bool) *ParseError {
 	if len(req.RawParams) == 0 {
 		return nil
 	}
-	var top map[string]json.RawMessage
-	if err := json.Unmarshal(req.RawParams, &top); err != nil {
+	if !isObject {
 		return &ParseError{Kind: ErrKindMalformedParams, Msg: "subscriptions/listen params must be an object"}
 	}
 
@@ -394,12 +477,11 @@ func lookupParamKey(obj map[string]json.RawMessage, key, method string) (json.Ra
 // extractToolsCall populates Name from params.name (required, non-empty
 // string) and Arguments from params.arguments (optional, must be an
 // object when present).
-func extractToolsCall(req *JSONRPCRequest) *ParseError {
+func extractToolsCall(req *JSONRPCRequest, top map[string]json.RawMessage, isObject bool) *ParseError {
 	if len(req.RawParams) == 0 {
 		return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call missing params"}
 	}
-	var top map[string]json.RawMessage
-	if err := json.Unmarshal(req.RawParams, &top); err != nil {
+	if !isObject {
 		return &ParseError{Kind: ErrKindMalformedParams, Msg: "tools/call params must be an object"}
 	}
 
@@ -441,12 +523,11 @@ func extractToolsCall(req *JSONRPCRequest) *ParseError {
 // extractByParamKey extracts Name from the named top-level params key
 // (required, non-empty string). Used for resources/read (key = "uri")
 // and prompts/get (key = "name").
-func extractByParamKey(req *JSONRPCRequest, key string) *ParseError {
+func extractByParamKey(req *JSONRPCRequest, top map[string]json.RawMessage, isObject bool, key string) *ParseError {
 	if len(req.RawParams) == 0 {
 		return &ParseError{Kind: ErrKindMalformedParams, Msg: req.Method + " missing params"}
 	}
-	var top map[string]json.RawMessage
-	if err := json.Unmarshal(req.RawParams, &top); err != nil {
+	if !isObject {
 		return &ParseError{Kind: ErrKindMalformedParams, Msg: req.Method + " params must be an object"}
 	}
 

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -4,6 +4,7 @@
 package core
 
 import (
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strings"
@@ -44,6 +45,12 @@ const (
 	mcpRuleTypeCondition        = "condition"
 	mcpRuleTypeConditionError   = "condition_error"
 	mcpRuleTypeMissingMethod    = "missing_method_header"
+
+	// mcpRuleTypeHeaderMismatch denies a request whose MCP transport headers
+	// contradict, or fail to describe, the body Warden parsed. Structural
+	// rather than a policy decision: no contract was consulted to reach it,
+	// and no contract can permit it.
+	mcpRuleTypeHeaderMismatch = "header_mismatch"
 
 	mcpRuleTypeMissingBody      = "missing_body"
 	mcpRuleTypeMalformedJSONRPC = "malformed_jsonrpc"
@@ -116,6 +123,33 @@ func (e *ErrMCPPolicyDenied) Error() string {
 }
 
 func (e *ErrMCPPolicyDenied) Unwrap() error {
+	return sdklogical.ErrPermissionDenied
+}
+
+// ErrMCPHeaderMismatch carries a transport-header refusal, which the HTTP
+// layer renders as a protocol-level JSON-RPC error rather than the
+// OAuth-shaped 403 a policy denial gets.
+//
+// It is a separate type from ErrMCPPolicyDenied precisely so it can be
+// branched on ahead of it: both denials arrive through the same MCPDecision
+// channel, and without the distinction a header mismatch would be reported
+// to the client as an authorization failure — which would send a dual-era
+// client downgrading to initialize instead of correcting its headers.
+//
+// RawID travels on the error rather than on MCPDecision, which has no id
+// field and should not grow one: the decision is a fingerprint-hygiene
+// surface, and an echoed id is adversary-controlled bytes.
+type ErrMCPHeaderMismatch struct {
+	Decision  *logical.MCPDecision
+	RawID     json.RawMessage
+	IDPresent bool
+}
+
+func (e *ErrMCPHeaderMismatch) Error() string {
+	return sdklogical.ErrPermissionDenied.Error()
+}
+
+func (e *ErrMCPHeaderMismatch) Unwrap() error {
 	return sdklogical.ErrPermissionDenied
 }
 
@@ -362,6 +396,18 @@ func decideMCP(sets []*CBPMCPRules, req *logical.Request, te *logical.TokenEntry
 			RuleType: desc.ParseErr.Kind,
 		}
 	default:
+		// Transport headers before contract evaluation: a body whose headers
+		// contradict it is refused on its own terms, without asking any
+		// contract whether the call it claims to be would have been allowed.
+		//
+		// This sits inside decideMCP, which runs only when a contract is in
+		// scope, so absence-deny still wins on a path with none — the
+		// validation result is simply never computed there, and the request
+		// is refused either way.
+		if hd := validateMCPHeaders(req, desc); hd != nil {
+			d = hd
+			break
+		}
 		d = evaluateMCPDescriptor(sets, desc, req, te, now, nsPath)
 		if d == nil {
 			// Defence in depth: evaluateMCPDescriptor returns nil
@@ -747,6 +793,7 @@ func mcpDenyRank(ruleType string) int {
 		mcpRuleTypeBatchEmpty,
 		mcpRuleTypeMalformedParams,
 		mcpRuleTypeBatchListUnfilterable,
+		mcpRuleTypeHeaderMismatch,
 		// Never actually competes — it is produced outside evaluateMCPCall,
 		// where there are no rule-sets to rank against. Listed so the ranking
 		// stays total over the rule-type domain.
@@ -834,6 +881,13 @@ func BuildMCPDenyDescription(d *logical.MCPDecision) string {
 		return "Batched list requests are not supported."
 	case mcpRuleTypeMissingMethod:
 		return "Request method required."
+	case mcpRuleTypeHeaderMismatch:
+		// Names no header and no value: the client already knows what it
+		// sent, and saying which half disagreed would hand an attacker a
+		// probe for the shape of the check. The HTTP layer answers this one
+		// with a JSON-RPC error rather than this description; the text is
+		// here for audit and for any path that renders a decision generically.
+		return "MCP transport headers do not match the request body."
 	case mcpRuleTypeNoMCPPolicy:
 		// Names the misconfiguration rather than the call. Every other message
 		// answers "what did I ask for that was refused?"; this one answers

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -40,11 +40,12 @@ func newMCPRequest(tb testing.TB, path, body string) *logical.Request {
 	return req
 }
 
-// synthesizeMCPDescriptorFromBody mirrors what extractMCPDescriptor
-// does on the production streaming branch: strict-parse the body,
-// then map every parsed JSONRPCRequest to an MCPCall. Lives next to
-// the matcher tests so they exercise the real pipeline without
-// dragging in the request_handler extractor's I/O concerns.
+// synthesizeMCPDescriptorFromBody runs the production pipeline on a body —
+// the strict parser, then the same mcpCallsFromParsed mapping
+// extractMCPDescriptor uses — without dragging in that extractor's I/O
+// concerns. It calls the real mapping rather than restating it, so a field
+// added to the descriptor cannot be gated in tests while production sees a
+// zero value.
 func synthesizeMCPDescriptorFromBody(body []byte) *logical.MCPRequestDescriptor {
 	desc := &logical.MCPRequestDescriptor{}
 	reqs, perr := ParseJSONRPCStrict(body)
@@ -55,16 +56,7 @@ func synthesizeMCPDescriptorFromBody(body []byte) *logical.MCPRequestDescriptor 
 		}
 		return desc
 	}
-	desc.Calls = make([]logical.MCPCall, len(reqs))
-	for i, r := range reqs {
-		desc.Calls[i] = logical.MCPCall{
-			Method:     r.Method,
-			Name:       r.Name,
-			MatchArgs:  classifyArgs(r.Arguments),
-			URIs:       r.URIs,
-			BatchIndex: i,
-		}
-	}
+	desc.Calls = mcpCallsFromParsed(reqs)
 	return desc
 }
 

--- a/core/policy_mcp_headers.go
+++ b/core/policy_mcp_headers.go
@@ -1,0 +1,262 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"github.com/stephnangue/warden/logical"
+)
+
+// MCP transport headers. From 2026-07-28 a client sends the protocol
+// revision on every request, plus a duplicate of the method it is calling and
+// — for the name-bearing methods — the name it is calling it on.
+const (
+	mcpProtocolVersionHeader = "MCP-Protocol-Version"
+	mcpMethodHeader          = "Mcp-Method"
+	mcpNameHeader            = "Mcp-Name"
+)
+
+// mcpRevisionHeaderEra is the first revision that requires the transport
+// headers. Revisions are dates, so an ordinary string comparison orders them.
+const mcpRevisionHeaderEra = "2026-07-28"
+
+// base64Sentinel wraps a header value whose true content is not
+// header-safe — a tool name carrying non-ASCII, say. The markers are exact
+// and lowercase.
+const (
+	base64SentinelPrefix = "=?base64?"
+	base64SentinelSuffix = "?="
+)
+
+// validateMCPHeaders enforces the spec's requirement that a server which
+// processes the message body MUST validate that the transport headers match
+// that body, rejecting a mismatch.
+//
+// Warden processes the body, so this is its rule to keep. The security case
+// is the mirrored-copy problem: the headers duplicate exactly the fields
+// Warden judges, so any component behind Warden that routes or authorises on
+// headers would otherwise act on input Warden never evaluated.
+//
+// Returns nil when the request is consistent — or when it is from an era
+// these rules do not govern. Those exemptions are fail-open by construction,
+// so each one is narrow and deliberate:
+//
+//   - No version header, or one older than the header era: the headers are
+//     not REQUIRED, because demanding them would brick every pre-2026-07-28
+//     upstream Warden fronts. A header that is nonetheless present is still
+//     held to the body. That split is deliberate: requiring headers is
+//     compatibility, matching them is security, and only the first is
+//     era-dependent. Skipping the match for a client that omits a version
+//     header would leave the whole check bypassable by omission.
+//   - A batch body: one header cannot describe several calls, so there is
+//     nothing coherent to compare against.
+//   - A notification: the spec leaves header rules for a body with no id
+//     undefined, so presence is not required. A mismatch is still refused.
+func validateMCPHeaders(req *logical.Request, desc *logical.MCPRequestDescriptor) *logical.MCPDecision {
+	if req == nil || req.HTTPRequest == nil || desc == nil || len(desc.Calls) == 0 {
+		return nil
+	}
+
+	// A header sent twice is a header two readers can disagree about: Get
+	// returns the first, and a downstream taking the last or the joined value
+	// acts on something else. Nothing legitimate sends these twice.
+	for _, h := range []string{mcpProtocolVersionHeader, mcpMethodHeader, mcpNameHeader} {
+		if len(req.HTTPRequest.Header.Values(h)) > 1 {
+			return mcpHeaderDeny(headerMismatchDuplicate)
+		}
+	}
+
+	version := strings.TrimSpace(req.HTTPRequest.Header.Get(mcpProtocolVersionHeader))
+	headerMethod := req.HTTPRequest.Header.Get(mcpMethodHeader)
+	rawHeaderName := req.HTTPRequest.Header.Get(mcpNameHeader)
+
+	// A batch has no single method or name for a header to describe. Skipping
+	// the check would leave the mirrored-copy problem permanently open for
+	// batch traffic, which the legacy era keeps accepting — so a batch that
+	// carries these headers at all is refused rather than forwarded with
+	// claims nobody checked.
+	if len(desc.Calls) > 1 {
+		if headerMethod != "" || rawHeaderName != "" {
+			return mcpHeaderDeny(headerMismatchBatch)
+		}
+		return nil
+	}
+
+	call := desc.Calls[0]
+
+	// The version decides only whether the headers are REQUIRED. Whether the
+	// ones actually sent must agree with the body is not a question of era: a
+	// mismatch is never legitimate, and a client that sends a header at all
+	// has volunteered it for checking. Reading "skip everything for a legacy
+	// client" as skipping the match too would leave the mirrored-copy problem
+	// wide open to anyone who simply omits a version header.
+	modern := isHeaderEraRevision(version) && call.IDPresent
+
+	if headerMethod == "" {
+		if modern {
+			return mcpHeaderDeny(headerMismatchMethod)
+		}
+	} else if headerMethod != call.Method {
+		// Case-sensitive: the spec defines method names as case-sensitive,
+		// and this compares a header against the body rather than against a
+		// policy pattern. Warden's own gate lowercases so a case-mismatch
+		// cannot route around policy; here, a difference in case IS the
+		// disagreement being detected.
+		return mcpHeaderDeny(headerMismatchMethod)
+	}
+
+	if requiresNameHeader(strings.ToLower(call.Method)) {
+		if rawHeaderName == "" {
+			if modern {
+				return mcpHeaderDeny(headerMismatchName)
+			}
+		} else if !headerNameMatches(rawHeaderName, call.Name) {
+			return mcpHeaderDeny(headerMismatchName)
+		}
+	}
+
+	// The body may declare its own revision in params._meta, and when it does
+	// that declaration is what a downstream reads to decide which protocol it
+	// is speaking. So the transport must agree with it — and must be there to
+	// agree: a body claiming a revision while the transport claims none is a
+	// modern request wearing legacy clothes, which is exactly how a client
+	// would buy itself the leniency the era split grants.
+	if call.MetaProtocolVersion != "" && call.MetaProtocolVersion != version {
+		return mcpHeaderDeny(headerMismatchVersion)
+	}
+
+	return nil
+}
+
+// Which half of the check refused, for the audit record. These are a closed
+// set of constants, never anything read off the wire, so recording one
+// carries no adversary-controlled bytes and gives an operator the detail the
+// client response deliberately withholds.
+const (
+	headerMismatchMethod    = "method"
+	headerMismatchName      = "name"
+	headerMismatchVersion   = "version"
+	headerMismatchDuplicate = "duplicate_header"
+	headerMismatchBatch     = "batch_headers"
+)
+
+// mcpHeaderDeny builds the refusal. Beyond the rule type it carries only the
+// closed-set reason above: naming the header value, or quoting what
+// disagreed, would put adversary-controlled bytes into operator-visible
+// output and hand a caller a probe for the shape of the check. Same
+// fingerprint hygiene the other structural denies keep.
+func mcpHeaderDeny(reason string) *logical.MCPDecision {
+	return &logical.MCPDecision{
+		Decision:    "deny",
+		RuleType:    mcpRuleTypeHeaderMismatch,
+		MatchedRule: reason,
+	}
+}
+
+// requiresNameHeader reports whether the spec expects an Mcp-Name header for
+// this method.
+//
+// Deliberately NOT isNameBearingMethod. That one answers the policy layer's
+// question — which methods carry a name a contract gates — and includes
+// resources/subscribe, whose URI answers to the same grant a read does. The
+// transport header set is a different set of three. Conflating them would
+// demand a header no client sends (the go-sdk's Subscribe sends Mcp-Method
+// and no Mcp-Name), refusing every modern resources/subscribe as a mismatch.
+// What policy gates and what the transport declares are separate questions
+// that merely overlap.
+func requiresNameHeader(method string) bool {
+	switch method {
+	case mcpMethodToolsCall, mcpMethodResourcesRead, mcpMethodPromptsGet:
+		return true
+	}
+	return false
+}
+
+// mcpHeaderMismatchError builds the typed error the HTTP layer renders,
+// recovering the request id from the descriptor. The id is read here rather
+// than carried on the decision so MCPDecision stays free of
+// adversary-controlled bytes.
+func mcpHeaderMismatchError(req *logical.Request, decision *logical.MCPDecision) *ErrMCPHeaderMismatch {
+	err := &ErrMCPHeaderMismatch{Decision: decision}
+	if req != nil && req.MCPDescriptor != nil && len(req.MCPDescriptor.Calls) == 1 {
+		call := req.MCPDescriptor.Calls[0]
+		err.RawID = call.RawID
+		err.IDPresent = call.IDPresent
+	}
+	return err
+}
+
+// isHeaderEraRevision reports whether a protocol version string names a
+// revision at or after the one that introduced the transport headers.
+//
+// Revisions are ISO dates, so string ordering is date ordering. A value that
+// is not shaped like one is not treated as modern: it is a client Warden
+// cannot place, and reading an unparseable version as "latest" would impose
+// requirements on traffic that may be far older.
+func isHeaderEraRevision(version string) bool {
+	if !isRevisionDate(version) {
+		return false
+	}
+	return version >= mcpRevisionHeaderEra
+}
+
+func isRevisionDate(s string) bool {
+	if len(s) != len("2026-07-28") {
+		return false
+	}
+	for i, c := range s {
+		switch i {
+		case 4, 7:
+			if c != '-' {
+				return false
+			}
+		default:
+			if c < '0' || c > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// headerNameMatches reports whether an Mcp-Name header describes the name in
+// the body, accepting either spelling of it.
+//
+// The header is compared literally first, then — if that fails and the value
+// wears the sentinel — as decoded base64. Accepting both is deliberate: the
+// spec defines the sentinel for names that are not header-safe, while the
+// go-sdk sets and compares Mcp-Name raw and reserves the sentinel for the
+// Mcp-Param-* family. Insisting on either convention alone would refuse
+// conforming clients of the other. Requiring only that ONE reading agrees
+// costs nothing, since a caller who controls both header and body gains
+// nothing by making them agree.
+func headerNameMatches(header, name string) bool {
+	if header == name {
+		return true
+	}
+	decoded, ok := decodeMCPHeaderValue(header)
+	return ok && decoded == name
+}
+
+// decodeMCPHeaderValue unwraps the base64 sentinel when present and returns
+// the value verbatim when it is not. Reports false for a sentinel whose
+// payload is not valid base64 — a value that cannot be decoded cannot be
+// compared, and treating it as literal text would compare the wrapper
+// instead of the name.
+//
+// The sentinel applies to Mcp-Name and the Mcp-Param-* family, never to
+// Mcp-Method: method names are ASCII token syntax by definition.
+func decodeMCPHeaderValue(v string) (string, bool) {
+	if !strings.HasPrefix(v, base64SentinelPrefix) || !strings.HasSuffix(v, base64SentinelSuffix) {
+		return v, true
+	}
+	payload := v[len(base64SentinelPrefix) : len(v)-len(base64SentinelSuffix)]
+	decoded, err := base64.StdEncoding.DecodeString(payload)
+	if err != nil {
+		return "", false
+	}
+	return string(decoded), true
+}

--- a/core/policy_mcp_headers_test.go
+++ b/core/policy_mcp_headers_test.go
@@ -1,0 +1,539 @@
+// Copyright (c) 2024 Warden Project
+// SPDX-License-Identifier: MPL-2.0
+
+package core
+
+import (
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	multierror "github.com/hashicorp/go-multierror"
+	sdklogical "github.com/openbao/openbao/sdk/v2/logical"
+	"github.com/stephnangue/warden/logical"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// headerReq builds an MCP-shaped request carrying the given transport
+// headers, with the descriptor produced by the real parser.
+func headerReq(t testing.TB, body string, headers map[string]string) *logical.Request {
+	t.Helper()
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/mcp/gateway/", strings.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		httpReq.Header.Set(k, v)
+	}
+	return &logical.Request{
+		Path:          "mcp/gateway/",
+		Operation:     logical.UpdateOperation,
+		HTTPRequest:   httpReq,
+		MCPDescriptor: synthesizeMCPDescriptorFromBody([]byte(body)),
+	}
+}
+
+const toolsCallBody = `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"deploy"}}`
+
+func TestValidateMCPHeaders(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		headers  map[string]string
+		wantDeny bool
+	}{
+		{
+			// The legacy skip branch. No version header at all means a
+			// pre-2026-07-28 client, and requiring headers of it would brick
+			// every legacy upstream Warden fronts.
+			name:    "no version header, no other headers",
+			body:    toolsCallBody,
+			headers: nil,
+		},
+		{
+			// The other half of that branch, and the one worth guarding: a
+			// mismatch is never legitimate, so it is refused even from a
+			// client that sent no version at all.
+			name: "no version header but a mismatched method header",
+			body: toolsCallBody,
+			headers: map[string]string{
+				mcpMethodHeader: "tools/list",
+			},
+			wantDeny: true,
+		},
+		{
+			name: "old version, headers absent",
+			body: toolsCallBody,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2025-11-25",
+			},
+		},
+		{
+			name: "old version, headers matching",
+			body: toolsCallBody,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2025-11-25",
+				mcpMethodHeader:          "tools/call",
+				mcpNameHeader:            "deploy",
+			},
+		},
+		{
+			name: "old version, method mismatched",
+			body: toolsCallBody,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2025-11-25",
+				mcpMethodHeader:          "tools/list",
+			},
+			wantDeny: true,
+		},
+		{
+			name: "modern, complete and matching",
+			body: toolsCallBody,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "tools/call",
+				mcpNameHeader:            "deploy",
+			},
+		},
+		{
+			name: "modern, method header missing",
+			body: toolsCallBody,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpNameHeader:            "deploy",
+			},
+			wantDeny: true,
+		},
+		{
+			name: "modern, name header missing on a name-bearing method",
+			body: toolsCallBody,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "tools/call",
+			},
+			wantDeny: true,
+		},
+		{
+			name: "modern, name header mismatched",
+			body: toolsCallBody,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "tools/call",
+				mcpNameHeader:            "delete_everything",
+			},
+			wantDeny: true,
+		},
+		{
+			// server/discover is not name-bearing, so no name is required of
+			// it — and it is the first request a modern client sends, so
+			// getting this wrong would break every one of them.
+			name: "modern server/discover needs no name header",
+			body: `{"jsonrpc":"2.0","id":1,"method":"server/discover"}`,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "server/discover",
+			},
+		},
+		{
+			name: "modern tools/list needs no name header",
+			body: `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "tools/list",
+			},
+		},
+		{
+			// A notification has no id, and the spec leaves header rules for
+			// that shape undefined — so presence is not required.
+			name: "modern notification with no headers",
+			body: `{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+			},
+		},
+		{
+			name: "modern notification with a mismatched method header",
+			body: `{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "tools/call",
+			},
+			wantDeny: true,
+		},
+		{
+			// Case-sensitive on purpose: this compares a header against the
+			// body, not against a policy pattern, so a difference in case is
+			// the disagreement being detected.
+			name: "modern, method differing only in case",
+			body: toolsCallBody,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "Tools/Call",
+				mcpNameHeader:            "deploy",
+			},
+			wantDeny: true,
+		},
+		{
+			name: "sentinel-encoded name matching a UTF-8 tool name",
+			body: `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"café_deploy"}}`,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "tools/call",
+				mcpNameHeader:            base64SentinelPrefix + base64.StdEncoding.EncodeToString([]byte("café_deploy")) + base64SentinelSuffix,
+			},
+		},
+		{
+			name: "sentinel-encoded name that decodes to the wrong name",
+			body: toolsCallBody,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "tools/call",
+				mcpNameHeader:            base64SentinelPrefix + base64.StdEncoding.EncodeToString([]byte("other")) + base64SentinelSuffix,
+			},
+			wantDeny: true,
+		},
+		{
+			name: "sentinel with invalid base64",
+			body: toolsCallBody,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "tools/call",
+				mcpNameHeader:            base64SentinelPrefix + "!!!not-base64!!!" + base64SentinelSuffix,
+			},
+			wantDeny: true,
+		},
+		{
+			// A body declaring a different revision than the transport is
+			// self-contradictory: something downstream will believe one of
+			// the two, and it may not be the one Warden judged.
+			name: "body _meta version contradicts the header",
+			body: `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"deploy","_meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25"}}}`,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "tools/call",
+				mcpNameHeader:            "deploy",
+			},
+			wantDeny: true,
+		},
+		{
+			name: "body _meta version agrees with the header",
+			body: `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"deploy","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "tools/call",
+				mcpNameHeader:            "deploy",
+			},
+		},
+		{
+			// A version Warden cannot place is not read as "latest":
+			// imposing modern requirements on traffic that may be far older
+			// is the wrong direction to guess in.
+			name: "unparseable version is not treated as modern",
+			body: toolsCallBody,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "latest",
+			},
+		},
+		{
+			// One header cannot describe several calls, so a batch is not
+			// required to carry any.
+			name: "batch without transport headers is skipped",
+			body: `[{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"a"}},{"jsonrpc":"2.0","id":2,"method":"tools/list"}]`,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+			},
+		},
+		{
+			// But one that arrives anyway describes something unverifiable.
+			// Forwarding it would leave the mirrored-copy problem
+			// permanently open for batch traffic, which the legacy era goes
+			// on accepting.
+			name: "batch carrying a method header denies",
+			body: `[{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"a"}},{"jsonrpc":"2.0","id":2,"method":"tools/list"}]`,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "tools/call",
+			},
+			wantDeny: true,
+		},
+		{
+			// A one-element batch has exactly one method and name, so it is
+			// validated like any single call rather than waved through.
+			name: "single-element batch is validated",
+			body: `[{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"deploy"}}]`,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "tools/list",
+			},
+			wantDeny: true,
+		},
+		{
+			// resources/subscribe is name-bearing to the policy layer but
+			// carries no Mcp-Name on the wire — the go-sdk's Subscribe sends
+			// the method header and nothing else. Requiring one would refuse
+			// every modern subscribe.
+			name: "modern resources/subscribe needs no name header",
+			body: `{"jsonrpc":"2.0","id":1,"method":"resources/subscribe","params":{"uri":"repo://a"}}`,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "resources/subscribe",
+			},
+		},
+		{
+			// A body declaring the modern revision while the transport
+			// declares none is a modern request wearing legacy clothes,
+			// which is how a client would buy itself the era split's
+			// leniency.
+			name: "body _meta version with no transport version",
+			body: `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"deploy","_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`,
+			headers: map[string]string{
+				mcpMethodHeader: "tools/call",
+				mcpNameHeader:   "deploy",
+			},
+			wantDeny: true,
+		},
+		{
+			// The go-sdk compares Mcp-Name raw and reserves the sentinel for
+			// Mcp-Param-*; the spec defines it for names that are not
+			// header-safe. Either reading agreeing is enough, so a tool
+			// literally named like a sentinel is not falsely refused.
+			name: "name literally spelled like a sentinel",
+			body: `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"=?base64?zzz?="}}`,
+			headers: map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "tools/call",
+				mcpNameHeader:            "=?base64?zzz?=",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := headerReq(t, tc.body, tc.headers)
+			require.Nil(t, req.MCPDescriptor.ParseErr, "test body must parse")
+
+			d := validateMCPHeaders(req, req.MCPDescriptor)
+
+			if !tc.wantDeny {
+				assert.Nil(t, d)
+				return
+			}
+			require.NotNil(t, d, "expected a header-mismatch deny")
+			assert.Equal(t, "deny", d.Decision)
+			assert.Equal(t, mcpRuleTypeHeaderMismatch, d.RuleType)
+			assert.Empty(t, d.Method, "the decision must name no body or header value")
+			assert.Empty(t, d.Name)
+			// The audit detail is a closed set of constants, never anything
+			// read off the wire.
+			assert.Contains(t, []string{
+				headerMismatchMethod, headerMismatchName, headerMismatchVersion,
+				headerMismatchDuplicate, headerMismatchBatch,
+			}, d.MatchedRule)
+		})
+	}
+}
+
+// The gate runs before any contract is consulted, so a request whose headers
+// contradict its body is refused without asking whether the call it claims to
+// be would have been allowed.
+func TestMCPEval_HeaderMismatch_DeniesBeforeTheContract(t *testing.T) {
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["*"] }
+  tools { allowed = ["*"] }
+}
+`)
+	req := headerReq(t, toolsCallBody, map[string]string{
+		mcpProtocolVersionHeader: "2026-07-28",
+		mcpMethodHeader:          "tools/list",
+	})
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.False(t, res.Allowed, "a wide-open contract must not rescue a contradictory request")
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeHeaderMismatch, res.MCPDecision.RuleType)
+}
+
+// Absence-deny wins where no contract is in scope: the validation never runs
+// there, and the request is refused either way.
+func TestMCPEval_HeaderMismatch_AbsenceDenyTakesPrecedence(t *testing.T) {
+	cbp := mustCBP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`)
+	req := headerReq(t, toolsCallBody, map[string]string{
+		mcpProtocolVersionHeader: "2026-07-28",
+		mcpMethodHeader:          "tools/list",
+	})
+	res := cbp.AllowOperation(testContext(), req, nil, false)
+
+	assert.False(t, res.Allowed)
+	require.NotNil(t, res.MCPDecision)
+	assert.Equal(t, mcpRuleTypeNoMCPPolicy, res.MCPDecision.RuleType)
+}
+
+func TestDecodeMCPHeaderValue(t *testing.T) {
+	v, ok := decodeMCPHeaderValue("plain_name")
+	assert.True(t, ok)
+	assert.Equal(t, "plain_name", v)
+
+	v, ok = decodeMCPHeaderValue(base64SentinelPrefix + base64.StdEncoding.EncodeToString([]byte("héllo")) + base64SentinelSuffix)
+	assert.True(t, ok)
+	assert.Equal(t, "héllo", v)
+
+	// The markers are exact and lowercase; anything else is a literal value,
+	// not a sentinel.
+	v, ok = decodeMCPHeaderValue("=?BASE64?aGk=?=")
+	assert.True(t, ok)
+	assert.Equal(t, "=?BASE64?aGk=?=", v)
+
+	_, ok = decodeMCPHeaderValue(base64SentinelPrefix + "%%%" + base64SentinelSuffix)
+	assert.False(t, ok)
+}
+
+func TestIsHeaderEraRevision(t *testing.T) {
+	assert.True(t, isHeaderEraRevision("2026-07-28"))
+	assert.True(t, isHeaderEraRevision("2027-01-01"))
+	assert.False(t, isHeaderEraRevision("2025-11-25"))
+	assert.False(t, isHeaderEraRevision("2025-06-18"))
+	assert.False(t, isHeaderEraRevision(""))
+	assert.False(t, isHeaderEraRevision("latest"))
+	assert.False(t, isHeaderEraRevision("2026-07-28-beta"))
+	assert.False(t, isHeaderEraRevision("20260728"))
+}
+
+// The _meta cross-check must see what the upstream's decoder will see. Both
+// of these hide the key from a raw byte scan of the body while every
+// conforming decoder still resolves it, so a byte-level pre-check on the
+// wire bytes is a bypass rather than an optimisation.
+func TestValidateMCPHeaders_MetaVersionCannotHideFromTheCrossCheck(t *testing.T) {
+	backslash := string(rune(92))
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			// The key spelled with a unicode escape for '_': the bytes carry
+			// no "_meta", the decoded key is exactly that.
+			name: "escape-encoded _meta key",
+			body: `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"deploy","` +
+				backslash + `u005fmeta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25"}}}`,
+		},
+		{
+			// A case variant, which a struct-decoding upstream matches to
+			// the canonical field.
+			name: "case-variant _Meta key",
+			body: `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"deploy","_Meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25"}}}`,
+		},
+		{
+			name: "case-variant protocol version key",
+			body: `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"deploy","_meta":{"IO.MODELCONTEXTPROTOCOL/PROTOCOLVERSION":"2025-11-25"}}}`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := headerReq(t, tc.body, map[string]string{
+				mcpProtocolVersionHeader: "2026-07-28",
+				mcpMethodHeader:          "tools/call",
+				mcpNameHeader:            "deploy",
+			})
+			require.Nil(t, req.MCPDescriptor.ParseErr)
+			require.Equal(t, "2025-11-25", req.MCPDescriptor.Calls[0].MetaProtocolVersion,
+				"the parser must resolve the key the same way the upstream decoder will")
+
+			d := validateMCPHeaders(req, req.MCPDescriptor)
+			require.NotNil(t, d, "a body declaring a different revision must be refused")
+			assert.Equal(t, headerMismatchVersion, d.MatchedRule)
+		})
+	}
+}
+
+// A header sent twice is a header two readers can disagree about: Get
+// returns the first, and a downstream taking the last or the joined value
+// acts on something else.
+func TestValidateMCPHeaders_DuplicateHeaderValuesDeny(t *testing.T) {
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/mcp/gateway/", strings.NewReader(toolsCallBody))
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set(mcpProtocolVersionHeader, "2026-07-28")
+	httpReq.Header.Add(mcpMethodHeader, "tools/call")
+	httpReq.Header.Add(mcpMethodHeader, "tools/list")
+	httpReq.Header.Set(mcpNameHeader, "deploy")
+
+	req := &logical.Request{
+		Path:          "mcp/gateway/",
+		Operation:     logical.UpdateOperation,
+		HTTPRequest:   httpReq,
+		MCPDescriptor: synthesizeMCPDescriptorFromBody([]byte(toolsCallBody)),
+	}
+
+	d := validateMCPHeaders(req, req.MCPDescriptor)
+	require.NotNil(t, d, "the first value matching must not rescue a second that does not")
+	assert.Equal(t, headerMismatchDuplicate, d.MatchedRule)
+}
+
+// A non-object _meta, or a version that is not a string, declares nothing
+// readable — nothing downstream reads it as a version either, so it is
+// treated as absent rather than as a new reason to refuse legacy bodies.
+func TestExtractMetaProtocolVersion_UnreadableShapesAreAbsent(t *testing.T) {
+	for _, body := range []string{
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"x","_meta":"not-an-object"}}`,
+		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"x","_meta":{"io.modelcontextprotocol/protocolVersion":7}}}`,
+	} {
+		reqs, err := ParseJSONRPCStrict([]byte(body))
+		require.Nil(t, err, "body must still parse: %s", body)
+		assert.Empty(t, reqs[0].MetaProtocolVersion)
+	}
+}
+
+// The type split at the deny-wrapping site is the interception point the
+// whole rendering decision hangs on: both refusals arrive as a deny
+// MCPDecision, and if a header mismatch were wrapped as ErrMCPPolicyDenied
+// the HTTP layer would answer with the OAuth-shaped 403 — telling a
+// dual-era client to downgrade rather than to fix its headers. Nothing else
+// covers it, so assert the discrimination directly.
+func TestMCPHeaderMismatchError_IsDistinguishableFromAPolicyDeny(t *testing.T) {
+	req := headerReq(t, toolsCallBody, map[string]string{
+		mcpProtocolVersionHeader: "2026-07-28",
+		mcpMethodHeader:          "tools/list",
+	})
+	decision := &logical.MCPDecision{
+		Decision: "deny",
+		RuleType: mcpRuleTypeHeaderMismatch,
+	}
+
+	wrapped := multierror.Append(nil, mcpHeaderMismatchError(req, decision))
+
+	var headerErr *ErrMCPHeaderMismatch
+	require.True(t, errors.As(wrapped, &headerErr), "must survive the multierror wrapping the handler applies")
+	assert.Equal(t, "1", string(headerErr.RawID), "the id must reach the renderer to be echoed")
+	assert.True(t, headerErr.IDPresent)
+
+	var policyErr *ErrMCPPolicyDenied
+	assert.False(t, errors.As(wrapped, &policyErr),
+		"a header mismatch must not also satisfy the policy-deny branch, which is checked second")
+
+	// Both still unwrap to the shared permission-denied sentinel, so every
+	// existing errors.Is call site keeps working.
+	assert.ErrorIs(t, wrapped, sdklogical.ErrPermissionDenied)
+}
+
+// A notification carries no id, and the renderer needs to know that rather
+// than echo an empty value.
+func TestMCPHeaderMismatchError_NotificationCarriesNoID(t *testing.T) {
+	req := headerReq(t, `{"jsonrpc":"2.0","method":"notifications/initialized"}`, map[string]string{
+		mcpProtocolVersionHeader: "2026-07-28",
+		mcpMethodHeader:          "tools/call",
+	})
+
+	err := mcpHeaderMismatchError(req, &logical.MCPDecision{Decision: "deny", RuleType: mcpRuleTypeHeaderMismatch})
+
+	assert.False(t, err.IDPresent)
+	assert.Empty(t, err.RawID)
+}

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -193,7 +193,18 @@ func (c *Core) CheckToken(ctx context.Context, req *logical.Request, unauth bool
 			// errors.Is(err, ErrPermissionDenied) call site keeps
 			// working unchanged.
 			if auth.MCPDecision != nil && auth.MCPDecision.Decision == "deny" {
-				retErr = multierror.Append(retErr, &ErrMCPPolicyDenied{Decision: auth.MCPDecision})
+				// A header mismatch is a protocol-level disagreement, not an
+				// authorization failure, and the HTTP layer renders it as
+				// one. It must be split out here: both arrive as a deny
+				// MCPDecision, and the generic wrapper below would send it
+				// out as the OAuth-shaped 403 — which a dual-era client
+				// reads as "not permitted" and answers by downgrading to
+				// initialize, rather than by fixing its headers.
+				if auth.MCPDecision.RuleType == mcpRuleTypeHeaderMismatch {
+					retErr = multierror.Append(retErr, mcpHeaderMismatchError(req, auth.MCPDecision))
+				} else {
+					retErr = multierror.Append(retErr, &ErrMCPPolicyDenied{Decision: auth.MCPDecision})
+				}
 			} else {
 				retErr = multierror.Append(retErr, sdklogical.ErrPermissionDenied)
 			}

--- a/core/request_handler_mcp.go
+++ b/core/request_handler_mcp.go
@@ -121,16 +121,32 @@ func (c *Core) extractMCPDescriptor(_ context.Context, req *logical.Request, bac
 		return
 	}
 
-	desc.Calls = make([]logical.MCPCall, len(reqs))
+	desc.Calls = mcpCallsFromParsed(reqs)
+}
+
+// mcpCallsFromParsed maps strictly-parsed JSON-RPC requests onto the
+// descriptor's calls, stamping BatchIndex in array order.
+//
+// It is a named function rather than a loop inlined above because tests
+// build descriptors from a body too, and a second copy of this mapping is a
+// trap: a field added to one and not the other still passes every evaluator
+// test while production sees a zero value. For URIs in particular that zero
+// value means "subscribes to nothing", which allows.
+func mcpCallsFromParsed(reqs []JSONRPCRequest) []logical.MCPCall {
+	calls := make([]logical.MCPCall, len(reqs))
 	for i, r := range reqs {
-		desc.Calls[i] = logical.MCPCall{
-			Method:     r.Method,
-			Name:       r.Name,
-			MatchArgs:  classifyArgs(r.Arguments),
-			URIs:       r.URIs,
-			BatchIndex: i,
+		calls[i] = logical.MCPCall{
+			Method:              r.Method,
+			Name:                r.Name,
+			MatchArgs:           classifyArgs(r.Arguments),
+			URIs:                r.URIs,
+			RawID:               r.RawID,
+			IDPresent:           r.IDPresent,
+			MetaProtocolVersion: r.MetaProtocolVersion,
+			BatchIndex:          i,
 		}
 	}
+	return calls
 }
 
 // classifyArgs typifies each tools/call argument from raw JSON bytes

--- a/http/logical.go
+++ b/http/logical.go
@@ -57,6 +57,19 @@ func handleLogical(c *core.Core, log *logger.GatedLogger, forwarder *standbyForw
 			// generic Warden error body unchanged. The typed error
 			// Unwraps to sdklogical.ErrPermissionDenied so the status
 			// code is still 403 from errorToStatusCode above.
+			// Branched ahead of the policy-denial case below: a header
+			// mismatch is a protocol fault, not an authorization decision,
+			// and answering it with the 403 would tell a dual-era client to
+			// downgrade rather than to fix its headers. It gets a real
+			// JSON-RPC error and a 400, overriding the 403 that
+			// errorToStatusCode derives from the shared ErrPermissionDenied
+			// unwrap.
+			var mcpHeaderErr *core.ErrMCPHeaderMismatch
+			if errors.As(err, &mcpHeaderErr) {
+				respondMCPHeaderMismatch(w, mcpHeaderErr.RawID, mcpHeaderErr.IDPresent)
+				return
+			}
+
 			var mcpErr *core.ErrMCPPolicyDenied
 			if errors.As(err, &mcpErr) {
 				respondMCPDeny(w, statusCode, mcpErr.Decision)

--- a/http/util.go
+++ b/http/util.go
@@ -61,6 +61,56 @@ type mcpDenyResponse struct {
 // Description templates per RuleType live in core/policy_mcp.go's
 // BuildMCPDenyDescription so the wire shape and the audit JSON tags
 // stay in lockstep.
+// jsonRPCCodeHeaderMismatch is the spec's error code for a request whose
+// transport headers contradict its body.
+const jsonRPCCodeHeaderMismatch = -32020
+
+// jsonRPCError is a JSON-RPC 2.0 error response. Unlike a policy denial,
+// which the MCP spec handles at the HTTP layer, a header mismatch is a
+// protocol-level fault and gets a real JSON-RPC envelope with the request's
+// id echoed back.
+type jsonRPCError struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Error   jsonRPCErrorObj `json:"error"`
+}
+
+type jsonRPCErrorObj struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// respondMCPHeaderMismatch renders a transport-header refusal as HTTP 400
+// with a JSON-RPC -32020 body.
+//
+// Returning the error the modern spec defines, rather than the 403 a policy
+// denial gets, is what stops a dual-era client reading the refusal as "not
+// permitted" and answering by downgrading to initialize. The message names
+// no header and no value: the client already knows what it sent, and an
+// attacker should not be handed a probe for which half of the check fired.
+//
+// The id is echoed verbatim from the request. A body with no id is a
+// notification, which by JSON-RPC takes no response at all — but one that
+// reaches here failed validation, so the status still carries the refusal
+// and the id renders as null.
+func respondMCPHeaderMismatch(w http.ResponseWriter, rawID json.RawMessage, idPresent bool) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+
+	id := json.RawMessage("null")
+	if idPresent && len(rawID) > 0 {
+		id = rawID
+	}
+	_ = json.NewEncoder(w).Encode(&jsonRPCError{
+		JSONRPC: "2.0",
+		ID:      id,
+		Error: jsonRPCErrorObj{
+			Code:    jsonRPCCodeHeaderMismatch,
+			Message: "MCP transport headers do not match the request body",
+		},
+	})
+}
+
 func respondMCPDeny(w http.ResponseWriter, status int, d *logical.MCPDecision) {
 	desc := core.BuildMCPDenyDescription(d)
 	w.Header().Set("Content-Type", "application/json")

--- a/http/util_test.go
+++ b/http/util_test.go
@@ -451,3 +451,78 @@ func TestRespondError_StatusCodes(t *testing.T) {
 		})
 	}
 }
+
+// =============================================================================
+// Header-mismatch responses
+// =============================================================================
+
+// A header mismatch is a protocol fault, not an authorization decision, and
+// gets a real JSON-RPC envelope rather than the OAuth-shaped 403 a policy
+// denial gets. Returning the error the modern spec defines is what stops a
+// dual-era client reading the refusal as "not permitted" and downgrading to
+// initialize instead of correcting its headers.
+func TestRespondMCPHeaderMismatch_JSONRPCEnvelope(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	respondMCPHeaderMismatch(w, json.RawMessage(`42`), true)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+	assert.Empty(t, w.Header().Get("WWW-Authenticate"), "this is not an auth failure")
+
+	var got struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Error   struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, "2.0", got.JSONRPC)
+	assert.Equal(t, "42", string(got.ID), "the request id must be echoed")
+	assert.Equal(t, -32020, got.Error.Code)
+	assert.NotEmpty(t, got.Error.Message)
+}
+
+// The id is echoed verbatim, whatever JSON-RPC type it carries.
+func TestRespondMCPHeaderMismatch_EchoesIDShapes(t *testing.T) {
+	for _, raw := range []string{`42`, `"req-1"`, `null`} {
+		w := httptest.NewRecorder()
+		respondMCPHeaderMismatch(w, json.RawMessage(raw), true)
+
+		var got struct {
+			ID json.RawMessage `json:"id"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+		assert.Equal(t, raw, string(got.ID))
+	}
+}
+
+// A notification carries no id, so the envelope renders null rather than
+// omitting the field — a JSON-RPC error response always has one.
+func TestRespondMCPHeaderMismatch_NotificationRendersNullID(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	respondMCPHeaderMismatch(w, nil, false)
+
+	var got struct {
+		ID json.RawMessage `json:"id"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, "null", string(got.ID))
+}
+
+// The message must not name the header, the value, or which half of the
+// check fired: the client already knows what it sent, and an attacker should
+// not be handed a probe for the shape of the validation.
+func TestRespondMCPHeaderMismatch_LeaksNothing(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	respondMCPHeaderMismatch(w, json.RawMessage(`"id"`), true)
+
+	body := w.Body.String()
+	for _, leak := range []string{"Mcp-Method", "Mcp-Name", "MCP-Protocol-Version", "tools/call"} {
+		assert.NotContains(t, body, leak)
+	}
+}

--- a/logical/mcp_descriptor.go
+++ b/logical/mcp_descriptor.go
@@ -3,6 +3,8 @@
 
 package logical
 
+import "encoding/json"
+
 // MCPRequestDescriptor carries the result of strictly parsing an
 // MCP-enforced backend's request body. Stashed on *Request by the core
 // handler's extractor; consumed by the policy evaluator in a later
@@ -34,12 +36,26 @@ type MCPRequestDescriptor struct {
 // matcher gates each one against the resources family, so subscribing
 // to a resource's update stream requires the same grant as reading it.
 // nil for other methods, and for a listen that names no resource.
+// RawID carries the JSON-RPC id verbatim so a protocol-level error
+// response can echo it, and IDPresent separates a request from a
+// notification — JSON-RPC permits a null id, which is present-but-null
+// and not the same as absent. Neither is ever matched against; they
+// exist so a refusal can be rendered as a well-formed JSON-RPC error
+// rather than an opaque HTTP status.
 type MCPCall struct {
 	Method     string
 	Name       string
 	MatchArgs  map[string]ParamValue
 	URIs       []string
+	RawID      json.RawMessage
+	IDPresent  bool
 	BatchIndex int
+
+	// MetaProtocolVersion is the protocol revision the body declares in
+	// params._meta, empty when it declares none. Compared against the
+	// transport header so a request cannot claim one revision to Warden
+	// and another to whatever reads the body next.
+	MetaProtocolVersion string
 }
 
 // ParamKind classifies the JSON type of a tools/call argument value
@@ -125,9 +141,15 @@ func (d *MCPRequestDescriptor) Clone() *MCPRequestDescriptor {
 // request.
 func (c MCPCall) Clone() MCPCall {
 	out := MCPCall{
-		Method:     c.Method,
-		Name:       c.Name,
-		BatchIndex: c.BatchIndex,
+		Method:              c.Method,
+		Name:                c.Name,
+		IDPresent:           c.IDPresent,
+		MetaProtocolVersion: c.MetaProtocolVersion,
+		BatchIndex:          c.BatchIndex,
+	}
+	if c.RawID != nil {
+		out.RawID = make(json.RawMessage, len(c.RawID))
+		copy(out.RawID, c.RawID)
 	}
 	if c.MatchArgs != nil {
 		out.MatchArgs = make(map[string]ParamValue, len(c.MatchArgs))

--- a/logical/mcp_descriptor_test.go
+++ b/logical/mcp_descriptor_test.go
@@ -1,6 +1,7 @@
 package logical
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -55,4 +56,24 @@ func TestMCPRequestDescriptor_Clone_NilAndParseErr(t *testing.T) {
 	clone := orig.Clone()
 	clone.ParseErr.Msg = "mutated"
 	assert.Equal(t, "bad", orig.ParseErr.Msg)
+}
+
+// RawID is bytes the client controls, and the audit layer's clone must not
+// share them with the live request.
+func TestMCPCall_Clone_BreaksRawIDAliasing(t *testing.T) {
+	orig := MCPCall{Method: "tools/call", RawID: json.RawMessage(`"req-1"`), IDPresent: true}
+
+	clone := orig.Clone()
+	require.Equal(t, orig.RawID, clone.RawID)
+	assert.True(t, clone.IDPresent)
+
+	clone.RawID[1] = 'X'
+	assert.Equal(t, `"req-1"`, string(orig.RawID), "clone shares the RawID backing array")
+}
+
+func TestMCPCall_Clone_NilRawIDStaysNil(t *testing.T) {
+	clone := MCPCall{Method: "notifications/initialized"}.Clone()
+
+	assert.Nil(t, clone.RawID, "a notification must not gain an empty id")
+	assert.False(t, clone.IDPresent)
 }


### PR DESCRIPTION
**Stack 3/8** — MCP 2026-07-28 alignment. Base: `feat/mcp-listen-uris` (#591).

## The problem

From 2026-07-28 a client sends `MCP-Protocol-Version` on every request, plus `Mcp-Method` and — for three name-bearing methods — `Mcp-Name`. The spec requires that any server which processes the message body MUST validate those headers against it and reject a mismatch with `-32020`.

Warden processes the body and validated nothing. The security case is the **mirrored-copy problem**: the headers duplicate exactly the fields Warden judges, so anything behind Warden that routes or authorises on headers acts on input Warden never evaluated.

## Where it runs

Inside `decideMCP`, before contract evaluation: a body whose headers contradict it is refused on its own terms, without asking any contract whether the call it *claims* to be would have been allowed. Because `decideMCP` runs only when a contract is in scope, absence-deny still wins on a path with none — the precedence question answers itself.

## The era split — the part worth reviewing

**The protocol version decides only whether the headers are REQUIRED.** Whether the ones actually sent agree with the body is not era-dependent: a mismatch is never legitimate, and a client that sends a header has volunteered it for checking.

This is a deliberate deviation. The plan's rule 2a said "header absent ⇒ skip everything", but its own e2e matrix demands that a version-less client with a mismatched `Mcp-Method` still be denied. Skipping the match would have left the whole check bypassable by simply omitting a version header. Verified against the go-sdk that no legitimate legacy sender of these headers exists — v1.4.0 has no such code, and v1.7.0 sets them only at the header-era version — so match-if-present costs real traffic nothing.

Requiredness is narrower, and deliberately so. A notification carries no id and the spec leaves its header rules undefined, so presence is not demanded of it; a mismatched one is still refused. A version string not shaped like a revision date is not read as "latest": imposing modern requirements on traffic that may be far older is the wrong way to guess.

**The name-header set is three methods, not the policy layer's four.** Separate questions that merely overlap: `resources/subscribe` is name-bearing to a contract (stack 2), but carries no `Mcp-Name` on the wire — the go-sdk's `Subscribe` sends the method header alone. Reusing the policy predicate would have refused every modern subscribe as a mismatch, including the traffic stack 2 was just built to allow.

**Batches** are not required to carry these headers — one header cannot describe several calls — but one that arrives anyway is refused rather than forwarded, because it describes something unverifiable and the legacy era goes on accepting batches indefinitely. A one-element batch has exactly one method and name, so it is validated like any single call.

**Duplicate header values** are refused outright: `Get` returns the first, and a downstream reading the last or the joined value acts on something else.

**The base64 sentinel** is accepted on `Mcp-Name` but not required there — literal compared first, decoded second. The spec defines the sentinel for names that are not header-safe while the go-sdk compares `Mcp-Name` raw and reserves the sentinel for `Mcp-Param-*`; insisting on either convention alone would refuse conforming clients of the other. A sentinel whose payload will not decode still fails closed. `Mcp-Method` is never decoded — method names are ASCII token syntax by definition.

**Explicit non-goal: `Mcp-Param-{Name}`.** Validating those needs the tool's `inputSchema`, which Warden does not have. Warden is the spec's intermediary case — forward and ignore — and already does.

## Supporting parser work

The id is retained rather than discarded (`RawID`, `IDPresent`): an error response must echo it, and its presence separates a request from a notification. `params._meta`'s declared protocol version is extracted so a body cannot claim one revision to Warden and another to whatever reads it next — and a body declaring a revision while the transport declares none is refused too, since that is precisely how a client would buy itself the era split's leniency while speaking the modern protocol upstream.

**That extraction cannot be gated on a scan of the raw bytes.** A key spelled with a unicode escape for its underscore decodes to `_meta` while the wire carries no such string; a case variant hides from a byte scan while a struct-decoding upstream still matches it. Both verified empirically. Params are now decoded **once** and the object shared with every shape extractor — one decode *fewer* than before for `tools/call`.

## Rendering

A header mismatch is a protocol fault, not an authorization decision: **HTTP 400 and a real JSON-RPC `-32020`** with the id echoed, branched ahead of `ErrMCPPolicyDenied`, which would otherwise render the OAuth-shaped 403. That distinction is load-bearing — a dual-era client reads a 403 as "not permitted" and answers by downgrading to `initialize` rather than by fixing its headers.

The client response names no header and no value; the decision carries a closed-set token for which half refused, so an operator gets the detail from audit without adversary bytes reaching either.

## Also

Removes a trap this work walked straight into: the evaluator tests built descriptors from a second, hand-maintained copy of the extractor's mapping, so the new fields were silently zero in every test until four of them failed. Both paths now call one `mcpCallsFromParsed`.

## Verification

Full suite clean; `BenchmarkAllowOperation_*` unmoved. A 20-row header table covering both era branches, both smuggling shapes, duplicate headers, the sentinel, and `resources/subscribe`; HTTP-layer tests for the 400 / `-32020` / echoed id / no-leak; and a test for the error-type split through `multierror`. Covered end to end in stack 7.
