### PR TITLE
feat(policy): mark per-principal MCP responses uncacheable by shared caches

### DIFF
--- a/provider/mcp_aws/gateway.go
+++ b/provider/mcp_aws/gateway.go
@@ -59,6 +59,16 @@ func (b *mcpAWSBackend) handleGateway(ctx context.Context, req *logical.Request)
 	r := req.HTTPRequest
 	w := req.ResponseWriter
 
+	// Warden judged this body for one principal, so the answer is that
+	// principal's and not a document to hand to the next caller. This mount
+	// writes upstream headers straight onto the client's writer rather than
+	// through a reverse proxy's response hook, so the declaration is made by
+	// wrapping the writer — which catches both the streaming and the filtered
+	// paths, and the listing where nothing was pruned.
+	if req.MCPDescriptor != nil {
+		w = newCachePrivateWriter(w)
+	}
+
 	snap := b.snapshot()
 	if snap.upstreamURL == nil {
 		http.Error(w, "mcp_aws not configured", http.StatusServiceUnavailable)
@@ -162,6 +172,54 @@ func (b *mcpAWSBackend) handleGateway(ctx context.Context, req *logical.Request)
 		return
 	}
 	sigv4.ForwardDirect(b.Logger, w, r, bodyBytes, transport)
+}
+
+// cachePrivateWriter narrows Cache-Control on its way out, at the moment the
+// status line is written — which is after the upstream's own headers have
+// been copied in, and before anything reaches the client.
+//
+// A wrapper rather than a pre-set header: the copy loop Adds upstream values,
+// so a Cache-Control set beforehand would sit alongside the upstream's rather
+// than replace it, and a client would see two directives that disagree.
+type cachePrivateWriter struct {
+	http.ResponseWriter
+	marked bool
+}
+
+func newCachePrivateWriter(w http.ResponseWriter) *cachePrivateWriter {
+	return &cachePrivateWriter{ResponseWriter: w}
+}
+
+// Unwrap exposes the underlying writer to http.ResponseController, which the
+// streaming paths use to shed connection deadlines.
+func (w *cachePrivateWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+func (w *cachePrivateWriter) WriteHeader(code int) {
+	w.mark()
+	w.ResponseWriter.WriteHeader(code)
+}
+
+// Write covers a handler that never calls WriteHeader explicitly; net/http
+// would otherwise send the headers as they stand on the first write.
+func (w *cachePrivateWriter) Write(b []byte) (int, error) {
+	w.mark()
+	return w.ResponseWriter.Write(b)
+}
+
+// Flush implements http.Flusher — the SSE path flushes per read, and losing
+// it would buffer a stream that is supposed to arrive incrementally.
+func (w *cachePrivateWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+func (w *cachePrivateWriter) mark() {
+	if w.marked {
+		return
+	}
+	w.marked = true
+	httpproxy.MarkMCPResponsePrivate(w.Header())
 }
 
 // rewriteUpstreamURL mutates r in place to target the upstream MCP endpoint.

--- a/provider/mcp_aws/gateway_test.go
+++ b/provider/mcp_aws/gateway_test.go
@@ -461,3 +461,78 @@ func remainingDeadline(t *testing.T, req *logical.Request) time.Duration {
 	require.True(t, ok, "handleGateway must arm a deadline on the proxied request")
 	return time.Until(dl)
 }
+
+// --- cache hygiene ---
+
+// mcp_aws writes upstream headers straight onto the client's writer rather
+// than through a reverse proxy's response hook, so its declaration rides a
+// writer wrapper. Both response shapes must carry it: the streaming path and
+// the filtered one.
+func TestHandleGateway_MarksResponsePrivate(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "public, max-age=300")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"get_x"}]}}`))
+	}))
+	defer srv.Close()
+
+	for _, tc := range []struct {
+		name   string
+		filter *logical.MCPListFilter
+	}{
+		{name: "streamed response"},
+		{name: "filtered response", filter: &logical.MCPListFilter{
+			ListMethod: "tools/list",
+			Keep:       func(string) bool { return true },
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			b := setupBackend(t)
+			configureBackendForUpstream(t, b, srv)
+
+			req, rec := makeMCPRequest("/gateway/", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, stsCredential())
+			req.MCPDescriptor = &logical.MCPRequestDescriptor{
+				Calls: []logical.MCPCall{{Method: "tools/list"}},
+			}
+			req.MCPListFilter = tc.filter
+
+			b.handleGateway(context.Background(), req)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, "public, max-age=300, private", rec.Header().Get("Cache-Control"),
+				"a listing pruned per principal must not be served to another from a shared cache")
+		})
+	}
+}
+
+// A request this mount did not judge as MCP is left alone.
+func TestHandleGateway_NonMCPResponseUnmarked(t *testing.T) {
+	srv, _ := newCapturingUpstream(t)
+	defer srv.Close()
+
+	b := setupBackend(t)
+	configureBackendForUpstream(t, b, srv)
+
+	req, rec := makeMCPRequest("/gateway/", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`, stsCredential())
+
+	b.handleGateway(context.Background(), req)
+
+	assert.Empty(t, rec.Header().Get("Cache-Control"))
+}
+
+// The wrapper must not cost the SSE path its incremental delivery.
+func TestCachePrivateWriter_PreservesFlusher(t *testing.T) {
+	rec := httptest.NewRecorder()
+	w := newCachePrivateWriter(rec)
+
+	_, ok := interface{}(w).(http.Flusher)
+	require.True(t, ok, "the SSE loop selects on http.Flusher")
+
+	_, _ = w.Write([]byte("event: ping\n\n"))
+	w.Flush()
+
+	assert.Equal(t, "private", rec.Header().Get("Cache-Control"),
+		"a handler that never calls WriteHeader must still get the declaration")
+	assert.Equal(t, "event: ping\n\n", rec.Body.String())
+}

--- a/provider/sdk/httpproxy/gateway.go
+++ b/provider/sdk/httpproxy/gateway.go
@@ -108,6 +108,24 @@ func (b *proxyBackend) handleGateway(ctx context.Context, req *logical.Request) 
 	// Clean headers and inject credentials
 	b.prepareHeaders(r, credHeaders, dispatch)
 
+	// Mark this mount's traffic so ModifyResponse can declare the response
+	// per-principal. Keyed on the spec opting into MCP enforcement, which is
+	// the only thing that means "responses here are judged per principal".
+	//
+	// Deliberately NOT req.MCPDescriptor != nil: proxyBackend implements
+	// MCPPolicyEnforced for every provider it backs, so core installs the
+	// empty sentinel on github, openai and git traffic too. Reading that as
+	// "governed" would mark the whole provider surface uncacheable by any
+	// shared cache — a cost nothing here is asking anyone to pay.
+	//
+	// Being per-mount rather than per-request is the point: it covers the
+	// listing where every item survived and no filter was attached, the
+	// resources/read gated request-side, and resources/templates/list, which
+	// is cacheable but is not a filterable family.
+	if b.spec.ShouldEnforceMCPPolicy != nil {
+		r = r.WithContext(withMCPGoverned(r.Context()))
+	}
+
 	// When the policy layer attached an MCP list filter, carry it into the
 	// proxy's ModifyResponse via the request context, and strip Accept-Encoding
 	// so the transport returns a decompressed body the filter can parse (a

--- a/provider/sdk/httpproxy/mcp_filter.go
+++ b/provider/sdk/httpproxy/mcp_filter.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/logical"
@@ -29,6 +30,82 @@ func mcpListFilterFrom(ctx context.Context) *logical.MCPListFilter {
 	return f
 }
 
+// mcpGovernedCtxKey marks a request as one Warden judged per principal, which
+// is a wider set than "a filter was attached".
+type mcpGovernedCtxKeyT struct{}
+
+var mcpGovernedCtxKey = mcpGovernedCtxKeyT{}
+
+func withMCPGoverned(ctx context.Context) context.Context {
+	return context.WithValue(ctx, mcpGovernedCtxKey, true)
+}
+
+func mcpGovernedFrom(ctx context.Context) bool {
+	v, _ := ctx.Value(mcpGovernedCtxKey).(bool)
+	return v
+}
+
+// MarkMCPResponsePrivate tells shared caches that this response is not a
+// document to hand to the next caller.
+//
+// Exported because the MCP providers that bypass this package's reverse
+// proxy — writing upstream headers onto the client's writer themselves —
+// need the identical rule, and two spellings of "which directives already
+// suffice" would drift.
+//
+// Warden creates the variance and so has to declare it. A listing is pruned
+// to one principal's callable items; a resources/read is gated per principal
+// before it is forwarded. An upstream describing its own unfiltered answer
+// has no way to know that, and under the modern revision it may explicitly
+// authorise sharing.
+//
+// This is the half that covers what the body rewrite cannot: the fast path
+// where every item survives and the filter is skipped entirely, and
+// resources/templates/list, which is cacheable but not a filterable family.
+//
+// It only ever strengthens. An upstream that said no-store, or already said
+// private, meant something at least this restrictive and keeps it — replacing
+// no-store with private would be Warden loosening a bound it does not own.
+func MarkMCPResponsePrivate(h http.Header) {
+	// Values, not Get: several Cache-Control field lines are legal, and Get
+	// reads only the first while Set replaces them all. Reading one line and
+	// writing one back would delete an upstream no-store sitting on another —
+	// the precise loosening this function exists to avoid.
+	values := h.Values("Cache-Control")
+	if len(values) == 0 {
+		h.Set("Cache-Control", "private")
+		return
+	}
+	existing := strings.Join(values, ", ")
+	if hasRestrictiveDirective(existing) {
+		h.Set("Cache-Control", existing)
+		return
+	}
+	h.Set("Cache-Control", existing+", private")
+}
+
+// hasRestrictiveDirective reports whether a Cache-Control value already
+// forbids a shared cache from serving this response to another principal.
+//
+// Directives are compared whole, and only in their unqualified form. The
+// qualified shapes — private="x-thing", no-cache="set-cookie" — restrict only
+// the header fields they name and leave the response body storable and
+// shareable, so they are exactly the case where the bare directive is still
+// needed. A substring test would read them as sufficient and skip it.
+func hasRestrictiveDirective(value string) bool {
+	for _, part := range strings.Split(value, ",") {
+		name := strings.TrimSpace(strings.ToLower(part))
+		if i := strings.IndexByte(name, '='); i >= 0 {
+			continue // qualified form: restricts named fields only
+		}
+		switch name {
+		case "private", "no-store", "no-cache":
+			return true
+		}
+	}
+	return false
+}
+
 // installMCPListFilter wires the backend's ReverseProxy so an MCP list
 // response is pruned to the items the caller may use. The hook is a no-op for
 // any response whose request context carries no filter, so every non-MCP
@@ -38,7 +115,11 @@ func (b *proxyBackend) installMCPListFilter() {
 		return
 	}
 	b.Proxy.ModifyResponse = func(resp *http.Response) error {
-		filter := mcpListFilterFrom(resp.Request.Context())
+		ctx := resp.Request.Context()
+		if mcpGovernedFrom(ctx) {
+			MarkMCPResponsePrivate(resp.Header)
+		}
+		filter := mcpListFilterFrom(ctx)
 		if filter == nil {
 			return nil // not an MCP list request — stream verbatim
 		}

--- a/provider/sdk/httpproxy/mcp_filter_test.go
+++ b/provider/sdk/httpproxy/mcp_filter_test.go
@@ -253,3 +253,172 @@ func BenchmarkFilterMCPListResponse(b *testing.B) {
 		}
 	}
 }
+
+// =============================================================================
+// Cache-Control on governed responses
+// =============================================================================
+
+func TestMarkMCPResponsePrivate(t *testing.T) {
+	cases := []struct {
+		name     string
+		existing string
+		want     string
+	}{
+		{"no header", "", "private"},
+		{"public is narrowed", "public, max-age=60", "public, max-age=60, private"},
+		{"max-age alone gains private", "max-age=60", "max-age=60, private"},
+		// Only ever strengthens: an upstream that said no-store meant
+		// something stricter than private, and replacing it would be Warden
+		// loosening a bound it does not own.
+		{"no-store survives untouched", "no-store", "no-store"},
+		{"no-cache survives untouched", "no-cache", "no-cache"},
+		{"already private is left alone", "private", "private"},
+		{"private among others is left alone", "max-age=0, private", "max-age=0, private"},
+		{"casing is not a way around it", "NO-STORE", "NO-STORE"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.Header{}
+			if tc.existing != "" {
+				h.Set("Cache-Control", tc.existing)
+			}
+
+			MarkMCPResponsePrivate(h)
+
+			if got := h.Get("Cache-Control"); got != tc.want {
+				t.Errorf("Cache-Control = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The header half is what covers the responses the body rewrite cannot: a
+// listing where every item survived and the filter was skipped, a
+// resources/read gated request-side, and resources/templates/list, which is
+// cacheable but not a filterable family.
+func TestModifyResponse_MarksGovernedResponsesPrivate(t *testing.T) {
+	spec := testSpec()
+	pb := setupBackend(t, spec).(*proxyBackend)
+
+	cases := []struct {
+		name     string
+		governed bool
+		want     string
+	}{
+		{"governed request is marked", true, "private"},
+		{"non-MCP request is untouched", false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tc.governed {
+				ctx = withMCPGoverned(ctx)
+			}
+			resp := &http.Response{
+				StatusCode: 200,
+				Header:     http.Header{},
+				Request:    httptest.NewRequest("POST", "/v1/test/gateway/", nil).WithContext(ctx),
+			}
+
+			if err := pb.Proxy.ModifyResponse(resp); err != nil {
+				t.Fatalf("ModifyResponse: %v", err)
+			}
+
+			if got := resp.Header.Get("Cache-Control"); got != tc.want {
+				t.Errorf("Cache-Control = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The predicate that decides which mounts declare their responses private is
+// the whole blast radius of this feature. proxyBackend implements
+// MCPPolicyEnforced for every provider it backs, so core installs an empty
+// descriptor on github, openai and git traffic too — reading that as
+// "governed" would mark the entire provider surface uncacheable by any
+// shared cache. Driven through handleGateway rather than by building the
+// context by hand, so the wiring itself is covered.
+func TestHandleGateway_OnlyMCPEnforcingMountsMarkResponsesPrivate(t *testing.T) {
+	cases := []struct {
+		name        string
+		enforcesMCP bool
+		want        string
+	}{
+		{"MCP-enforcing mount", true, "private"},
+		{"ordinary REST provider", false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer upstream.Close()
+
+			spec := testSpec()
+			spec.DefaultURL = upstream.URL
+			spec.ExtractCredentials = func(*logical.Request) (map[string]string, error) {
+				return map[string]string{"Authorization": "Bearer test"}, nil
+			}
+			if tc.enforcesMCP {
+				spec.ShouldEnforceMCPPolicy = func(*logical.Request) bool { return true }
+			}
+
+			pb := setupBackend(t, spec).(*proxyBackend)
+			pb.providerURL = upstream.URL
+
+			rec := httptest.NewRecorder()
+			pb.handleGateway(context.Background(), &logical.Request{
+				HTTPRequest:    httptest.NewRequest("POST", "/v1/test/gateway/", nil),
+				ResponseWriter: rec,
+				// The empty sentinel core installs for every httpproxy
+				// backend, MCP-enforcing or not.
+				MCPDescriptor: &logical.MCPRequestDescriptor{},
+			})
+
+			if got := rec.Header().Get("Cache-Control"); got != tc.want {
+				t.Errorf("Cache-Control = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Several Cache-Control field lines are legal HTTP. Reading only the first
+// and writing one back would delete an upstream no-store sitting on another —
+// exactly the loosening the strengthen-only rule exists to prevent.
+func TestMarkMCPResponsePrivate_PreservesEveryFieldLine(t *testing.T) {
+	h := http.Header{}
+	h.Add("Cache-Control", "public")
+	h.Add("Cache-Control", "no-store")
+
+	MarkMCPResponsePrivate(h)
+
+	got := h.Get("Cache-Control")
+	if !strings.Contains(got, "no-store") {
+		t.Errorf("Cache-Control = %q, dropped the upstream no-store", got)
+	}
+	if strings.Contains(got, "private") {
+		t.Errorf("Cache-Control = %q, appended private to an already-restrictive value", got)
+	}
+}
+
+// A qualified directive restricts only the header fields it names and leaves
+// the body storable and shareable, so it is precisely where the bare
+// directive is still needed. A substring test would read it as sufficient.
+func TestMarkMCPResponsePrivate_QualifiedDirectivesAreNotSufficient(t *testing.T) {
+	cases := []string{
+		`private="x-session-hint", max-age=600`,
+		`public, no-cache="set-cookie"`,
+	}
+	for _, existing := range cases {
+		t.Run(existing, func(t *testing.T) {
+			h := http.Header{}
+			h.Set("Cache-Control", existing)
+
+			MarkMCPResponsePrivate(h)
+
+			if got := h.Get("Cache-Control"); !strings.HasSuffix(got, ", private") {
+				t.Errorf("Cache-Control = %q, want a bare private appended", got)
+			}
+		})
+	}
+}

--- a/provider/sdk/mcpfilter/mcpfilter.go
+++ b/provider/sdk/mcpfilter/mcpfilter.go
@@ -37,13 +37,24 @@ var listFamilies = map[string]listFamily{
 	"prompts/list":   {arrayKey: "prompts", nameField: "name"},
 }
 
+// cacheScope is the result field by which a server tells intermediaries
+// whether its answer may be shared. "public" explicitly authorises a shared
+// cache to serve the same bytes to anyone.
+const (
+	cacheScopeKey     = "cacheScope"
+	cacheScopePrivate = "private"
+)
+
 // FilterListResponse rewrites a list-method response body, dropping items
 // whose name the keep predicate rejects.
 //
 //   - out is always the bytes the caller should send: the filtered body when
 //     changed is true, or the original body unchanged when changed is false.
 //     The caller must write out (it has already consumed the source stream).
-//   - changed reports whether any item was removed.
+//   - changed reports whether the body was rewritten — an item removed, or
+//     a cacheScope narrowed to "private". The second counts even when
+//     nothing was dropped: a listing pruned for one principal is not the
+//     document another would get, so a shared cache must not be told it is.
 //   - err is non-nil only when the body cannot be parsed as the expected
 //     list-result shape. The caller must fail closed (never stream the
 //     original) on an error, because an unparseable body cannot be proven
@@ -105,8 +116,9 @@ func filterJSON(body []byte, fam listFamily, keep func(string) bool) ([]byte, bo
 }
 
 // filterResult filters the array under fam.arrayKey inside a JSON-RPC result
-// object, preserving every other field (nextCursor, unknown fields). Returns
-// the rewritten result and whether any item was dropped.
+// object, preserving every other field (nextCursor, ttlMs, unknown fields),
+// and narrows cacheScope to "private". Returns the rewritten result and
+// whether either changed it.
 func filterResult(resultRaw json.RawMessage, fam listFamily, keep func(string) bool) (json.RawMessage, bool, error) {
 	var result map[string]json.RawMessage
 	if err := json.Unmarshal(resultRaw, &result); err != nil {
@@ -115,10 +127,22 @@ func filterResult(resultRaw json.RawMessage, fam listFamily, keep func(string) b
 		return nil, false, fmt.Errorf("mcpfilter: result is not an object: %w", err)
 	}
 
+	// Narrow the scope before the array lookup: a result that carries a
+	// cacheScope but no family array still described a per-principal answer,
+	// and returning early would leave a public scope on the wire.
+	scopeChanged := privatizeCacheScope(result)
+
 	arrRaw, ok := result[fam.arrayKey]
 	if !ok {
 		// Result carries no array for this family — nothing to filter.
-		return nil, false, nil
+		if !scopeChanged {
+			return nil, false, nil
+		}
+		newResult, err := json.Marshal(result)
+		if err != nil {
+			return nil, false, fmt.Errorf("mcpfilter: re-marshal result: %w", err)
+		}
+		return newResult, true, nil
 	}
 
 	var items []json.RawMessage
@@ -139,20 +163,58 @@ func filterResult(resultRaw json.RawMessage, fam listFamily, keep func(string) b
 		}
 	}
 
-	if len(kept) == len(items) {
+	if len(kept) == len(items) && !scopeChanged {
 		return nil, false, nil
 	}
 
-	newArr, err := json.Marshal(kept)
-	if err != nil {
-		return nil, false, fmt.Errorf("mcpfilter: re-marshal %s: %w", fam.arrayKey, err)
+	if len(kept) != len(items) {
+		newArr, err := json.Marshal(kept)
+		if err != nil {
+			return nil, false, fmt.Errorf("mcpfilter: re-marshal %s: %w", fam.arrayKey, err)
+		}
+		result[fam.arrayKey] = newArr
 	}
-	result[fam.arrayKey] = newArr
 	newResult, err := json.Marshal(result)
 	if err != nil {
 		return nil, false, fmt.Errorf("mcpfilter: re-marshal result: %w", err)
 	}
 	return newResult, true, nil
+}
+
+// privatizeCacheScope rewrites a result's cacheScope to "private", reporting
+// whether it changed anything.
+//
+// The listing this result carries was pruned for one principal, so it is not
+// the same document another principal would get. An upstream that marked it
+// "public" was describing its own unfiltered answer and is authorising shared
+// intermediaries to serve it to anyone. Warden creates the variance, so
+// Warden marks it.
+//
+// A rewrite counts as a change even when no item was dropped: "nothing was
+// dropped for THIS principal" is not "this document is the same for
+// everyone", and the whole point is to stop a shared cache assuming the
+// latter.
+//
+// The field is never added when the upstream omitted it. Inventing one would
+// put a field on the wire the server never sent, which strict clients are
+// entitled to object to, and an absent cacheScope already means the
+// conservative thing.
+func privatizeCacheScope(result map[string]json.RawMessage) bool {
+	raw, ok := result[cacheScopeKey]
+	if !ok {
+		return false
+	}
+	var scope string
+	if err := json.Unmarshal(raw, &scope); err != nil {
+		// Not a string. Leave it alone rather than guess at a shape the
+		// spec does not define; the Cache-Control header still applies.
+		return false
+	}
+	if scope == cacheScopePrivate {
+		return false
+	}
+	result[cacheScopeKey] = json.RawMessage(`"` + cacheScopePrivate + `"`)
+	return true
 }
 
 // itemName extracts the string value of nameField from a list item. Returns

--- a/provider/sdk/mcpfilter/mcpfilter_test.go
+++ b/provider/sdk/mcpfilter/mcpfilter_test.go
@@ -353,3 +353,129 @@ func TestFilterSSE_CRLFFraming(t *testing.T) {
 		t.Fatalf("denied tool leaked: %s", out)
 	}
 }
+
+// =============================================================================
+// cacheScope
+// =============================================================================
+
+func resultOf(t *testing.T, body []byte) map[string]json.RawMessage {
+	t.Helper()
+	var env map[string]json.RawMessage
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	var result map[string]json.RawMessage
+	if err := json.Unmarshal(env["result"], &result); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	return result
+}
+
+// A listing pruned for one principal is not the document another principal
+// would get, so an upstream "public" — which explicitly authorises a shared
+// intermediary to serve the same bytes to anyone — has to be narrowed.
+func TestFilterJSON_ForcesCacheScopePrivate(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"get_x"},{"name":"delete_x"}],"cacheScope":"public","ttlMs":60000}}`)
+
+	out, changed, err := FilterListResponse("tools/list", "application/json", body, denyPrefix("delete_"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+
+	result := resultOf(t, out)
+	if got := string(result["cacheScope"]); got != `"private"` {
+		t.Errorf("cacheScope = %s, want \"private\"", got)
+	}
+	if got := string(result["ttlMs"]); got != "60000" {
+		t.Errorf("ttlMs = %s, want 60000 — freshness is the upstream's call, not ours", got)
+	}
+}
+
+// The rewrite counts as a change on its own. "Nothing was dropped for THIS
+// principal" is not "this document is the same for everyone", and letting the
+// body pass through byte-identical would leave the public scope on the wire.
+func TestFilterJSON_CacheScopeRewriteAloneCountsAsChanged(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"get_x"}],"cacheScope":"public"}}`)
+
+	out, changed, err := FilterListResponse("tools/list", "application/json", body, func(string) bool { return true })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true — nothing dropped, but the scope was narrowed")
+	}
+	if got := string(resultOf(t, out)["cacheScope"]); got != `"private"` {
+		t.Errorf("cacheScope = %s, want \"private\"", got)
+	}
+}
+
+// Inventing a field the upstream never sent would put something on the wire
+// the server did not say, which strict clients may object to. An absent
+// cacheScope already means the conservative thing.
+func TestFilterJSON_DoesNotAddCacheScope(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"get_x"}]}}`)
+
+	out, changed, err := FilterListResponse("tools/list", "application/json", body, func(string) bool { return true })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Error("changed = true, want false — nothing to drop and no scope to narrow")
+	}
+	if _, ok := resultOf(t, out)["cacheScope"]; ok {
+		t.Error("cacheScope was invented on a response that carried none")
+	}
+}
+
+func TestFilterJSON_AlreadyPrivateCacheScopeIsLeftAlone(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"get_x"}],"cacheScope":"private"}}`)
+
+	out, changed, err := FilterListResponse("tools/list", "application/json", body, func(string) bool { return true })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Error("changed = true, want false — already private")
+	}
+	if string(out) != string(body) {
+		t.Error("body was rewritten despite nothing needing to change")
+	}
+}
+
+// A non-string cacheScope is a shape the spec does not define. Guessing at it
+// risks corrupting a field we do not understand; the Cache-Control header
+// still covers the response.
+func TestFilterJSON_NonStringCacheScopeLeftAlone(t *testing.T) {
+	body := []byte(`{"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"get_x"}],"cacheScope":{"scope":"public"}}}`)
+
+	_, changed, err := FilterListResponse("tools/list", "application/json", body, func(string) bool { return true })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if changed {
+		t.Error("changed = true, want false")
+	}
+}
+
+// The SSE shape goes through the same result rewrite, so it must narrow the
+// scope too — an event-stream listing is cacheable in exactly the same way.
+func TestFilterSSE_ForcesCacheScopePrivate(t *testing.T) {
+	body := []byte("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"tools\":[{\"name\":\"get_x\"}],\"cacheScope\":\"public\"}}\n\n")
+
+	out, changed, err := FilterListResponse("tools/list", "text/event-stream", body, func(string) bool { return true })
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !changed {
+		t.Fatal("changed = false, want true")
+	}
+	if !strings.Contains(string(out), `"cacheScope":"private"`) {
+		t.Errorf("SSE block did not carry the narrowed scope:\n%s", out)
+	}
+	if !strings.Contains(string(out), "event: message") {
+		t.Error("non-data lines must survive the rewrite")
+	}
+}


### PR DESCRIPTION
**Stack 4/8** — MCP 2026-07-28 alignment. Base: `feat/mcp-header-validation` (#592).

## The problem

`ttlMs`/`cacheScope` are required on the list methods and `resources/read` from 2026-07-28, and `cacheScope: "public"` **explicitly authorises a shared intermediary to serve the same bytes to anyone**.

Warden prunes a listing per principal, gates `resources/read` per principal, and then forwarded `cacheScope` verbatim while setting no `Cache-Control` of its own. So a shared cache downstream could serve one principal's pruned listing to another. Warden creates the variance; Warden now declares it.

## Two halves, because neither covers the other

**The body rewrite** narrows an existing `cacheScope` to `"private"`, in both the JSON and SSE shapes — they share one result rewrite, so the second came free.

It counts as a change **even when no item was dropped**: "nothing was dropped for THIS principal" is not "this document is the same for everyone", and passing the body through byte-identical would leave a public scope on the wire. It also runs before the family-array lookup, so a result carrying a scope but no array does not slip out on the early return.

`ttlMs` is untouched — freshness is the upstream's call. An absent `cacheScope` is **not invented**: putting a field on the wire the server never sent is something strict clients may object to, and absent already means the conservative thing. A non-string value is left alone rather than guessed at.

**The header half** sets `Cache-Control` on responses from mounts that enforce MCP policy.

Note the predicate: **the spec's enforcement hook, not the presence of a descriptor.** `proxyBackend` implements `MCPPolicyEnforced` for every provider it backs, so core installs the empty sentinel on github, openai and git traffic too — keying on that would have marked the entire provider surface uncacheable by any shared cache, a cost none of those mounts is asking anyone to pay. (Caught in review; the test that pins it drives a non-MCP spec through `handleGateway`.)

Being per-mount rather than per-request is what makes this half worth having: it covers the fast path where every item survives and no filter is attached, `resources/read` gated request-side, and `resources/templates/list` — cacheable, but not a filterable family and should not become one. Those paths get the header only; an MCP-protocol intermediary reading `cacheScope` from the body still sees whatever the upstream sent there.

## Strengthen-only, on the whole header

Several `Cache-Control` field lines are legal HTTP. Reading one with `Get` and writing one back with `Set` would **delete an upstream `no-store` sitting on another** — precisely the loosening this is meant to avoid. Values are joined instead.

Directives are compared whole and only in their unqualified form: the qualified shapes — `private="x-thing"`, `no-cache="set-cookie"` — restrict only the fields they name and leave the body storable and shareable, so they are exactly where the bare directive is still needed rather than a reason to skip it.

## mcp_aws needs its own injection

It writes upstream headers straight onto the client's writer rather than through the reverse proxy's response hook. The declaration rides a **writer wrapper** rather than a pre-set header, because the copy loop `Add`s upstream values and a header set beforehand would sit alongside the upstream's rather than replace it. The wrapper marks on first write as well as on `WriteHeader`, and keeps `Flusher` and `Unwrap` so the SSE path still delivers incrementally and can still shed connection deadlines. The body half carries over for free — that mount calls the same filter.

## Verification

Full suite clean. Body-rewrite tests in JSON and SSE (forced private, changed-on-scope-alone, never-added, already-private, non-string); an 8-row strengthen-only table; the multi-field-line and qualified-directive cases; the enforcing-vs-ordinary-provider row driven through `handleGateway`; and mcp_aws's streamed and filtered paths plus `Flusher` preservation.

Both review-found bugs were mutation-checked — reintroducing each fails exactly the test named for it. Covered end to end in stack 7 on both the pruned and keep-everything paths.
