### PR TITLE
feat(cred): let an aws source override the STS and Secrets Manager endpoints

### DIFF
--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -58,10 +58,14 @@ type AWSDriver struct {
 	// so a keyless federation (auth_method=oidc_federation) source needs no IAM keys.
 	anonSTSClient *sts.Client
 
-	// smBaseEndpoint, when non-empty, overrides the Secrets Manager endpoint for
-	// clients built from freshly federated credentials. Test-only: production leaves
-	// it empty so the SDK resolves the real regional endpoint.
+	// smBaseEndpoint and stsEndpoint, when non-empty, override where the Secrets
+	// Manager and STS calls are sent. Resolved once in Create from the source's
+	// secretsmanager_endpoint / sts_endpoint; empty leaves the SDK to resolve the
+	// real regional endpoint. Every client of either service is built through
+	// smOptions/stsOptions so an override applies to all of them, including the
+	// ones used to validate the source at write time.
 	smBaseEndpoint string
+	stsEndpoint    string
 }
 
 // awsAuthMethodStatic and awsAuthMethodOIDCFederation select how the source
@@ -126,6 +130,14 @@ func (f *AWSDriverFactory) ValidateConfig(config map[string]string) error {
 		credential.StringField("audience").
 			Describe("Audience minted into a warden_identity assertion for this source (oidc_federation only; default sts.amazonaws.com)").
 			Example("sts.amazonaws.com"),
+
+		credential.StringField("sts_endpoint").
+			Describe("Override where STS calls are sent, including the credential probe run when this source is written (default: the SDK's regional endpoint). Does not apply to the IAM, Redshift or RDS clients").
+			Example("https://sts.us-east-1.amazonaws.com"),
+
+		credential.StringField("secretsmanager_endpoint").
+			Describe("Override where Secrets Manager calls are sent (default: the SDK's regional endpoint)").
+			Example("https://secretsmanager.us-east-1.amazonaws.com"),
 	); err != nil {
 		return err
 	}
@@ -209,15 +221,19 @@ func (f *AWSDriverFactory) Create(config map[string]string, log *logger.GatedLog
 			Type:   credential.SourceTypeAWS,
 			Config: config,
 		},
-		logger:    log.WithSubsystem(credential.SourceTypeAWS),
-		baseCreds: baseCreds,
-		region:    region,
-		// AssumeRoleWithWebIdentity is unsigned: anonymous credentials skip SigV4.
-		anonSTSClient: sts.NewFromConfig(aws.Config{
-			Region:      region,
-			Credentials: aws.AnonymousCredentials{},
-		}),
+		logger:         log.WithSubsystem(credential.SourceTypeAWS),
+		baseCreds:      baseCreds,
+		region:         region,
+		stsEndpoint:    credential.GetString(config, "sts_endpoint", ""),
+		smBaseEndpoint: credential.GetString(config, "secretsmanager_endpoint", ""),
 	}
+
+	// AssumeRoleWithWebIdentity is unsigned: anonymous credentials skip SigV4.
+	// Built after the literal so it picks up the resolved endpoint override.
+	driver.anonSTSClient = sts.NewFromConfig(aws.Config{
+		Region:      region,
+		Credentials: aws.AnonymousCredentials{},
+	}, driver.stsOptions())
 
 	// A federation source holds no IAM keys: skip the eager credential probe. All
 	// authentication happens per-request from the caller's identity assertion.
@@ -253,7 +269,7 @@ func (d *AWSDriver) authenticateLocked(ctx context.Context) error {
 			baseSTS := sts.NewFromConfig(aws.Config{
 				Region:      d.region,
 				Credentials: d.baseCreds,
-			})
+			}, d.stsOptions())
 			if _, err := baseSTS.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}); err != nil {
 				return fmt.Errorf("invalid AWS credentials: %w", err)
 			}
@@ -276,7 +292,7 @@ func (d *AWSDriver) authenticateLocked(ctx context.Context) error {
 	baseSTS := sts.NewFromConfig(aws.Config{
 		Region:      d.region,
 		Credentials: d.baseCreds,
-	})
+	}, d.stsOptions())
 
 	input := &sts.AssumeRoleInput{
 		RoleArn:         &assumeRoleArn,
@@ -316,14 +332,36 @@ func (d *AWSDriver) authenticateLocked(ctx context.Context) error {
 	return nil
 }
 
-// buildClients creates AWS service clients from the given credentials provider
+// stsOptions applies the source's STS endpoint override, if it set one. Every STS
+// client goes through here: an override that reached only the minting clients would
+// leave the source validated against the real service and minted against another.
+func (d *AWSDriver) stsOptions() func(*sts.Options) {
+	return func(o *sts.Options) {
+		if d.stsEndpoint != "" {
+			o.BaseEndpoint = aws.String(d.stsEndpoint)
+		}
+	}
+}
+
+// smOptions applies the source's Secrets Manager endpoint override, if it set one.
+func (d *AWSDriver) smOptions() func(*secretsmanager.Options) {
+	return func(o *secretsmanager.Options) {
+		if d.smBaseEndpoint != "" {
+			o.BaseEndpoint = aws.String(d.smBaseEndpoint)
+		}
+	}
+}
+
+// buildClients creates AWS service clients from the given credentials provider.
+// The IAM, Redshift and Redshift Serverless clients keep their resolved endpoints —
+// the endpoint overrides cover only the mint and source-validation paths.
 func (d *AWSDriver) buildClients(creds aws.CredentialsProvider) {
 	cfg := aws.Config{
 		Region:      d.region,
 		Credentials: creds,
 	}
-	d.stsClient = sts.NewFromConfig(cfg)
-	d.secretsManagerClient = secretsmanager.NewFromConfig(cfg)
+	d.stsClient = sts.NewFromConfig(cfg, d.stsOptions())
+	d.secretsManagerClient = secretsmanager.NewFromConfig(cfg, d.smOptions())
 	d.iamClient = iam.NewFromConfig(cfg)
 	d.redshiftClient = redshift.NewFromConfig(cfg)
 	d.redshiftServerlessClient = redshiftserverless.NewFromConfig(cfg)
@@ -646,16 +684,10 @@ func (d *AWSDriver) credsFromWebIdentity(spec *credential.CredSpec, result *sts.
 }
 
 // newSecretsManagerClient builds a Secrets Manager client bound to the given credentials
-// (e.g. freshly federated temporary credentials). smBaseEndpoint, when set, overrides the
-// endpoint for tests.
+// (e.g. freshly federated temporary credentials), honouring the source's endpoint
+// override when it set one.
 func (d *AWSDriver) newSecretsManagerClient(creds aws.CredentialsProvider) *secretsmanager.Client {
-	cfg := aws.Config{Region: d.region, Credentials: creds}
-	if d.smBaseEndpoint != "" {
-		return secretsmanager.NewFromConfig(cfg, func(o *secretsmanager.Options) {
-			o.BaseEndpoint = aws.String(d.smBaseEndpoint)
-		})
-	}
-	return secretsmanager.NewFromConfig(cfg)
+	return secretsmanager.NewFromConfig(aws.Config{Region: d.region, Credentials: creds}, d.smOptions())
 }
 
 // mintViaSecretsManager fetches a secret using the source's authenticated client (static

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -55,6 +56,27 @@ func TestAWSDriverFactory_ValidateConfig(t *testing.T) {
 				"external_id":       "ext-123",
 				"session_name":      "my-session",
 				"session_duration":  "2h",
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config with endpoint overrides",
+			config: map[string]string{
+				"access_key_id":           "AKIAIOSFODNN7EXAMPLE",
+				"secret_access_key":       "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				"region":                  "us-east-1",
+				"sts_endpoint":            "https://sts.us-east-1.amazonaws.com",
+				"secretsmanager_endpoint": "https://secretsmanager.us-east-1.amazonaws.com",
+			},
+			wantErr: false,
+		},
+		{
+			name: "endpoint overrides on a federation source",
+			config: map[string]string{
+				"auth_method":             "oidc_federation",
+				"region":                  "us-east-1",
+				"sts_endpoint":            "https://sts.us-east-1.amazonaws.com",
+				"secretsmanager_endpoint": "https://secretsmanager.us-east-1.amazonaws.com",
 			},
 			wantErr: false,
 		},
@@ -908,4 +930,193 @@ func TestAWSValidateConfig_AudienceOnlyFederation(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+}
+
+// =============================================================================
+// Endpoint overrides (sts_endpoint / secretsmanager_endpoint)
+// =============================================================================
+
+// stsStub answers the three STS actions the driver calls, recording each one. The
+// AssumeRole and AssumeRoleWithWebIdentity results share a credential shape, so one
+// handler covers every path that needs an STS endpoint.
+func stsStub(t *testing.T, actions *[]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		action := r.Form.Get("Action")
+		*actions = append(*actions, action)
+		w.Header().Set("Content-Type", "text/xml")
+
+		creds := `<Credentials>
+      <AccessKeyId>ASIAEXAMPLE</AccessKeyId>
+      <SecretAccessKey>secretexample</SecretAccessKey>
+      <SessionToken>tokenexample</SessionToken>
+      <Expiration>2035-01-01T00:00:00Z</Expiration>
+    </Credentials>
+    <AssumedRoleUser>
+      <Arn>arn:aws:sts::123456789012:assumed-role/App/warden</Arn>
+      <AssumedRoleId>AROAEXAMPLE:warden</AssumedRoleId>
+    </AssumedRoleUser>`
+
+		switch action {
+		case "GetCallerIdentity":
+			_, _ = w.Write([]byte(`<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetCallerIdentityResult>
+    <Arn>arn:aws:iam::123456789012:user/warden</Arn>
+    <UserId>AIDAEXAMPLE</UserId>
+    <Account>123456789012</Account>
+  </GetCallerIdentityResult>
+</GetCallerIdentityResponse>`))
+		case "AssumeRole":
+			_, _ = w.Write([]byte(`<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    ` + creds + `
+  </AssumeRoleResult>
+</AssumeRoleResponse>`))
+		case "AssumeRoleWithWebIdentity":
+			_, _ = w.Write([]byte(`<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>
+    ` + creds + `
+  </AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>`))
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+}
+
+// smStub answers GetSecretValue with the given JSON payload, recording the target
+// and the SigV4 scope of each call.
+func smStub(t *testing.T, payload string, target, authScope *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*target = r.Header.Get("X-Amz-Target")
+		*authScope = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+		body, _ := json.Marshal(map[string]string{"Name": "prod/app", "SecretString": payload})
+		_, _ = w.Write(body)
+	}))
+}
+
+// TestAWSDriver_EndpointOverride_StaticSourceValidation pins the case a partial
+// application of the override would break: creating a static source runs a
+// GetCallerIdentity probe, which must reach the configured endpoint rather than the
+// real service. Without sts_endpoint on the authenticateLocked client, Create here
+// would call AWS and fail.
+func TestAWSDriver_EndpointOverride_StaticSourceValidation(t *testing.T) {
+	var actions []string
+	srv := stsStub(t, &actions)
+	defer srv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
+		"secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		"region":            "us-east-1",
+		"sts_endpoint":      srv.URL,
+	}, log)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"GetCallerIdentity"}, actions)
+	assert.Equal(t, srv.URL, drv.(*AWSDriver).stsEndpoint)
+}
+
+// TestAWSDriver_EndpointOverride_AssumeRoleSource covers the second STS client on the
+// source-creation path: a source with assume_role_arn calls AssumeRole instead of the
+// base-credential probe.
+func TestAWSDriver_EndpointOverride_AssumeRoleSource(t *testing.T) {
+	var actions []string
+	srv := stsStub(t, &actions)
+	defer srv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	_, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
+		"secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		"region":            "us-east-1",
+		"assume_role_arn":   "arn:aws:iam::123456789012:role/WardenSourceRole",
+		"sts_endpoint":      srv.URL,
+	}, log)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"AssumeRole"}, actions)
+}
+
+// TestAWSDriver_EndpointOverride_SecretsManagerMint proves the override reaches the
+// Secrets Manager client built by buildClients, i.e. the static mint path.
+func TestAWSDriver_EndpointOverride_SecretsManagerMint(t *testing.T) {
+	var actions []string
+	stsSrv := stsStub(t, &actions)
+	defer stsSrv.Close()
+
+	var target, authScope string
+	smSrv := smStub(t, `{"api_key":"stored-key"}`, &target, &authScope)
+	defer smSrv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"access_key_id":           "AKIAIOSFODNN7EXAMPLE",
+		"secret_access_key":       "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		"region":                  "us-east-1",
+		"sts_endpoint":            stsSrv.URL,
+		"secretsmanager_endpoint": smSrv.URL,
+	}, log)
+	require.NoError(t, err)
+
+	rawData, _, _, _, err := drv.MintCredential(context.TODO(), &credential.CredSpec{
+		Name:   "sm",
+		Config: map[string]string{"mint_method": "secrets_manager", "secret_id": "prod/app"},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, target, "GetSecretValue")
+	assert.Equal(t, "stored-key", rawData["api_key"])
+}
+
+// TestAWSDriver_EndpointOverride_WebIdentity proves both overrides reach a keyless
+// source built through the factory: the anonymous STS client and the client bound to
+// the freshly federated credentials.
+func TestAWSDriver_EndpointOverride_WebIdentity(t *testing.T) {
+	var actions []string
+	stsSrv := stsStub(t, &actions)
+	defer stsSrv.Close()
+
+	var target, authScope string
+	smSrv := smStub(t, `{"api_key":"federated-key"}`, &target, &authScope)
+	defer smSrv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"auth_method":             "oidc_federation",
+		"region":                  "us-east-1",
+		"sts_endpoint":            stsSrv.URL,
+		"secretsmanager_endpoint": smSrv.URL,
+	}, log)
+	require.NoError(t, err)
+
+	spec := &credential.CredSpec{Name: "sm", Config: map[string]string{
+		"mint_method": "secrets_manager",
+		"secret_id":   "prod/app",
+		"role_arn":    "arn:aws:iam::123456789012:role/App",
+	}}
+	rawData, _, _, _, err := drv.(*AWSDriver).MintCredentialWithExchange(context.TODO(), spec, &credential.ExchangeInputs{
+		SubjectToken:     "eyJ.warden.assertion",
+		SubjectTokenType: credential.TokenTypeJWT,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"AssumeRoleWithWebIdentity"}, actions)
+	assert.Contains(t, target, "GetSecretValue")
+	assert.Contains(t, authScope, "ASIAEXAMPLE", "the fetch must be signed with the federated credentials")
+	assert.Equal(t, "federated-key", rawData["api_key"])
+}
+
+// TestAWSDriver_EndpointOverride_AbsentLeavesResolverAlone: a source that sets neither
+// key must leave both empty, so the SDK resolves the real regional endpoints.
+func TestAWSDriver_EndpointOverride_AbsentLeavesResolverAlone(t *testing.T) {
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"auth_method": "oidc_federation",
+		"region":      "us-east-1",
+	}, log)
+	require.NoError(t, err)
+	awsDrv := drv.(*AWSDriver)
+	assert.Empty(t, awsDrv.stsEndpoint)
+	assert.Empty(t, awsDrv.smBaseEndpoint)
 }


### PR DESCRIPTION
First of a nine-PR stack. Each is based on the one before it; review in order.

The driver's only endpoint override was an unexported test-only field, so nothing outside the package could point it anywhere. Every other cloud source that can be exercised against a local stub exposes its endpoint in source config — alicloud's `sts_endpoint`, IBM's `iam_endpoint`. This brings aws in line with two keys, `sts_endpoint` and `secretsmanager_endpoint`, both defaulting to the SDK's regional resolution.

Both apply at **every** construction site of their service, including the two STS clients used to validate a source at write time. An override that reached only the minting clients would leave a source verified against the real service and minted against another, which is worse than not having the key at all.

The IAM, Redshift and Redshift Serverless clients keep their resolved endpoints; rotation and the database mint methods are out of scope.

### Security note

Whoever can write aws source config can point `sts_endpoint` at a host they control and harvest the `WebIdentityToken` from every federated mint — under `agent_identity` that is the agent's real inbound IdP JWT, replayable at any relying party trusting that IdP for its remaining lifetime; under `warden_identity` a Warden assertion with `aud sts.amazonaws.com`. `secretsmanager_endpoint` additionally lets that operator forge the secret injected upstream. SigV4 does not leak `secret_access_key` itself.

This is the same exposure the existing alicloud `sts_endpoint`, IBM `iam_endpoint` and the kubernetes source's API-server URL already carry — the trust model is that source-config writers are trusted. Stating it explicitly rather than leaving it to the precedent.

### Why it exists

The last PR in this stack is a full-chain e2e for a new AWS mint method. Nothing in the e2e tree talks to AWS today, and it cannot without this.

### Verification

`go build`, `go vet`, `go test -race ./credential/drivers/` clean. Five new tests covering both keys across static creation, assume-role sources, static minting, and the keyless path.