### PR TITLE
feat(cred): validate the RFC 9207 issuer on an OAuth2 connect callback

### DIFF
--- a/api/sys_credential_specs.go
+++ b/api/sys_credential_specs.go
@@ -352,6 +352,12 @@ type AuthorizeCredentialSpecInput struct {
 type AuthorizeCredentialSpecOutput struct {
 	Name         string `json:"name"`
 	AuthorizeURL string `json:"authorize_url"`
+
+	// Issuer is the identifier an RFC 9207 "iss" callback parameter must
+	// match, empty when the source records none. It rides the authorize
+	// response because the comparison happens at the callback, before the
+	// code is sent back to be redeemed.
+	Issuer string `json:"issuer,omitempty"`
 }
 
 // ConnectCredentialSpecInput is the input for completing the connect flow.
@@ -408,6 +414,9 @@ func (c *Sys) AuthorizeCredentialSpecWithContext(ctx context.Context, name strin
 	}
 	if v, ok := resource.Data["authorize_url"].(string); ok {
 		output.AuthorizeURL = v
+	}
+	if v, ok := resource.Data["issuer"].(string); ok {
+		output.Issuer = v
 	}
 	return output, nil
 }

--- a/cmd/cred/spec/connect.go
+++ b/cmd/cred/spec/connect.go
@@ -148,7 +148,7 @@ func runConnect(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	code, err := awaitCallback(cmd.Context(), ln, state, connectTimeout)
+	code, err := awaitCallback(cmd.Context(), ln, state, authzOut.Issuer, connectTimeout)
 	if err != nil {
 		return err
 	}
@@ -176,9 +176,13 @@ func runConnect(cmd *cobra.Command, args []string) error {
 	})
 }
 
-// awaitCallback serves a single request on the loopback listener, validates the
-// state, and returns the authorization code. It always shuts the server down.
-func awaitCallback(parent context.Context, ln net.Listener, state string, timeout time.Duration) (string, error) {
+// awaitCallback serves a single request on the loopback listener, validates
+// the state and (when the source records one) the RFC 9207 issuer, and
+// returns the authorization code. It always shuts the server down.
+//
+// issuer is "" when the source records none, which downgrades the issuer
+// check to a warning — see the callback handler.
+func awaitCallback(parent context.Context, ln net.Listener, state, issuer string, timeout time.Duration) (string, error) {
 	type result struct {
 		code string
 		err  error
@@ -220,6 +224,34 @@ func awaitCallback(parent context.Context, ln net.Listener, state string, timeou
 				writeCallbackPage(w, false, "state parameter mismatch")
 				send(result{err: errors.New("state parameter mismatch — possible CSRF, aborting")})
 				return
+			}
+			// RFC 9207 mix-up defense. An authorization server that supports it
+			// names itself in the callback; if that is not the server we sent
+			// the user to, the code in hand was issued by someone else and
+			// redeeming it would hand our client credentials to them. So the
+			// check sits here, before the code is sent back for redemption —
+			// after the fact it defends nothing.
+			//
+			// Compared byte-exactly: an issuer identifier is an opaque string,
+			// and normalising it (trailing slash, case, percent-encoding)
+			// would be inventing equivalences the spec does not grant.
+			if gotIss := q.Get("iss"); gotIss != "" {
+				switch {
+				case issuer == "":
+					// Fail open, deliberately: no existing source records an
+					// issuer, and refusing here would break every flow that
+					// works today to enforce something the operator has not
+					// configured. Say so loudly instead.
+					fmt.Fprintf(os.Stderr,
+						"warning: the authorization server identified itself as %q, but this credential source records no issuer.\n"+
+							"         Set issuer on the source to have Warden verify it.\n", gotIss)
+				case gotIss != issuer:
+					writeCallbackPage(w, false, "issuer mismatch")
+					send(result{err: fmt.Errorf(
+						"issuer mismatch — the callback came from %q but this source expects %q; aborting before the code is redeemed",
+						gotIss, issuer)})
+					return
+				}
 			}
 			if gotCode == "" {
 				writeCallbackPage(w, false, "missing authorization code")

--- a/cmd/cred/spec/connect_test.go
+++ b/cmd/cred/spec/connect_test.go
@@ -78,7 +78,7 @@ func TestAwaitCallback_Success(t *testing.T) {
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	fireCallback(t, port, "code=the-code&state=the-state")
-	code, err := awaitCallback(context.Background(), ln, "the-state", 5*time.Second)
+	code, err := awaitCallback(context.Background(), ln, "the-state", "", 5*time.Second)
 	require.NoError(t, err)
 	assert.Equal(t, "the-code", code)
 }
@@ -89,7 +89,7 @@ func TestAwaitCallback_StateMismatch(t *testing.T) {
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	fireCallback(t, port, "code=the-code&state=attacker-state")
-	_, err = awaitCallback(context.Background(), ln, "the-state", 5*time.Second)
+	_, err = awaitCallback(context.Background(), ln, "the-state", "", 5*time.Second)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "state parameter mismatch")
 }
@@ -100,7 +100,7 @@ func TestAwaitCallback_ProviderError(t *testing.T) {
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	fireCallback(t, port, "error=access_denied&error_description=user+declined")
-	_, err = awaitCallback(context.Background(), ln, "the-state", 5*time.Second)
+	_, err = awaitCallback(context.Background(), ln, "the-state", "", 5*time.Second)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "access_denied")
 }
@@ -113,7 +113,7 @@ func TestAwaitCallback_EmptyCode(t *testing.T) {
 	port := ln.Addr().(*net.TCPAddr).Port
 
 	fireCallback(t, port, "state=the-state&code=")
-	_, err = awaitCallback(context.Background(), ln, "the-state", 5*time.Second)
+	_, err = awaitCallback(context.Background(), ln, "the-state", "", 5*time.Second)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no authorization code")
 }
@@ -123,7 +123,7 @@ func TestAwaitCallback_Timeout(t *testing.T) {
 	require.NoError(t, err)
 	defer ln.Close()
 
-	_, err = awaitCallback(context.Background(), ln, "the-state", 150*time.Millisecond)
+	_, err = awaitCallback(context.Background(), ln, "the-state", "", 150*time.Millisecond)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "timed out")
 }
@@ -138,7 +138,7 @@ func TestAwaitCallback_ContextCanceled(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 		cancel()
 	}()
-	_, err = awaitCallback(ctx, ln, "the-state", 5*time.Second)
+	_, err = awaitCallback(ctx, ln, "the-state", "", 5*time.Second)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "canceled")
 }
@@ -161,7 +161,7 @@ func TestAwaitCallback_IgnoresNonCallbackRequest(t *testing.T) {
 		}
 	}()
 
-	code, err := awaitCallback(context.Background(), ln, "the-state", 5*time.Second)
+	code, err := awaitCallback(context.Background(), ln, "the-state", "", 5*time.Second)
 	require.NoError(t, err)
 	assert.Equal(t, "real", code)
 }
@@ -242,4 +242,101 @@ func TestRunConnect_PortConflict(t *testing.T) {
 	err := runConnect(cmd, []string{"gh"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "conflicts with the spec's pinned redirect_uri port 8765")
+}
+
+// =============================================================================
+// RFC 9207 issuer validation
+// =============================================================================
+
+// The mix-up defense: a code that came from an authorization server other
+// than the one we sent the user to was issued to someone else's client, and
+// redeeming it would hand our credentials to them. The abort has to happen
+// here, before the code goes back for redemption — afterwards it defends
+// nothing.
+func TestAwaitCallback_IssuerMismatchAbortsBeforeRedemption(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	fireCallback(t, port, "code=the-code&state=the-state&iss=https%3A%2F%2Fattacker.example")
+	code, err := awaitCallback(context.Background(), ln, "the-state", "https://github.com/login/oauth", 5*time.Second)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "issuer mismatch")
+	assert.Empty(t, code, "the code must not be returned for redemption")
+}
+
+func TestAwaitCallback_IssuerMatchProceeds(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	fireCallback(t, port, "code=the-code&state=the-state&iss=https%3A%2F%2Fgithub.com%2Flogin%2Foauth")
+	code, err := awaitCallback(context.Background(), ln, "the-state", "https://github.com/login/oauth", 5*time.Second)
+
+	require.NoError(t, err)
+	assert.Equal(t, "the-code", code)
+}
+
+// Byte-exact: an issuer identifier is an opaque string, and normalising a
+// trailing slash or a case difference would be inventing an equivalence the
+// spec does not grant.
+func TestAwaitCallback_IssuerComparisonIsExact(t *testing.T) {
+	for _, iss := range []string{
+		"https%3A%2F%2Fgithub.com%2Flogin%2Foauth%2F", // trailing slash
+		"https%3A%2F%2FGitHub.com%2Flogin%2Foauth",    // case
+	} {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		port := ln.Addr().(*net.TCPAddr).Port
+
+		fireCallback(t, port, "code=the-code&state=the-state&iss="+iss)
+		_, err = awaitCallback(context.Background(), ln, "the-state", "https://github.com/login/oauth", 5*time.Second)
+
+		require.Error(t, err, "iss=%s should not be treated as equivalent", iss)
+		assert.Contains(t, err.Error(), "issuer mismatch")
+	}
+}
+
+// Fail open when the source records no issuer: no existing source does, and
+// refusing would break every flow that works today to enforce something the
+// operator has not configured. The flow proceeds and the operator is told.
+func TestAwaitCallback_NoRecordedIssuerProceeds(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	fireCallback(t, port, "code=the-code&state=the-state&iss=https%3A%2F%2Fanything.example")
+	code, err := awaitCallback(context.Background(), ln, "the-state", "", 5*time.Second)
+
+	require.NoError(t, err)
+	assert.Equal(t, "the-code", code)
+}
+
+// RFC 9207 only binds when the server sends iss. A server that does not
+// support it must keep working against a source that records an issuer.
+func TestAwaitCallback_AbsentIssParamProceeds(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	fireCallback(t, port, "code=the-code&state=the-state")
+	code, err := awaitCallback(context.Background(), ln, "the-state", "https://github.com/login/oauth", 5*time.Second)
+
+	require.NoError(t, err)
+	assert.Equal(t, "the-code", code)
+}
+
+// The state check runs first: a callback that fails both must be reported as
+// the CSRF it is.
+func TestAwaitCallback_StateCheckPrecedesIssuerCheck(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	fireCallback(t, port, "code=the-code&state=attacker-state&iss=https%3A%2F%2Fattacker.example")
+	_, err = awaitCallback(context.Background(), ln, "the-state", "https://github.com/login/oauth", 5*time.Second)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "state parameter mismatch")
 }

--- a/core/sys_credentials.go
+++ b/core/sys_credentials.go
@@ -766,9 +766,13 @@ func (b *SystemBackend) handleCredentialSpecAuthorize(ctx context.Context, req *
 		return logical.ErrorResponse(logical.ErrBadRequest(err.Error())), nil
 	}
 
+	// The issuer travels with the authorize URL because the check it enables
+	// belongs at the callback, in the CLI, before the code comes back here to
+	// be redeemed. Empty when the source records none.
 	return b.respondSuccess(map[string]any{
 		"name":          name,
 		"authorize_url": authorizeURL,
+		"issuer":        authorizer.AuthorizationIssuer(),
 	}), nil
 }
 

--- a/credential/drivers/oauth2_driver.go
+++ b/credential/drivers/oauth2_driver.go
@@ -113,6 +113,16 @@ func (f *OAuth2DriverFactory) ValidateConfig(config map[string]string) error {
 			Describe("OAuth2 authorization endpoint (HTTPS) — required for authorization_code specs").
 			Example("https://github.com/login/oauth/authorize"),
 
+		credential.StringField("issuer").
+			Custom(func(v string) error {
+				if v == "" {
+					return nil
+				}
+				return validateOAuth2SafeURL(v, "issuer", credential.GetBool(config, "tls_skip_verify", false))
+			}).
+			Describe("Authorization server issuer identifier (HTTPS). When set, a connect callback carrying RFC 9207 'iss' must match it exactly before the authorization code is redeemed — the mix-up defense. Never guessed from auth_url: issuers routinely differ from the authorization endpoint's origin (realm and tenant paths), and a wrong guess would refuse legitimate flows").
+			Example("https://github.com/login/oauth"),
+
 		credential.StringField("introspection_url").
 			Custom(func(v string) error {
 				if v == "" {
@@ -616,6 +626,17 @@ func (d *OAuth2Driver) ExchangeAuthorizationCode(ctx context.Context, spec *cred
 		return nil, fmt.Errorf("%s OAuth2 authorization-code exchange returned neither refresh_token nor access_token", name)
 	}
 	return sealed, nil
+}
+
+// AuthorizationIssuer returns the source's recorded issuer identifier, empty
+// when the operator recorded none.
+//
+// Source-only, like auth_url and token_url: they describe the authorization
+// server, not the identity being authorized, and splitting the issuer from
+// its siblings would leave one half of a pair configurable in a different
+// place from the other.
+func (d *OAuth2Driver) AuthorizationIssuer() string {
+	return credential.GetString(d.credSource.Config, "issuer", "")
 }
 
 // BuildAuthorizeURL assembles the provider authorize URL. Scopes are read as

--- a/credential/source_driver.go
+++ b/credential/source_driver.go
@@ -276,6 +276,13 @@ type OAuth2Authorizer interface {
 	// returns the spec-config keys to seal (notably "refresh_token", or a static
 	// "access_token" for providers that do not issue refresh tokens).
 	ExchangeAuthorizationCode(ctx context.Context, spec *CredSpec, code, redirectURI, codeVerifier string) (map[string]string, error)
+
+	// AuthorizationIssuer returns the issuer identifier the caller must find in
+	// an RFC 9207 "iss" callback parameter, or "" when the source records
+	// none. It travels with the authorize URL because the check it enables
+	// happens in the CLI, at the callback, before the code is sent back for
+	// redemption — which is the whole of the mix-up defense.
+	AuthorizationIssuer() string
 }
 
 // ExchangeMinter is an optional interface for drivers that consume caller-derived


### PR DESCRIPTION
**Stack 6/8** — MCP 2026-07-28 alignment. Base: `feat/mcp-modern-strictness` (#594).

Independent of the MCP work; grouped with it because the same spec revision pulls in the OAuth guidance.

## The problem

`awaitCallback` validated `state` in constant time but never read `iss`, which the spec makes a client MUST validate **before redeeming the code**.

Without it, a code issued by an authorization server other than the one the user was sent to is redeemed anyway — with Warden's client credentials, at the attacker's server. That is the mix-up attack RFC 9207 exists to stop.

## The change

The check sits in the callback handler, **after** the state comparison and **before** the code is returned for redemption. That ordering is the whole defense: afterwards there is nothing left to protect.

Comparison is byte-exact. An issuer identifier is an opaque string, so normalising a trailing slash, a case difference or a percent-encoding would be inventing equivalences the spec does not grant — and each one is a way for a near-miss issuer to pass.

## Where the issuer lives

Recorded on the **credential source**, beside `auth_url` and `token_url`. Those describe the authorization server rather than the identity being authorized; putting the issuer on the spec would split one half of a pair from the other.

It reaches the CLI on the authorize response, because the check happens at the callback while the server only sees the code afterwards.

It is **never guessed from `auth_url`**: issuers routinely differ from the authorization endpoint's origin — realm and tenant paths — and a wrong guess would refuse legitimate flows.

## Fail-open when no issuer is recorded

Deliberate, and the decision you took. No source records one yet, so enforcing would break every flow that works today over something the operator has not configured. A callback that names an issuer Warden cannot check warns to stderr and proceeds, naming the server that identified itself so the operator can record it. A server that sends no `iss` at all is unaffected either way — RFC 9207 binds only when the parameter is present.

## Usage

```bash
warden cred source create github-oauth-source -json '{
  "type": "oauth2",
  "config": {
    "token_url": "https://github.com/login/oauth/access_token",
    "auth_url":  "https://github.com/login/oauth/authorize",
    "issuer":    "https://github.com/login/oauth"
  }
}'

warden cred spec connect gh-oauth
```

## Verification

`go test ./cmd/cred/spec/ -run Connect` — mismatch aborts and returns no code, match proceeds, exact comparison rejects a trailing slash and a case difference, no recorded issuer proceeds, absent `iss` proceeds, and the state check still precedes the issuer check so a callback failing both is reported as the CSRF it is. Full suite clean.
