### PR TITLE
feat(policy): refuse modern-era batches, record the client's self-description

### DIFF
--- a/audit/types.go
+++ b/audit/types.go
@@ -143,16 +143,38 @@ type PolicyResults struct {
 	Allowed          bool     `json:"allowed"`
 	GrantingPolicies []string `json:"granting_policies,omitempty"`
 
-	// MCPDecision carries the MCP-specific policy decision when an
-	// mcp { } block was consulted during CBP evaluation. nil when no
-	// such block applied. The field is omitempty so non-MCP audit
-	// records remain byte-identical to today's output.
+	// MCPDecision carries the decision an MCP-shaped request reached,
+	// populated on both outcomes: a contract was consulted and allowed or
+	// denied the call, or no contract was in scope at all and the request
+	// was refused with no_mcp_policy. The absence case is the one worth
+	// recording loudest — it is an operator misconfiguration, not a caller
+	// overstepping.
+	//
+	// nil for everything else: every non-MCP provider, and the body-less
+	// verbs an MCP mount serves alongside its JSON-RPC POSTs. The field is
+	// omitempty so those records stay byte-identical to today's output.
 	MCPDecision *logical.MCPDecision `json:"mcp_decision,omitempty"`
+
+	// MCPClient carries the client's self-description, taken from the
+	// request body's _meta. It sits beside MCPDecision rather than on it
+	// because it decided nothing: it is unverified, unauthenticated and
+	// trivially forged, useful for telling one agent build from another in
+	// a log and for nothing else. Never gate on it.
+	MCPClient *MCPClientInfo `json:"mcp_client,omitempty"`
 
 	// Condition carries the path-level CEL condition decision when a condition
 	// was evaluated for a non-MCP request (the MCP per-call condition is
 	// recorded on MCPDecision.Condition instead). nil when none applied.
 	Condition *logical.ConditionResult `json:"condition,omitempty"`
+}
+
+// MCPClientInfo is a client's self-reported identity. Control characters are
+// stripped and each field length-capped at extraction, so a caller cannot
+// use it to inject line breaks into an audit record or to grow one without
+// bound.
+type MCPClientInfo struct {
+	Name    string `json:"name,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 // AuthResult contains authentication result from login operations
@@ -325,6 +347,10 @@ func (e *LogEntry) Clone() *LogEntry {
 				Allowed:     e.Auth.PolicyResults.Allowed,
 				MCPDecision: e.Auth.PolicyResults.MCPDecision.Clone(),
 				Condition:   e.Auth.PolicyResults.Condition.Clone(),
+			}
+			if mc := e.Auth.PolicyResults.MCPClient; mc != nil {
+				mcCopy := *mc
+				clone.Auth.PolicyResults.MCPClient = &mcCopy
 			}
 			if e.Auth.PolicyResults.GrantingPolicies != nil {
 				clone.Auth.PolicyResults.GrantingPolicies = make([]string, len(e.Auth.PolicyResults.GrantingPolicies))

--- a/core/audit_helpers.go
+++ b/core/audit_helpers.go
@@ -153,10 +153,9 @@ func buildAuditAuth(auth *logical.Auth, te *logical.TokenEntry) *audit.Auth {
 				}
 				auditAuth.PolicyResults.GrantingPolicies = policies
 			}
-			// Surface the MCP decision into the audit record when an
-			// mcp { } rule-set was consulted. The audit's PolicyResults
-			// owns the wire shape; the in-memory MCPDecision flows in
-			// from logical.Auth.MCPDecision via the request handler.
+			// Surface the MCP decision into the audit record. The audit's
+			// PolicyResults owns the wire shape; the in-memory MCPDecision
+			// flows in from logical.Auth.MCPDecision via the request handler.
 			if auth.MCPDecision != nil {
 				auditAuth.PolicyResults.MCPDecision = auth.MCPDecision
 			}
@@ -294,6 +293,7 @@ func (c *Core) buildRequestAuditEntry(
 		Auth:      buildAuditAuth(auth, te),
 	}
 	stampUserAttribution(entry, req)
+	stampMCPClient(entry, req)
 
 	if outerErr != nil {
 		entry.Error = outerErr.Error()
@@ -321,6 +321,38 @@ func stampUserAttribution(entry *audit.LogEntry, req *logical.Request) {
 	}
 }
 
+// stampMCPClient records the client's self-description on the audit entry.
+//
+// It rides the request descriptor rather than the authorization result
+// because it took no part in one: the value is unverified, unauthenticated,
+// and set by the caller. It is here so an operator reading a denial can tell
+// which agent build produced it, and for nothing else.
+//
+// Stamped even when the request was refused — the client that sent a body
+// Warden rejected is exactly the one an operator wants named.
+func stampMCPClient(entry *audit.LogEntry, req *logical.Request) {
+	if entry == nil || req == nil || req.MCPDescriptor == nil {
+		return
+	}
+	desc := req.MCPDescriptor
+	if desc.ClientInfoName == "" && desc.ClientInfoVersion == "" {
+		return
+	}
+	if entry.Auth == nil {
+		entry.Auth = &audit.Auth{}
+	}
+	// PolicyResults is allocated only when policy evaluation produced
+	// results, and a request refused before that — which is exactly a
+	// request worth attributing — has none.
+	if entry.Auth.PolicyResults == nil {
+		entry.Auth.PolicyResults = &audit.PolicyResults{}
+	}
+	entry.Auth.PolicyResults.MCPClient = &audit.MCPClientInfo{
+		Name:    desc.ClientInfoName,
+		Version: desc.ClientInfoVersion,
+	}
+}
+
 // buildResponseAuditEntry creates an audit.LogEntry for a response
 func (c *Core) buildResponseAuditEntry(
 	ctx context.Context,
@@ -345,6 +377,7 @@ func (c *Core) buildResponseAuditEntry(
 		Response:  buildAuditResponse(resp, req, cred),
 	}
 	stampUserAttribution(entry, req)
+	stampMCPClient(entry, req)
 
 	// Capture error from multiple sources:
 	// 1. outerErr - errors from request processing (e.g., routing errors)

--- a/core/audit_test.go
+++ b/core/audit_test.go
@@ -1336,3 +1336,88 @@ func TestBuildRequestAuditEntry_WithError(t *testing.T) {
 	entry := core.buildRequestAuditEntry(ctx, req, nil, nil, assert.AnError)
 	assert.Equal(t, assert.AnError.Error(), entry.Error)
 }
+
+// The client's self-description rides the request descriptor, not the
+// authorization result, because it decided nothing — so it is stamped onto
+// the entry separately, and must survive a request that never reached policy
+// evaluation.
+func TestStampMCPClient(t *testing.T) {
+	t.Run("stamped from the descriptor", func(t *testing.T) {
+		entry := &audit.LogEntry{}
+		req := &logical.Request{MCPDescriptor: &logical.MCPRequestDescriptor{
+			ClientInfoName:    "claude-code",
+			ClientInfoVersion: "2.1.0",
+		}}
+
+		stampMCPClient(entry, req)
+
+		require.NotNil(t, entry.Auth)
+		require.NotNil(t, entry.Auth.PolicyResults, "a refusal before policy evaluation has no PolicyResults yet")
+		require.NotNil(t, entry.Auth.PolicyResults.MCPClient)
+		assert.Equal(t, "claude-code", entry.Auth.PolicyResults.MCPClient.Name)
+		assert.Equal(t, "2.1.0", entry.Auth.PolicyResults.MCPClient.Version)
+	})
+
+	t.Run("absent client info stamps nothing", func(t *testing.T) {
+		entry := &audit.LogEntry{}
+		stampMCPClient(entry, &logical.Request{MCPDescriptor: &logical.MCPRequestDescriptor{}})
+		assert.Nil(t, entry.Auth)
+	})
+
+	t.Run("non-MCP request stamps nothing", func(t *testing.T) {
+		entry := &audit.LogEntry{}
+		stampMCPClient(entry, &logical.Request{})
+		assert.Nil(t, entry.Auth)
+	})
+
+	t.Run("nil-safe", func(t *testing.T) {
+		stampMCPClient(nil, nil)
+	})
+}
+
+// The async audit writer works from a clone, so a field the clone drops is a
+// field that never reaches the log.
+func TestLogEntry_CloneCarriesMCPClient(t *testing.T) {
+	entry := &audit.LogEntry{Auth: &audit.Auth{PolicyResults: &audit.PolicyResults{
+		MCPClient: &audit.MCPClientInfo{Name: "claude-code", Version: "2.1.0"},
+	}}}
+
+	clone := entry.Clone()
+
+	require.NotNil(t, clone.Auth.PolicyResults.MCPClient)
+	assert.Equal(t, "claude-code", clone.Auth.PolicyResults.MCPClient.Name)
+
+	clone.Auth.PolicyResults.MCPClient.Name = "mutated"
+	assert.Equal(t, "claude-code", entry.Auth.PolicyResults.MCPClient.Name,
+		"the clone must not share the struct with the live entry")
+}
+
+// The stamp is only useful if the entry builders call it. Asserting through
+// them rather than through stampMCPClient directly means removing the call
+// site fails the test.
+func TestAuditEntries_CarryMCPClient(t *testing.T) {
+	c := createTestCore(t)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	req := &logical.Request{
+		Path:      "mcp/gateway/",
+		Operation: logical.UpdateOperation,
+		MCPDescriptor: &logical.MCPRequestDescriptor{
+			ClientInfoName:    "claude-code",
+			ClientInfoVersion: "2.1.0",
+		},
+	}
+
+	t.Run("request entry", func(t *testing.T) {
+		entry := c.buildRequestAuditEntry(ctx, req, nil, nil, nil)
+		require.NotNil(t, entry.Auth)
+		require.NotNil(t, entry.Auth.PolicyResults.MCPClient)
+		assert.Equal(t, "claude-code", entry.Auth.PolicyResults.MCPClient.Name)
+	})
+
+	t.Run("response entry", func(t *testing.T) {
+		entry := c.buildResponseAuditEntry(ctx, req, &logical.Response{StatusCode: 403}, nil, nil, nil)
+		require.NotNil(t, entry.Auth)
+		require.NotNil(t, entry.Auth.PolicyResults.MCPClient)
+		assert.Equal(t, "2.1.0", entry.Auth.PolicyResults.MCPClient.Version)
+	})
+}

--- a/core/policy_jsonrpc.go
+++ b/core/policy_jsonrpc.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"io"
 	"strings"
+	"unicode/utf8"
 )
 
 // maxJSONDepth bounds the recursion of the strict JSON-RPC body walker
@@ -52,6 +53,12 @@ type JSONRPCRequest struct {
 	// MetaProtocolVersion is the revision the body itself declares in
 	// params._meta, empty when it declares none.
 	MetaProtocolVersion string
+
+	// ClientInfoName and ClientInfoVersion are the client's self-description
+	// from params._meta. Unverified and unauthenticated — recorded for
+	// operators, never consulted by a gate.
+	ClientInfoName    string
+	ClientInfoVersion string
 }
 
 // ParseErrorKind enumerates structural-failure deny reasons. Each kind
@@ -112,58 +119,72 @@ func (e *ParseError) Error() string {
 // callers that need to map their own size-cap failure into the same
 // rule_type vocabulary.
 func ParseJSONRPCStrict(body []byte) ([]JSONRPCRequest, *ParseError) {
+	reqs, _, perr := ParseJSONRPCStrictBody(body)
+	return reqs, perr
+}
+
+// ParseJSONRPCStrictBody is ParseJSONRPCStrict plus the body's outer shape:
+// isBatch reports whether the top-level value was an array.
+//
+// The shape is not recoverable from the returned slice — a one-element array
+// and a single object both yield one request — and callers that must
+// distinguish them need it. A batch is a legacy-only shape: it was dropped
+// from the spec in 2025-06-18, so a modern client sending one is
+// self-contradictory in a way only this flag can see.
+func ParseJSONRPCStrictBody(body []byte) ([]JSONRPCRequest, bool, *ParseError) {
 	if hasUTF8BOM(body) {
-		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "body has UTF-8 BOM"}
+		return nil, false, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "body has UTF-8 BOM"}
 	}
 
 	first, ok := firstNonWS(body)
 	if !ok {
-		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "empty body"}
+		return nil, false, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "empty body"}
 	}
 
 	dec := json.NewDecoder(bytes.NewReader(body))
 	dec.UseNumber()
 
 	var requests []JSONRPCRequest
+	isBatch := first == '['
 
 	switch first {
 	case '{':
 		req, perr := parseJSONRPCRequest(dec)
 		if perr != nil {
-			return nil, perr
+			return nil, isBatch, perr
 		}
 		requests = []JSONRPCRequest{*req}
 	case '[':
 		// Consume the opening '['.
 		if _, err := dec.Token(); err != nil {
-			return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+			return nil, isBatch, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
 		}
 		for dec.More() {
 			req, perr := parseJSONRPCRequest(dec)
 			if perr != nil {
-				return nil, perr
+				return nil, isBatch, perr
 			}
 			requests = append(requests, *req)
 		}
 		// Consume the closing ']'.
 		if _, err := dec.Token(); err != nil {
-			return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
+			return nil, isBatch, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: err.Error()}
 		}
 		if len(requests) == 0 {
-			return nil, &ParseError{Kind: ErrKindBatchEmpty, Msg: "empty batch"}
+			return nil, isBatch, &ParseError{Kind: ErrKindBatchEmpty, Msg: "empty batch"}
 		}
 	default:
-		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "top-level value must be object or array"}
+		return nil, isBatch, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "top-level value must be object or array"}
 	}
 
 	// No trailing data after the top-level value. dec.Token() returning
 	// io.EOF means clean end; anything else (including a successful
 	// token read) is trailing data.
 	if _, err := dec.Token(); err != io.EOF {
-		return nil, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "trailing data after JSON-RPC payload"}
+		return nil, isBatch, &ParseError{Kind: ErrKindMalformedJSONRPC, Msg: "trailing data after JSON-RPC payload"}
 	}
 
-	return requests, nil
+	return requests, isBatch, nil
 }
 
 // parseJSONRPCRequest parses one JSON-RPC request object from the
@@ -306,6 +327,10 @@ func decodeParamsObject(raw json.RawMessage) (map[string]json.RawMessage, bool) 
 // rejection.
 const metaProtocolVersionKey = "io.modelcontextprotocol/protocolVersion"
 
+// metaClientInfoKey carries the client's self-description, which the
+// stateless protocol moved onto every request from the initialize handshake.
+const metaClientInfoKey = "io.modelcontextprotocol/clientInfo"
+
 // extractMetaProtocolVersion peeks params._meta for the client's declared
 // protocol revision, so the header validator can cross-check the transport
 // header against what the body itself claims.
@@ -330,6 +355,8 @@ func extractMetaProtocolVersion(req *JSONRPCRequest, top map[string]json.RawMess
 	if err := json.Unmarshal(metaRaw, &meta); err != nil {
 		return nil
 	}
+	extractMetaClientInfo(req, meta)
+
 	verRaw, ok, perr := lookupParamKey(meta, metaProtocolVersionKey, req.Method)
 	if perr != nil {
 		return perr
@@ -343,6 +370,52 @@ func extractMetaProtocolVersion(req *JSONRPCRequest, top map[string]json.RawMess
 	}
 	req.MetaProtocolVersion = ver
 	return nil
+}
+
+// maxClientInfoField bounds each recorded clientInfo string. The value is
+// self-reported and unverified, so it is capped rather than trusted not to
+// arrive as a megabyte of text aimed at the audit log.
+const maxClientInfoField = 128
+
+// extractMetaClientInfo reads the client's self-description out of _meta.
+// Under the stateless protocol it rides every request, having previously come
+// from the initialize handshake.
+//
+// Never an error: this is decoration. A shape that will not decode simply
+// records nothing, because refusing a request over the contents of a field
+// nothing is authorised by would be trading a working call for a log line.
+func extractMetaClientInfo(req *JSONRPCRequest, meta map[string]json.RawMessage) {
+	infoRaw, ok, perr := lookupParamKey(meta, metaClientInfoKey, req.Method)
+	if perr != nil || !ok {
+		return
+	}
+	var info struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(infoRaw, &info); err != nil {
+		return
+	}
+	req.ClientInfoName = boundedField(info.Name)
+	req.ClientInfoVersion = boundedField(info.Version)
+}
+
+// boundedField strips ASCII control characters and truncates, so a
+// self-reported value cannot inject line breaks into an audit record or grow
+// it without limit.
+//
+// Truncation backs off to a rune boundary rather than cutting mid-sequence,
+// which would leave a dangling byte for stripCTL to substitute and put the
+// result over the cap it was just held to.
+func boundedField(s string) string {
+	if len(s) > maxClientInfoField {
+		cut := maxClientInfoField
+		for cut > 0 && !utf8.RuneStart(s[cut]) {
+			cut--
+		}
+		s = s[:cut]
+	}
+	return stripCTL(s)
 }
 
 // extractMethodShape populates Name and (for tools/call) Arguments

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -58,6 +58,7 @@ const (
 	mcpRuleTypeOversizedBody    = "oversized_body"
 	mcpRuleTypeBatchEmpty       = "batch_empty"
 	mcpRuleTypeMalformedParams  = "malformed_params"
+	mcpRuleTypeBatchUnsupported = "batch_unsupported"
 
 	// mcpRuleTypeBatchListUnfilterable denies an otherwise-allowed batch
 	// that contains a list method. A batched JSON-RPC list response can't
@@ -793,6 +794,7 @@ func mcpDenyRank(ruleType string) int {
 		mcpRuleTypeBatchEmpty,
 		mcpRuleTypeMalformedParams,
 		mcpRuleTypeBatchListUnfilterable,
+		mcpRuleTypeBatchUnsupported,
 		mcpRuleTypeHeaderMismatch,
 		// Never actually competes — it is produced outside evaluateMCPCall,
 		// where there are no rule-sets to rank against. Listed so the ranking
@@ -879,6 +881,8 @@ func BuildMCPDenyDescription(d *logical.MCPDecision) string {
 		return "Request params have unexpected shape."
 	case mcpRuleTypeBatchListUnfilterable:
 		return "Batched list requests are not supported."
+	case mcpRuleTypeBatchUnsupported:
+		return "Batched requests are not supported at the requested protocol version."
 	case mcpRuleTypeMissingMethod:
 		return "Request method required."
 	case mcpRuleTypeHeaderMismatch:

--- a/core/policy_mcp_eval_test.go
+++ b/core/policy_mcp_eval_test.go
@@ -1031,6 +1031,12 @@ func TestBuildMCPDenyDescription_PerRuleType(t *testing.T) {
 		decision *logical.MCPDecision
 		want     string
 	}{
+		{mcpRuleTypeBatchUnsupported,
+			&logical.MCPDecision{RuleType: mcpRuleTypeBatchUnsupported},
+			"Batched requests are not supported at the requested protocol version."},
+		{mcpRuleTypeHeaderMismatch,
+			&logical.MCPDecision{RuleType: mcpRuleTypeHeaderMismatch, MatchedRule: headerMismatchMethod},
+			"MCP transport headers do not match the request body."},
 		{mcpRuleTypeDeniedMethods,
 			&logical.MCPDecision{Method: "tools/call", RuleType: mcpRuleTypeDeniedMethods},
 			"Method 'tools/call' not allowed."},

--- a/core/request_handler_mcp.go
+++ b/core/request_handler_mcp.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
+	"strings"
 
 	"github.com/stephnangue/warden/framework"
 	"github.com/stephnangue/warden/logical"
@@ -112,7 +114,7 @@ func (c *Core) extractMCPDescriptor(_ context.Context, req *logical.Request, bac
 		return
 	}
 
-	reqs, perr := ParseJSONRPCStrict(body)
+	reqs, isBatch, perr := ParseJSONRPCStrictBody(body)
 	if perr != nil {
 		desc.ParseErr = &logical.MCPParseError{
 			Kind: string(perr.Kind),
@@ -120,8 +122,55 @@ func (c *Core) extractMCPDescriptor(_ context.Context, req *logical.Request, bac
 		}
 		return
 	}
+	desc.IsBatch = isBatch
+	if len(reqs) > 0 {
+		// One body, one client: the self-description rides every call, so the
+		// first is as good as any and the descriptor carries it once. Recorded
+		// before any refusal below — the client that sent a body Warden
+		// rejected is exactly the one an operator wants named.
+		desc.ClientInfoName = reqs[0].ClientInfoName
+		desc.ClientInfoVersion = reqs[0].ClientInfoVersion
+	}
+
+	// JSON-RPC batching left the spec in 2025-06-18, so a client announcing a
+	// revision that postdates its removal while sending one is contradicting
+	// itself. Refuse it here, in the extractor, so it is refused as a batch
+	// rather than reaching the header validator and being reported as a
+	// header mismatch — the client would then go looking at its headers, which
+	// are not the problem.
+	//
+	// The parser itself is untouched: an upstream of the legacy era still
+	// gets its batches, which is most of why Warden can front both eras.
+	if isBatch && announcesHeaderEra(req.HTTPRequest, reqs) {
+		desc.ParseErr = &logical.MCPParseError{
+			Kind: logical.MCPParseKindBatchUnsupported,
+			Msg:  "batch request from a client announcing a revision that dropped batching",
+		}
+		return
+	}
 
 	desc.Calls = mcpCallsFromParsed(reqs)
+}
+
+// announcesHeaderEra reports whether a client claimed a modern revision, in
+// either place it can make that claim.
+//
+// The body counts, not only the transport header. The header validator
+// refuses a single call that declares a modern revision in params._meta while
+// the transport declares none — but it skips batches, having no single method
+// to compare against. Reading only the header here would leave that exact
+// combination as the way through: declare modernity in _meta, send two
+// elements, and be neither refused as a batch nor caught as a mismatch.
+func announcesHeaderEra(r *http.Request, reqs []JSONRPCRequest) bool {
+	if r != nil && isHeaderEraRevision(strings.TrimSpace(r.Header.Get(mcpProtocolVersionHeader))) {
+		return true
+	}
+	for _, req := range reqs {
+		if isHeaderEraRevision(req.MetaProtocolVersion) {
+			return true
+		}
+	}
+	return false
 }
 
 // mcpCallsFromParsed maps strictly-parsed JSON-RPC requests onto the

--- a/core/request_handler_mcp_test.go
+++ b/core/request_handler_mcp_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -417,5 +418,218 @@ func TestExtractMCPDescriptor_ListenWithoutSubscriptions(t *testing.T) {
 
 	if got := req.MCPDescriptor.Calls[0].URIs; got != nil {
 		t.Errorf("URIs = %v, want nil", got)
+	}
+}
+
+// =============================================================================
+// Modern-era batch rejection
+// =============================================================================
+
+func batchReq(t *testing.T, version string) *logical.Request {
+	t.Helper()
+	req := newReq(t, `[{"jsonrpc":"2.0","id":1,"method":"tools/list"},{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"x"}}]`)
+	if version != "" {
+		req.HTTPRequest.Header.Set(mcpProtocolVersionHeader, version)
+	}
+	return req
+}
+
+// Batching left the spec in 2025-06-18, so a client announcing a revision
+// that postdates its removal while sending one is contradicting itself.
+func TestExtractMCPDescriptor_ModernBatchRejected(t *testing.T) {
+	c := &Core{}
+	req := batchReq(t, "2026-07-28")
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+
+	c.extractMCPDescriptor(context.Background(), req, b)
+
+	desc := req.MCPDescriptor
+	if desc.ParseErr == nil {
+		t.Fatal("ParseErr = nil, want a batch refusal")
+	}
+	if desc.ParseErr.Kind != logical.MCPParseKindBatchUnsupported {
+		t.Errorf("Kind = %q, want %q", desc.ParseErr.Kind, logical.MCPParseKindBatchUnsupported)
+	}
+	if desc.Calls != nil {
+		t.Error("Calls must be unspecified when ParseErr is set")
+	}
+}
+
+// The fail-open branch that keeps dual-era support working, and the one that
+// most needs a test that fails when it is taken wrongly: a legacy client's
+// batch must still be accepted and every element policy-checked.
+func TestExtractMCPDescriptor_LegacyBatchStillAccepted(t *testing.T) {
+	for _, version := range []string{"", "2025-11-25", "2025-06-18"} {
+		t.Run("version="+version, func(t *testing.T) {
+			c := &Core{}
+			req := batchReq(t, version)
+			b := &mcpBackend{}
+			b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+
+			c.extractMCPDescriptor(context.Background(), req, b)
+
+			desc := req.MCPDescriptor
+			if desc.ParseErr != nil {
+				t.Fatalf("ParseErr = %v, want nil — legacy batches must keep working", desc.ParseErr)
+			}
+			if len(desc.Calls) != 2 {
+				t.Fatalf("Calls len = %d, want 2 — every element must be policy-checked", len(desc.Calls))
+			}
+			if !desc.IsBatch {
+				t.Error("IsBatch = false, want true")
+			}
+		})
+	}
+}
+
+// A one-element array is a batch that looks like a single call in Calls
+// alone. Tracking the outer shape is the only way to tell them apart.
+func TestExtractMCPDescriptor_SingleElementBatchIsStillABatch(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]`)
+	req.HTTPRequest.Header.Set(mcpProtocolVersionHeader, "2026-07-28")
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+
+	c.extractMCPDescriptor(context.Background(), req, b)
+
+	if req.MCPDescriptor.ParseErr == nil {
+		t.Fatal("a one-element batch must be refused like any other batch")
+	}
+}
+
+// A version Warden cannot place is not read as modern, matching how the
+// header validator treats it — guessing "latest" would refuse legacy traffic.
+func TestExtractMCPDescriptor_UnparseableVersionKeepsBatches(t *testing.T) {
+	c := &Core{}
+	req := batchReq(t, "latest")
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+
+	c.extractMCPDescriptor(context.Background(), req, b)
+
+	if req.MCPDescriptor.ParseErr != nil {
+		t.Fatalf("ParseErr = %v, want nil", req.MCPDescriptor.ParseErr)
+	}
+}
+
+// =============================================================================
+// clientInfo
+// =============================================================================
+
+func TestExtractMCPDescriptor_CarriesClientInfo(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"deploy","_meta":{"io.modelcontextprotocol/clientInfo":{"name":"claude-code","version":"2.1.0"}}}}`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+
+	c.extractMCPDescriptor(context.Background(), req, b)
+
+	desc := req.MCPDescriptor
+	if desc.ClientInfoName != "claude-code" || desc.ClientInfoVersion != "2.1.0" {
+		t.Errorf("client info = %q/%q, want claude-code/2.1.0", desc.ClientInfoName, desc.ClientInfoVersion)
+	}
+}
+
+// The value is self-reported and unverified, so it must not be able to break
+// the log it lands in.
+func TestExtractMCPDescriptor_ClientInfoIsBounded(t *testing.T) {
+	long := strings.Repeat("a", 500)
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"x","_meta":{"io.modelcontextprotocol/clientInfo":{"name":"`+long+`","version":"1.0\ninjected: line"}}}}`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+
+	c.extractMCPDescriptor(context.Background(), req, b)
+
+	desc := req.MCPDescriptor
+	if len(desc.ClientInfoName) > maxClientInfoField {
+		t.Errorf("name length = %d, want <= %d", len(desc.ClientInfoName), maxClientInfoField)
+	}
+	if strings.ContainsAny(desc.ClientInfoVersion, "\n\r") {
+		t.Errorf("version = %q still carries control characters", desc.ClientInfoVersion)
+	}
+}
+
+// Decoration must never cost a working call: a shape that will not decode
+// records nothing and the request proceeds.
+func TestExtractMCPDescriptor_MalformedClientInfoIsNotAnError(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"x","_meta":{"io.modelcontextprotocol/clientInfo":"not-an-object"}}}`)
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+
+	c.extractMCPDescriptor(context.Background(), req, b)
+
+	desc := req.MCPDescriptor
+	if desc.ParseErr != nil {
+		t.Fatalf("ParseErr = %v, want nil", desc.ParseErr)
+	}
+	if desc.ClientInfoName != "" {
+		t.Errorf("ClientInfoName = %q, want empty", desc.ClientInfoName)
+	}
+}
+
+// The header is not the only place a client can announce its era. The header
+// validator skips batches — it has no single method to compare against — so
+// reading only the header here would leave one combination through: declare
+// modernity in params._meta, send two elements, and be neither refused as a
+// batch nor caught as a mismatch.
+func TestExtractMCPDescriptor_MetaDeclaredModernBatchRejected(t *testing.T) {
+	const elem = `{"jsonrpc":"2.0","id":%d,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2026-07-28"}}}`
+
+	c := &Core{}
+	// No transport version header at all — the shape that used to slip past.
+	req := newReq(t, "["+fmt.Sprintf(elem, 1)+","+fmt.Sprintf(elem, 2)+"]")
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+
+	c.extractMCPDescriptor(context.Background(), req, b)
+
+	desc := req.MCPDescriptor
+	if desc.ParseErr == nil {
+		t.Fatal("ParseErr = nil, want a batch refusal")
+	}
+	if desc.ParseErr.Kind != logical.MCPParseKindBatchUnsupported {
+		t.Errorf("Kind = %q, want %q", desc.ParseErr.Kind, logical.MCPParseKindBatchUnsupported)
+	}
+}
+
+// A legacy body declaring a legacy revision in _meta is still a legacy
+// batch — the era test must read the declared value, not merely its presence.
+func TestExtractMCPDescriptor_MetaDeclaredLegacyBatchAccepted(t *testing.T) {
+	const elem = `{"jsonrpc":"2.0","id":%d,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"2025-11-25"}}}`
+
+	c := &Core{}
+	req := newReq(t, "["+fmt.Sprintf(elem, 1)+","+fmt.Sprintf(elem, 2)+"]")
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+
+	c.extractMCPDescriptor(context.Background(), req, b)
+
+	if req.MCPDescriptor.ParseErr != nil {
+		t.Fatalf("ParseErr = %v, want nil", req.MCPDescriptor.ParseErr)
+	}
+}
+
+// The refusal this PR introduces must still attribute the client: the one
+// that sent a body Warden rejected is exactly the one an operator wants
+// named.
+func TestExtractMCPDescriptor_BatchRefusalStillCarriesClientInfo(t *testing.T) {
+	c := &Core{}
+	req := newReq(t, `[{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{"io.modelcontextprotocol/clientInfo":{"name":"claude-code","version":"2.1.0"}}}},{"jsonrpc":"2.0","id":2,"method":"tools/list"}]`)
+	req.HTTPRequest.Header.Set(mcpProtocolVersionHeader, "2026-07-28")
+	b := &mcpBackend{}
+	b.enforced = &fakeMCPHook{enforce: true, cap: 1 << 20}
+
+	c.extractMCPDescriptor(context.Background(), req, b)
+
+	desc := req.MCPDescriptor
+	if desc.ParseErr == nil {
+		t.Fatal("expected the batch to be refused")
+	}
+	if desc.ClientInfoName != "claude-code" {
+		t.Errorf("ClientInfoName = %q, want claude-code — a refused request still names its client", desc.ClientInfoName)
 	}
 }

--- a/logical/mcp_descriptor.go
+++ b/logical/mcp_descriptor.go
@@ -18,6 +18,19 @@ import "encoding/json"
 type MCPRequestDescriptor struct {
 	Calls    []MCPCall
 	ParseErr *MCPParseError
+
+	// IsBatch records that the body's top-level value was an array. Not
+	// recoverable from Calls, since a one-element array and a single
+	// object both yield one call — and that is exactly the pair the
+	// modern-era batch rejection has to tell apart.
+	IsBatch bool
+
+	// ClientInfoName and ClientInfoVersion are the client's
+	// self-description, carried for the audit record. Unverified,
+	// unauthenticated, and trivially forged: never consult them in a
+	// gate.
+	ClientInfoName    string
+	ClientInfoVersion string
 }
 
 // MCPCall is one strictly-parsed JSON-RPC request extracted from the
@@ -108,6 +121,14 @@ const (
 	MCPParseKindOversizedBody    = "oversized_body"
 	MCPParseKindBatchEmpty       = "batch_empty"
 	MCPParseKindMalformedParams  = "malformed_params"
+
+	// MCPParseKindBatchUnsupported refuses a batch from a client announcing
+	// a protocol revision that postdates batching's removal from the spec.
+	// Distinct from MCPParseKindBatchEmpty, and distinct from a header
+	// mismatch: the body is well-formed and the headers describe it
+	// correctly — the two claims it makes about itself simply cannot both
+	// be true.
+	MCPParseKindBatchUnsupported = "batch_unsupported"
 )
 
 // Clone returns a deep copy of the MCPRequestDescriptor. Safe to call
@@ -120,7 +141,11 @@ func (d *MCPRequestDescriptor) Clone() *MCPRequestDescriptor {
 	if d == nil {
 		return nil
 	}
-	clone := &MCPRequestDescriptor{}
+	clone := &MCPRequestDescriptor{
+		IsBatch:           d.IsBatch,
+		ClientInfoName:    d.ClientInfoName,
+		ClientInfoVersion: d.ClientInfoVersion,
+	}
 	if d.Calls != nil {
 		clone.Calls = make([]MCPCall, len(d.Calls))
 		for i, c := range d.Calls {

--- a/logical/mcp_descriptor_test.go
+++ b/logical/mcp_descriptor_test.go
@@ -77,3 +77,21 @@ func TestMCPCall_Clone_NilRawIDStaysNil(t *testing.T) {
 	assert.Nil(t, clone.RawID, "a notification must not gain an empty id")
 	assert.False(t, clone.IDPresent)
 }
+
+// The audit layer treats the descriptor as a deep-copy field, so every field
+// added to it has to be carried. A value field silently dropped by Clone is
+// invisible until something reads the clone and finds a zero.
+func TestMCPRequestDescriptor_CloneCarriesEveryField(t *testing.T) {
+	orig := &MCPRequestDescriptor{
+		Calls:             []MCPCall{{Method: "tools/list"}},
+		IsBatch:           true,
+		ClientInfoName:    "claude-code",
+		ClientInfoVersion: "2.1.0",
+	}
+
+	clone := orig.Clone()
+
+	assert.True(t, clone.IsBatch, "the outer shape is not recoverable from Calls")
+	assert.Equal(t, "claude-code", clone.ClientInfoName)
+	assert.Equal(t, "2.1.0", clone.ClientInfoVersion)
+}


### PR DESCRIPTION
**Stack 5/8** — MCP 2026-07-28 alignment. Base: `feat/mcp-cache-hygiene` (#593).

Two modern-era refinements, neither of which touches what the legacy era is allowed to send.

## Modern-era batches

JSON-RPC batching left the MCP spec in **2025-06-18**, so a client announcing a revision that postdates its removal while sending one is contradicting itself.

The strict parser is deliberately untouched — legacy batches must keep working, and that is most of why Warden can front both eras. Instead the parser now also reports the body's **outer shape**, and the extractor refuses the combination. The shape has to be reported explicitly because it is not recoverable from the parsed calls: a one-element array and a single object both yield one call, and that is exactly the pair this has to tell apart.

The refusal lives in the **extractor** rather than the header validator so a modern batch is reported as a batch. Routed the other way it would surface as a header mismatch and send the client to inspect headers that are not the problem.

**Era is read from both places a client can announce it.** The transport header is the obvious one; `params._meta` is the other, and reading only the header left a live way through — the header validator skips batches, having no single method to compare against, so a body declaring the modern revision in `_meta` with no version header was refused as a single call and **forwarded as a two-element batch**. Same claim, same refusal, whichever way it is made. (Caught in review.)

## clientInfo

Under the stateless protocol the client's self-description rides `params._meta` on every request, having previously come from the initialize handshake. Verified against the go-sdk's `MetaKeyClientInfo`.

It is stamped from the **request descriptor** rather than the authorization result because it took no part in one: unverified, unauthenticated, trivially forged, useful for telling one agent build from another in a log and for nothing else. No gate reads it, and the field comment says so.

Stripped of control characters and length-capped at extraction, with truncation backing off to a rune boundary rather than cutting a sequence in half. Recorded **before any refusal**, including the new batch one — the client that sent a body Warden rejected is exactly the one an operator wants named. (Also caught in review: the copy sat after the refusal's early return.)

## Also

Corrects a stale comment on the audit `MCPDecision` field while adding beside it. MCP rules moved out of capability policies into their own document type, and since the absence rule the decision is populated precisely when *no* contract applied — which the comment claimed was when it would be nil.

## Verification

Full suite clean; `BenchmarkAllowOperation_*` unmoved.

Modern batch refused; legacy batch accepted across `version=""`, `2025-11-25`, `2025-06-18`; one-element batch still a batch; unparseable version still legacy; the `_meta`-declared modern and legacy batch rows; clientInfo carried, bounded, malformed-tolerant, and present on the batch refusal; audit stamping through both entry builders and through `LogEntry.Clone`.

Covered end to end in stack 7, both branches.
