### PR TITLE
docs(mcp): correct the prose the 2026-07-28 work made stale

### DIFF
--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -351,13 +351,18 @@ func mcpDescriptorPopulated(req *logical.Request) bool {
 //
 //   - Non-nil, empty descriptor (Calls nil, ParseErr nil) — the
 //     backend is MCP-aware but ShouldEnforceMCPPolicy declined for
-//     this request (typically a non-POST verb, or a non-JSON
-//     Content-Type). A contract is body-authoritative; a verb with no
-//     body cannot be governed by method/tool allow-lists, so we
-//     return nil to skip evaluation and let the cap-level check
-//     decide. This is what makes MCP Streamable HTTP's GET
-//     (notification SSE stream) and DELETE (session terminate) work
-//     on the same URL that POST gates.
+//     this request (a non-POST verb, or a non-JSON Content-Type). A
+//     contract is body-authoritative; a verb with no body cannot be
+//     governed by method/tool allow-lists, so we return nil to skip
+//     evaluation and let the cap-level check decide. This is what
+//     makes Streamable HTTP's GET (notification stream) and DELETE
+//     (session terminate) work on the same URL that POST gates.
+//
+//     Both verbs are legacy-era. 2026-07-28 removed the GET endpoint
+//     in favour of subscriptions/listen, which is a POST and is
+//     therefore gated like any other call, and left no session for
+//     DELETE to terminate; a modern server answers both 405. The
+//     branch remains for the upstreams that still serve them.
 //
 //   - descriptor.ParseErr non-nil — strict JSON-RPC parse failed.
 //     Deny with the typed rule_type (malformed_jsonrpc, duplicate_key,

--- a/core/request_handler_mcp.go
+++ b/core/request_handler_mcp.go
@@ -22,18 +22,24 @@ import (
 // tri-state contract:
 //
 //  1. Nil — backend does not implement MCPPolicyEnforced at all. If an
-//     mcp{} block is bound to such a path that's an operator misconfig
+//     MCP contract is bound to such a path that's an operator misconfig
 //     and decideMCP fails closed with missing_body.
 //
 //  2. Non-nil, empty (Calls nil, ParseErr nil) — backend implements
 //     the interface but ShouldEnforceMCPPolicy returned enforce=false
-//     for THIS request (typically a non-POST verb on a multi-method
-//     MCP endpoint, or a non-JSON Content-Type). mcp{} is body-
-//     authoritative and cannot meaningfully gate a body-less request,
-//     so decideMCP skips evaluation and lets the cap-level policy
-//     decide. This is the path that lets MCP Streamable HTTP's GET
-//     (notification SSE stream) and DELETE (session terminate) verbs
-//     share the same URL with the POST that carries JSON-RPC.
+//     for THIS request (a non-POST verb on a multi-method MCP endpoint,
+//     or a non-JSON Content-Type). A contract is body-authoritative and
+//     cannot meaningfully gate a body-less request, so decideMCP skips
+//     evaluation and lets the cap-level policy decide.
+//
+//     This is what lets Streamable HTTP's GET (notification stream) and
+//     DELETE (session terminate) share a URL with the POST that carries
+//     JSON-RPC. Both verbs are legacy-era: 2026-07-28 removed the GET
+//     endpoint in favour of subscriptions/listen and has no session to
+//     terminate, so a modern server answers them 405. The sentinel stays
+//     because Warden still fronts upstreams that serve them — and the
+//     GET, being the legacy notification channel, takes listen_timeout
+//     rather than the unary one.
 //
 //  3. Non-nil with Calls or ParseErr populated — backend opted in and
 //     extraction either succeeded (Calls) or failed in a typed way

--- a/core/sys_mcp.go
+++ b/core/sys_mcp.go
@@ -118,8 +118,12 @@ func mcpRequestFromContext(ctx context.Context) *http.Request {
 // /v1/sys/mcp. It runs the official SDK's Streamable HTTP transport in
 // stateless JSON mode: each POST is a self-contained request/response with no
 // Mcp-Session-Id affinity, so a standby node can forward it to the active node
-// without session-stickiness concerns. The SDK still performs the full
-// initialize + protocol-version negotiation on every call.
+// without session-stickiness concerns.
+//
+// A modern client needs no handshake to get there — under 2026-07-28 the
+// per-request _meta carries what initialize used to negotiate — while a legacy
+// client's initialize is still answered, with an ephemeral session, so both
+// eras reach the same two tools.
 func (c *Core) MCPServerHandler() http.Handler {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "warden",

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/hashicorp/vault/api v1.23.0
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mitchellh/pointerstructure v1.2.1
-	github.com/modelcontextprotocol/go-sdk v1.7.0 // TODO: bump to stable v1.7.0 once cut (~end of July 2026); transport is identical, one-line change.
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/oklog/ulid v1.3.1
 	github.com/openbao/go-kms-wrapping/v2 v2.8.0
 	github.com/openbao/go-kms-wrapping/wrappers/alicloudkms/v2 v2.3.0

--- a/provider/mcp/provider.go
+++ b/provider/mcp/provider.go
@@ -178,6 +178,12 @@ canonical server URL. JSON-RPC bodies, the Accept header, and the
 Mcp-Session-Id header pass through unchanged. Streamable HTTP responses
 (JSON or SSE) are streamed without buffering.
 
+Mcp-Session-Id is legacy-era and is forwarded for the upstreams that still
+use it; a server speaking 2026-07-28 holds no session and ignores it. The
+transport headers that revision introduced — MCP-Protocol-Version, Mcp-Method
+and Mcp-Name — are validated against the parsed body when a client sends
+them, and required of a client that announces the revision.
+
 The role can be provided via the X-Warden-Role header, or embedded in
 the URL path:
   /mcp/role/{role}/gateway/
@@ -213,9 +219,28 @@ against the parsed body, never against client-supplied request headers. The
 parser rejects malformed bodies, duplicate keys at any depth, empty batches, and
 oversized payloads; on any structural failure the request denies with a specific
 rule_type (malformed_jsonrpc, duplicate_key, oversized_body, batch_empty,
-missing_body, malformed_params). Denied requests return HTTP 403 with an RFC
-6750 WWW-Authenticate header and a small JSON body the agent SDK surfaces as a
-structured tool-call failure.
+missing_body, malformed_params, batch_unsupported, header_mismatch). Denied
+requests return HTTP 403 with an RFC 6750 WWW-Authenticate header and a small
+JSON body the agent SDK surfaces as a structured tool-call failure.
+
+Two refusals are protocol faults rather than authorization decisions and are
+answered differently. A request whose transport headers contradict its body
+gets HTTP 400 and a JSON-RPC -32020 with the request id echoed, so a client
+that speaks both eras corrects its headers instead of reading a 403 as "not
+permitted" and downgrading to initialize. A batch from a client announcing
+2026-07-28 is refused as batch_unsupported — batching left the spec in
+2025-06-18 — while a legacy client's batch is still accepted and every element
+policy-checked.
+
+The methods a contract governs span both eras. server/discover joins
+initialize, ping and notifications/* as exempt from the method allow-list:
+a modern client sends it as the first request of every connection, and it
+discloses protocol versions, coarse capabilities and serverInfo, never tool or
+resource names. Naming it in denied_methods still blocks it. Subscribing to a
+resource's updates answers to the resources family exactly as reading it does,
+whether the caller subscribes with the modern subscriptions/listen or the
+legacy resources/subscribe — the content never arrives either way, but the
+resource's existence and the timing of every change would.
 
 Body parsing runs only for POST requests carrying Content-Type
 application/json. Other request shapes do not produce a parsed body descriptor:
@@ -225,6 +250,25 @@ stanzas to paths they expect to carry JSON-RPC POSTs.
 
 Paths with no MCP stanza in scope skip the strict parser entirely — no body
 buffering or parsing is performed on them.
+
+Deadlines:
+Two knobs, chosen by what the request is rather than by how it responds.
+subscriptions/listen — and the legacy SSE GET it replaced — take
+listen_timeout, because a subscription is open-ended by design. Everything
+else takes timeout.
+
+The boundary surprises people, so state it plainly: a long-running tool call
+that streams progress notifications is still capped by timeout, not by
+listen_timeout. Raising listen_timeout will not save it. That is the intended
+split — a unary call should be bounded more tightly than an open-ended
+subscription — and the alternative is worse: raising timeout far enough to
+hold a stream open would hand every hung call on the mount the same ceiling,
+each one holding a goroutine and two connections for the duration.
+
+A severed stream is survivable. The spec treats an abrupt drop as a reconnect
+trigger, and a modern server holds no cross-connection subscription state, so
+the client reconnects with a fresh subscription. Notifications that would have
+arrived in the gap are lost.
 
 Configuration:
 - mcp_url: MCP server base URL (required; no default)

--- a/provider/mcp/skill.md
+++ b/provider/mcp/skill.md
@@ -79,6 +79,22 @@ JWT expired (typical TTL 5–60 min) — refresh it in the client config.
 - **Streamable HTTP / SSE flows through transparently.** The server's framing
   comes back unchanged, and the `Mcp-Session-Id` response header round-trips
   automatically so follow-up requests reach the same upstream session.
+  `Mcp-Session-Id` is legacy-era; an upstream speaking 2026-07-28 holds no
+  session and ignores it.
+- **Both protocol eras are served.** `server/discover` needs no allow-list
+  entry — it is exempt like `initialize`, `ping` and `notifications/*` — so a
+  modern client's opening request works under any contract, though an operator
+  can still block it by name. If you send the 2026-07-28 transport headers
+  (`MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`), they must match the body
+  you send: a contradiction is refused with HTTP 400 and a JSON-RPC `-32020`,
+  which means fix the headers, not the policy. Announce that revision and your
+  JSON-RPC batches are refused too — batching left the spec in 2025-06-18.
+- **Subscribing to a resource needs the same grant as reading it.** A
+  `subscriptions/listen` naming resource URIs — and the legacy
+  `resources/subscribe` — answer to the `resources` allow-list, because a
+  subscription leaks a resource's existence and the timing of every change
+  even though its content never arrives. A listen that only asks for
+  list-changed events names no resource and needs no such grant.
 - **Two mount-wide deadlines, picked by method.** `timeout` caps a single call —
   a tool call, a listing, a resource read (default 60 seconds).
   `listen_timeout` caps a `subscriptions/listen` stream (default 10 minutes),

--- a/provider/mcp_aws/provider.go
+++ b/provider/mcp_aws/provider.go
@@ -407,6 +407,18 @@ JSON-RPC bodies, the Accept header, and the Mcp-Session-Id header pass
 through unchanged. Streamable HTTP responses (JSON or SSE) stream
 without buffering.
 
+Mcp-Session-Id is legacy-era and is forwarded for the upstreams that still
+use it; a server speaking 2026-07-28 holds no session and ignores it.
+
+Deadlines are chosen by what the request is, not by how it responds.
+subscriptions/listen — and the legacy SSE GET it replaced — take
+listen_timeout, because a subscription is open-ended by design; everything
+else takes timeout. A long-running tool call that streams progress is still
+capped by timeout, and raising listen_timeout will not save it: the
+alternative, raising timeout far enough to hold a stream open, would hand
+every hung call on the mount the same ceiling. A severed stream is a
+reconnect trigger, losing only the notifications in the gap.
+
 Configuration:
 - mcp_aws_url:    MCP endpoint base URL (default: https://aws-mcp.us-east-1.api.aws/mcp)
 - region:         SigV4 signing region. Optional when the URL host yields one

--- a/provider/mcp_aws/skill.md
+++ b/provider/mcp_aws/skill.md
@@ -87,7 +87,18 @@ convention. A `401` means the JWT expired (typical TTL 5–60 min) — refresh i
   back). Read the `error_description` to tell them apart. Structural problems
   (malformed JSON-RPC, duplicate keys, oversized body) also fail closed.
 - **Streamable HTTP / SSE flows through transparently.** The `Mcp-Session-Id`
-  response header round-trips so follow-up requests reach the same session.
+  response header round-trips so follow-up requests reach the same session. It
+  is legacy-era; an upstream speaking 2026-07-28 holds no session and ignores
+  it.
+- **Both protocol eras are served.** `server/discover` needs no allow-list
+  entry — it is exempt like `initialize`, `ping` and `notifications/*` — though
+  an operator can still block it by name. If you send the 2026-07-28 transport
+  headers (`MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`), they must match
+  the body: a contradiction is refused with HTTP 400 and a JSON-RPC `-32020`,
+  which means fix the headers, not the policy. Announce that revision and your
+  JSON-RPC batches are refused too. Subscribing to a resource — modern
+  `subscriptions/listen` or legacy `resources/subscribe` — answers to the
+  `resources` allow-list, the same grant that governs reading it.
 - **Two mount-wide deadlines, picked by method.** `timeout` caps a single call
   (default 60 seconds); `listen_timeout` caps a `subscriptions/listen` stream
   (default 10 minutes), and only that method. Ask the operator to raise


### PR DESCRIPTION
**Stack 8/8** — MCP 2026-07-28 alignment. Base: `test/mcp-dual-era-e2e` (#596).

No behaviour change. Each of these described something that stopped being true while the series landed, and a comment that confidently states the opposite of the code is worse than none.

## What was wrong

**`core/sys_mcp.go`** claimed the SDK "still performs the full initialize + protocol-version negotiation on every call". It does not: a modern client needs no handshake, since the per-request `_meta` carries what `initialize` used to negotiate. The legacy handshake is still answered, so the comment now says both.

**The tri-state descriptor contract**, in both places it is written down, called GET and DELETE simply "non-POST verbs". They are **legacy-era verbs specifically**: 2026-07-28 removed the GET endpoint in favour of `subscriptions/listen` — which is a POST, and therefore gated like any other call — and left no session for DELETE to terminate, so a modern server answers both 405. The empty sentinel stays for the upstreams that still serve them, and the GET, being the legacy notification channel, takes `listen_timeout` rather than the unary one. Both comments also still said "`mcp{}` block", which has not been the grammar since MCP rules moved into their own document type.

**The provider help texts** gained the deadline boundary that will otherwise surprise whoever raises `listen_timeout` and watches their slow tool die anyway: a long-running tool call streaming progress is capped by `timeout`, not by `listen_timeout`, and the alternative — raising `timeout` far enough to hold a stream open — would hand every hung call on the mount the same ceiling. They also record that a severed stream is a reconnect trigger losing only the notifications in the gap, that `Mcp-Session-Id` is legacy-era and ignored by a modern upstream, and that the `rule_type` vocabulary now includes `batch_unsupported` and `header_mismatch`.

**Both seeded skills** gained the agent-facing half: `server/discover` needs no allow-list entry; transport headers must match the body or the call is refused with a `-32020` that means *fix the headers, not the policy*; announcing 2026-07-28 refuses batches; subscribing to a resource needs the same grant as reading it.

**`go.mod`** drops a TODO to bump to a version it already pins.

No CHANGELOG entries, per convention. **`site/` is deliberately untouched.**

## Release-note action — verified, not assumed

An updated provider skill **does not reach an existing cluster**. `SeedProviderSkill` delegates to `seedOne`, which leaves an existing record alone, so any cluster that has ever mounted an MCP provider keeps the stored copy indefinitely. Operators pick up the new text with `PUT /sys/skills/{name}`.

## Still outstanding for release prep

Deliberately not in this PR:

- **42 occurrences of `mcp { }` across 9 site docs** document a policy grammar that no longer parses — `core/policy.go:399` rejects it with a pointer to `sys/policies/mcp/<name>`. This is the *previous* series' debt (#586), in the same unreleased window, and it is actively broken guidance.
- Six site docs enumerate the exempt lifecycle set without `server/discover`.
- MCP config samples across the site still show `"timeout": "10m"`, which after #589 means every hung call on the mount gets a ten-minute ceiling.
- No provider's `Configuration:` help block lists `user_auth_path` / `user_auth_role` — a pre-existing repo-wide gap, not specific to MCP.
