### PR TITLE
fix(cred): give each aws mint one coherent client generation

### DIFF
--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
 	"time"
@@ -44,14 +45,22 @@ type AWSDriver struct {
 	elevatedExpiry time.Time
 	authMu         sync.Mutex
 
-	// AWS clients (rebuilt on auth changes)
-	stsClient                *sts.Client
-	secretsManagerClient     *secretsmanager.Client
-	iamClient                *iam.Client
-	redshiftClient           *redshift.Client
-	redshiftServerlessClient *redshiftserverless.Client
-	region                   string
-	baseCredsVerified        bool
+	// clients is the current generation of service clients, rebuilt on auth
+	// changes. Written and read only under authMu; a mint takes one reference and
+	// uses it without the lock. See awsClients.
+	clients *awsClients
+
+	region string
+
+	// baseCredsVerified records that the base key was proven usable by a live
+	// call. It says nothing about whether the current elevated session is fresh —
+	// only elevatedExpiry answers that, and conflating the two would let an
+	// assume-role source serve an expired session indefinitely.
+	baseCredsVerified bool
+
+	// httpClient bounds every request the SDK makes and carries any custom CA the
+	// source configured. Immutable after Create.
+	httpClient *http.Client
 
 	// anonSTSClient calls sts:AssumeRoleWithWebIdentity, which is unsigned — it
 	// takes no AWS credentials, only the web identity token. Built once in Create
@@ -81,6 +90,35 @@ const (
 // backing a single federated Secrets Manager read. They are used once and discarded, so
 // this is the AWS minimum for AssumeRoleWithWebIdentity (15m) rather than the secret's TTL.
 const federatedFetchSessionDuration = 15 * time.Minute
+
+// awsRequestTimeout bounds a single HTTP attempt to any AWS service. The SDK's
+// default retryer may make up to three, so the worst case is a small multiple of
+// this rather than the unbounded wait a missing timeout would allow.
+const awsRequestTimeout = 30 * time.Second
+
+// awsCreateProbeTimeout bounds the credential probe run when a source is written.
+// A var, not a const, so tests can shrink it — an endpoint that accepts the
+// connection and never answers would otherwise hold the write open for the full
+// request timeout.
+var awsCreateProbeTimeout = 30 * time.Second
+
+// awsClients is one coherent generation of service clients, together with the
+// config and base credentials they were built from. It is built under authMu and
+// then used without it: a mint takes the whole snapshot up front, so every call it
+// makes signs with a single generation even if a rotation commit swaps the driver
+// underneath it mid-request.
+//
+// cfg is safe to read unlocked because a source's config map is never written in
+// place — a rotation builds a fresh map and swaps the whole thing — so a snapshot
+// of the pointer is a snapshot of the contents.
+type awsClients struct {
+	cfg        map[string]string
+	baseCreds  aws.CredentialsProvider
+	sts        *sts.Client
+	sm         *secretsmanager.Client
+	redshift   *redshift.Client
+	redshiftSL *redshiftserverless.Client
+}
 
 // AWSDriverFactory creates AWSDriver instances
 type AWSDriverFactory struct{}
@@ -216,6 +254,11 @@ func (f *AWSDriverFactory) Create(config map[string]string, log *logger.GatedLog
 
 	baseCreds := credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, "")
 
+	httpClient, err := BuildHTTPClient(config, awsRequestTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build HTTP client: %w", err)
+	}
+
 	driver := &AWSDriver{
 		credSource: &credential.CredSource{
 			Type:   credential.SourceTypeAWS,
@@ -226,6 +269,7 @@ func (f *AWSDriverFactory) Create(config map[string]string, log *logger.GatedLog
 		region:         region,
 		stsEndpoint:    credential.GetString(config, "sts_endpoint", ""),
 		smBaseEndpoint: credential.GetString(config, "secretsmanager_endpoint", ""),
+		httpClient:     httpClient,
 	}
 
 	// AssumeRoleWithWebIdentity is unsigned: anonymous credentials skip SigV4.
@@ -233,6 +277,7 @@ func (f *AWSDriverFactory) Create(config map[string]string, log *logger.GatedLog
 	driver.anonSTSClient = sts.NewFromConfig(aws.Config{
 		Region:      region,
 		Credentials: aws.AnonymousCredentials{},
+		HTTPClient:  httpClient,
 	}, driver.stsOptions())
 
 	// A federation source holds no IAM keys: skip the eager credential probe. All
@@ -241,16 +286,22 @@ func (f *AWSDriverFactory) Create(config map[string]string, log *logger.GatedLog
 		return driver, nil
 	}
 
-	// Perform initial authentication
-	if err := driver.authenticate(context.Background()); err != nil {
+	// Perform initial authentication. Bounded: a source write must not hang on an
+	// endpoint that accepts the connection and never answers.
+	probeCtx, cancel := context.WithTimeout(context.Background(), awsCreateProbeTimeout)
+	defer cancel()
+	if _, err := driver.authenticate(probeCtx); err != nil {
 		return nil, fmt.Errorf("AWS authentication failed: %w", err)
 	}
 
 	return driver, nil
 }
 
-// authenticate refreshes the elevated session if needed (thread-safe)
-func (d *AWSDriver) authenticate(ctx context.Context) error {
+// authenticate refreshes the session if needed and returns the client generation
+// to use. Thread-safe. The returned snapshot is the caller's for the rest of its
+// request: it must not re-read driver fields afterwards, or it risks mixing two
+// credential generations across a rotation.
+func (d *AWSDriver) authenticate(ctx context.Context) (*awsClients, error) {
 	d.authMu.Lock()
 	defer d.authMu.Unlock()
 	return d.authenticateLocked(ctx)
@@ -258,30 +309,35 @@ func (d *AWSDriver) authenticate(ctx context.Context) error {
 
 // authenticateLocked performs authentication without acquiring authMu.
 // Caller must hold authMu.
-func (d *AWSDriver) authenticateLocked(ctx context.Context) error {
+func (d *AWSDriver) authenticateLocked(ctx context.Context) (*awsClients, error) {
 	assumeRoleArn := credential.GetString(d.credSource.Config, "assume_role_arn", "")
 	if assumeRoleArn == "" {
-		// No role chaining; use base creds directly
-		d.buildClients(d.baseCreds)
+		// Base credentials do not expire, so a verified generation stays good until
+		// a rotation drops it. The assumeRoleArn guard is what keeps this branch
+		// from answering for an elevated session, whose expiry it cannot see.
+		if d.clients != nil && d.baseCredsVerified {
+			return d.clients, nil
+		}
 
 		// Verify base credentials are valid once with a lightweight API call
 		if !d.baseCredsVerified {
 			baseSTS := sts.NewFromConfig(aws.Config{
 				Region:      d.region,
 				Credentials: d.baseCreds,
+				HTTPClient:  d.httpClient,
 			}, d.stsOptions())
 			if _, err := baseSTS.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}); err != nil {
-				return fmt.Errorf("invalid AWS credentials: %w", err)
+				return nil, fmt.Errorf("invalid AWS credentials: %w", err)
 			}
 			d.baseCredsVerified = true
 		}
 
-		return nil
+		return d.buildClientsLocked(d.baseCreds), nil
 	}
 
 	// Check if elevated session is still valid (30-second buffer)
-	if d.elevatedCreds != nil && time.Now().Add(30*time.Second).Before(d.elevatedExpiry) {
-		return nil
+	if d.clients != nil && d.elevatedCreds != nil && time.Now().Add(30*time.Second).Before(d.elevatedExpiry) {
+		return d.clients, nil
 	}
 
 	// Call STS AssumeRole using base credentials
@@ -292,6 +348,7 @@ func (d *AWSDriver) authenticateLocked(ctx context.Context) error {
 	baseSTS := sts.NewFromConfig(aws.Config{
 		Region:      d.region,
 		Credentials: d.baseCreds,
+		HTTPClient:  d.httpClient,
 	}, d.stsOptions())
 
 	input := &sts.AssumeRoleInput{
@@ -305,7 +362,7 @@ func (d *AWSDriver) authenticateLocked(ctx context.Context) error {
 
 	result, err := baseSTS.AssumeRole(ctx, input)
 	if err != nil {
-		return fmt.Errorf("failed to assume role %s: %w", assumeRoleArn, err)
+		return nil, fmt.Errorf("failed to assume role %s: %w", assumeRoleArn, err)
 	}
 
 	d.elevatedCreds = &aws.Credentials{
@@ -320,7 +377,7 @@ func (d *AWSDriver) authenticateLocked(ctx context.Context) error {
 		d.elevatedCreds.SecretAccessKey,
 		d.elevatedCreds.SessionToken,
 	)
-	d.buildClients(elevatedProvider)
+	clients := d.buildClientsLocked(elevatedProvider)
 
 	if d.logger != nil {
 		d.logger.Trace("authenticated to AWS via AssumeRole",
@@ -329,7 +386,7 @@ func (d *AWSDriver) authenticateLocked(ctx context.Context) error {
 		)
 	}
 
-	return nil
+	return clients, nil
 }
 
 // stsOptions applies the source's STS endpoint override, if it set one. Every STS
@@ -352,25 +409,41 @@ func (d *AWSDriver) smOptions() func(*secretsmanager.Options) {
 	}
 }
 
-// buildClients creates AWS service clients from the given credentials provider.
-// The IAM, Redshift and Redshift Serverless clients keep their resolved endpoints —
-// the endpoint overrides cover only the mint and source-validation paths.
-func (d *AWSDriver) buildClients(creds aws.CredentialsProvider) {
+// buildClientsLocked creates a new client generation from the given credentials
+// and publishes it. Caller must hold authMu.
+//
+// The Redshift clients keep their resolved endpoints — the endpoint overrides
+// cover only the mint and source-validation paths.
+func (d *AWSDriver) buildClientsLocked(creds aws.CredentialsProvider) *awsClients {
 	cfg := aws.Config{
 		Region:      d.region,
 		Credentials: creds,
+		HTTPClient:  d.httpClient,
 	}
-	d.stsClient = sts.NewFromConfig(cfg, d.stsOptions())
-	d.secretsManagerClient = secretsmanager.NewFromConfig(cfg, d.smOptions())
-	d.iamClient = iam.NewFromConfig(cfg)
-	d.redshiftClient = redshift.NewFromConfig(cfg)
-	d.redshiftServerlessClient = redshiftserverless.NewFromConfig(cfg)
+	d.clients = &awsClients{
+		cfg:        d.credSource.Config,
+		baseCreds:  d.baseCreds,
+		sts:        sts.NewFromConfig(cfg, d.stsOptions()),
+		sm:         secretsmanager.NewFromConfig(cfg, d.smOptions()),
+		redshift:   redshift.NewFromConfig(cfg),
+		redshiftSL: redshiftserverless.NewFromConfig(cfg),
+	}
+	return d.clients
+}
+
+// sourceConfig returns the current source config for callers that need it before
+// (or without) authenticating. The map is never written in place, so the pointer
+// is a stable snapshot; a rotation swaps in a whole new map instead.
+func (d *AWSDriver) sourceConfig() map[string]string {
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
+	return d.credSource.Config
 }
 
 // MintCredential mints credentials using AWS based on credential spec
 func (d *AWSDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	mintMethod := credential.GetString(spec.Config, "mint_method", "")
-	authMethod := credential.GetString(d.credSource.Config, "auth_method", awsAuthMethodStatic)
+	authMethod := credential.GetString(d.sourceConfig(), "auth_method", awsAuthMethodStatic)
 
 	// A federation source holds no static credentials: it authenticates per-request
 	// by federating a caller assertion, which flows through MintCredentialWithExchange.
@@ -381,27 +454,29 @@ func (d *AWSDriver) MintCredential(ctx context.Context, spec *credential.CredSpe
 		return nil, nil, 0, "", fmt.Errorf("auth_method=oidc_federation requires subject_token_source on the spec (warden_identity or agent_identity); federated minting runs through the token-exchange path")
 	}
 
-	// Re-authenticate if needed
-	if err := d.authenticate(ctx); err != nil {
+	// Re-authenticate if needed. The returned generation is this mint's for the
+	// rest of the call; a concurrent rotation swaps the driver's, not this one.
+	c, err := d.authenticate(ctx)
+	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("authentication failed: %w", err)
 	}
 
 	switch mintMethod {
 	case "sts_assume_role":
-		return d.mintViaSTSAssumeRole(ctx, spec)
+		return d.mintViaSTSAssumeRole(ctx, c, spec)
 	case "secrets_manager":
-		return d.mintViaSecretsManager(ctx, spec)
+		return d.mintViaSecretsManager(ctx, c, spec)
 	case "rds_iam_token":
-		return d.mintViaRDSIAMToken(ctx, spec)
+		return d.mintViaRDSIAMToken(ctx, c, spec)
 	case "redshift_iam_token":
-		return d.mintViaRedshiftIAMToken(ctx, spec)
+		return d.mintViaRedshiftIAMToken(ctx, c, spec)
 	default:
 		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for AWS driver; use 'sts_assume_role', 'secrets_manager', 'rds_iam_token', or 'redshift_iam_token'", mintMethod)
 	}
 }
 
 // mintViaSTSAssumeRole mints temporary credentials via STS AssumeRole
-func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, c *awsClients, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	roleArn, err := credential.GetStringRequired(spec.Config, "role_arn")
 	if err != nil {
 		return nil, nil, 0, "", err
@@ -436,7 +511,7 @@ func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, spec *credential.C
 		input.Policy = &policy
 	}
 
-	result, err := d.stsClient.AssumeRole(ctx, input)
+	result, err := c.sts.AssumeRole(ctx, input)
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("STS AssumeRole failed for %s: %w", roleArn, err)
 	}
@@ -508,7 +583,7 @@ func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, spec *credential.C
 //   - sts_assume_role: the federated role credentials are themselves the issued credential.
 //   - secrets_manager: the federated credentials read one secret and are then discarded.
 func (d *AWSDriver) MintCredentialWithExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	if credential.GetString(d.credSource.Config, "auth_method", awsAuthMethodStatic) != awsAuthMethodOIDCFederation {
+	if credential.GetString(d.sourceConfig(), "auth_method", awsAuthMethodStatic) != awsAuthMethodOIDCFederation {
 		return nil, nil, 0, "", fmt.Errorf("aws: web-identity federation requires auth_method=oidc_federation on the source")
 	}
 	if inputs == nil || inputs.SubjectToken == "" {
@@ -692,8 +767,8 @@ func (d *AWSDriver) newSecretsManagerClient(creds aws.CredentialsProvider) *secr
 
 // mintViaSecretsManager fetches a secret using the source's authenticated client (static
 // auth). The keyless (federation) path fetches with a temp-credential client instead.
-func (d *AWSDriver) mintViaSecretsManager(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	return d.fetchSecret(ctx, d.secretsManagerClient, spec)
+func (d *AWSDriver) mintViaSecretsManager(ctx context.Context, c *awsClients, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	return d.fetchSecret(ctx, c.sm, spec)
 }
 
 // fetchSecret reads and parses a Secrets Manager secret with the given client. The client
@@ -755,7 +830,7 @@ func accountIDFromARN(arn string) string {
 // mintViaRDSIAMToken generates a short-lived IAM authentication token for RDS.
 // The token is a pre-signed STS GetCallerIdentity URL that RDS accepts as a password.
 // This is a local SigV4 signing operation — no network call to RDS.
-func (d *AWSDriver) mintViaRDSIAMToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+func (d *AWSDriver) mintViaRDSIAMToken(ctx context.Context, c *awsClients, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	dbEndpoint, err := credential.GetStringRequired(spec.Config, "db_endpoint")
 	if err != nil {
 		return nil, nil, 0, "", err
@@ -771,7 +846,7 @@ func (d *AWSDriver) mintViaRDSIAMToken(ctx context.Context, spec *credential.Cre
 
 	endpoint := fmt.Sprintf("%s:%s", dbEndpoint, dbPort)
 
-	token, err := rdsauth.BuildAuthToken(ctx, endpoint, region, dbUser, d.baseCreds)
+	token, err := rdsauth.BuildAuthToken(ctx, endpoint, region, dbUser, c.baseCreds)
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("failed to build RDS IAM auth token: %w", err)
 	}
@@ -807,7 +882,7 @@ func (d *AWSDriver) mintViaRDSIAMToken(ctx context.Context, spec *credential.Cre
 //
 // Both APIs return a database user (mapped 1:1 to the source IAM identity for
 // provisioned, workgroup-scoped for serverless) and a temporary password.
-func (d *AWSDriver) mintViaRedshiftIAMToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+func (d *AWSDriver) mintViaRedshiftIAMToken(ctx context.Context, c *awsClients, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	dbEndpoint, err := credential.GetStringRequired(spec.Config, "db_endpoint")
 	if err != nil {
 		return nil, nil, 0, "", err
@@ -846,7 +921,7 @@ func (d *AWSDriver) mintViaRedshiftIAMToken(ctx context.Context, spec *credentia
 		if dbName != "" {
 			input.DbName = aws.String(dbName)
 		}
-		out, err := d.redshiftClient.GetClusterCredentialsWithIAM(ctx, input)
+		out, err := c.redshift.GetClusterCredentialsWithIAM(ctx, input)
 		if err != nil {
 			return nil, nil, 0, "", fmt.Errorf("Redshift GetClusterCredentialsWithIAM failed for cluster %s: %w", clusterID, err)
 		}
@@ -865,7 +940,7 @@ func (d *AWSDriver) mintViaRedshiftIAMToken(ctx context.Context, spec *credentia
 		if dbName != "" {
 			input.DbName = aws.String(dbName)
 		}
-		out, err := d.redshiftServerlessClient.GetCredentials(ctx, input)
+		out, err := c.redshiftSL.GetCredentials(ctx, input)
 		if err != nil {
 			return nil, nil, 0, "", fmt.Errorf("Redshift Serverless GetCredentials failed for workgroup %s: %w", workgroup, err)
 		}
@@ -943,7 +1018,7 @@ func (d *AWSDriver) Cleanup(ctx context.Context) error {
 // SupportsRotation returns true if this driver can rotate its own IAM keys.
 // Only permanent IAM keys (AKIA prefix) support rotation.
 func (d *AWSDriver) SupportsRotation() bool {
-	accessKeyID := credential.GetString(d.credSource.Config, "access_key_id", "")
+	accessKeyID := credential.GetString(d.sourceConfig(), "access_key_id", "")
 	return strings.HasPrefix(accessKeyID, "AKIA")
 }
 
@@ -951,17 +1026,21 @@ func (d *AWSDriver) SupportsRotation() bool {
 // Both old and new keys remain valid during the overlap period.
 // Returns activateAfter to allow time for AWS IAM eventual consistency propagation.
 func (d *AWSDriver) PrepareRotation(ctx context.Context) (map[string]string, map[string]string, time.Duration, error) {
+	// Snapshot what the IAM calls need, then release: preparing must not modify
+	// driver state, and holding the lock across this call would block every mint
+	// on the source for as long as IAM takes to answer.
 	d.authMu.Lock()
-	defer d.authMu.Unlock()
+	cfg, baseCreds := d.credSource.Config, d.baseCreds
+	d.authMu.Unlock()
 
-	oldAccessKeyID := credential.GetString(d.credSource.Config, "access_key_id", "")
+	oldAccessKeyID := credential.GetString(cfg, "access_key_id", "")
 
 	// Use base credentials (not elevated) for IAM operations on the user's own keys
-	baseCfg := aws.Config{
+	iamClient := iam.NewFromConfig(aws.Config{
 		Region:      d.region,
-		Credentials: d.baseCreds,
-	}
-	iamClient := iam.NewFromConfig(baseCfg)
+		Credentials: baseCreds,
+		HTTPClient:  d.httpClient,
+	})
 
 	// IAM users can have max 2 keys. If there are already 2 (e.g., from a
 	// previously failed rotation), delete the orphaned key before creating a new one.
@@ -1042,8 +1121,10 @@ func (d *AWSDriver) CommitRotation(ctx context.Context, newConfig map[string]str
 	d.elevatedExpiry = time.Time{}
 	d.baseCredsVerified = false
 
-	// Re-authenticate (we already hold authMu, so use locked variant)
-	if err := d.authenticateLocked(ctx); err != nil {
+	// Drop the stale client generation, then re-authenticate to build a new one
+	// (we already hold authMu, so use the locked variant).
+	d.clients = nil
+	if _, err := d.authenticateLocked(ctx); err != nil {
 		return fmt.Errorf("failed to authenticate with new IAM keys: %w", err)
 	}
 
@@ -1064,17 +1145,20 @@ func (d *AWSDriver) CleanupRotation(ctx context.Context, cleanupConfig map[strin
 		return nil
 	}
 
+	// Snapshot and release, as PrepareRotation does — cleanup runs on a retry
+	// schedule and must not hold minting up while IAM answers.
 	d.authMu.Lock()
-	defer d.authMu.Unlock()
+	baseCreds := d.baseCreds
+	d.authMu.Unlock()
 
 	// Use base credentials (not elevated) for IAM operations on the user's own keys,
 	// matching PrepareRotation. Elevated/assumed-role creds operate as the role
 	// principal and cannot delete the IAM user's access keys.
-	baseCfg := aws.Config{
+	iamClient := iam.NewFromConfig(aws.Config{
 		Region:      d.region,
-		Credentials: d.baseCreds,
-	}
-	iamClient := iam.NewFromConfig(baseCfg)
+		Credentials: baseCreds,
+		HTTPClient:  d.httpClient,
+	})
 
 	_, err := iamClient.DeleteAccessKey(ctx, &iam.DeleteAccessKeyInput{
 		AccessKeyId: &oldAccessKeyID,

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -3,12 +3,17 @@ package drivers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/credential/types"
@@ -16,6 +21,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// primeClients gives a hand-built driver a usable client generation without the
+// network probe, standing in for the Create-time authenticate these tests skip.
+func primeClients(d *AWSDriver) {
+	d.authMu.Lock()
+	defer d.authMu.Unlock()
+	d.baseCredsVerified = true
+	d.buildClientsLocked(d.baseCreds)
+}
 
 func TestAWSDriverFactory_Type(t *testing.T) {
 	factory := &AWSDriverFactory{}
@@ -280,8 +294,7 @@ func TestAWSDriver_MintCredential_InvalidMethod(t *testing.T) {
 		region: "us-east-1",
 	}
 	// Build clients so authenticate doesn't fail (no assume_role_arn)
-	driver.buildClients(driver.baseCreds)
-	driver.baseCredsVerified = true
+	primeClients(driver)
 
 	spec := &credential.CredSpec{
 		Name: "test-spec",
@@ -308,8 +321,7 @@ func TestAWSDriver_MintCredential_TTLBelowMinimum(t *testing.T) {
 		},
 		region: "us-east-1",
 	}
-	driver.buildClients(driver.baseCreds)
-	driver.baseCredsVerified = true
+	primeClients(driver)
 
 	spec := &credential.CredSpec{
 		Name:   "test-spec",
@@ -339,8 +351,7 @@ func TestAWSDriver_MintCredential_TTLExceedsMaximum(t *testing.T) {
 		},
 		region: "us-east-1",
 	}
-	driver.buildClients(driver.baseCreds)
-	driver.baseCredsVerified = true
+	primeClients(driver)
 
 	spec := &credential.CredSpec{
 		Name:   "test-spec",
@@ -445,8 +456,7 @@ func newRedshiftTestDriver(t *testing.T) *AWSDriver {
 		},
 		region: "us-east-1",
 	}
-	driver.buildClients(driver.baseCreds)
-	driver.baseCredsVerified = true
+	primeClients(driver)
 	return driver
 }
 
@@ -1067,6 +1077,7 @@ func TestAWSDriver_EndpointOverride_SecretsManagerMint(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Contains(t, target, "GetSecretValue")
+	assert.Contains(t, authScope, "AKIAIOSFODNN7EXAMPLE", "the static mint must sign with the source's own key")
 	assert.Equal(t, "stored-key", rawData["api_key"])
 }
 
@@ -1119,4 +1130,300 @@ func TestAWSDriver_EndpointOverride_AbsentLeavesResolverAlone(t *testing.T) {
 	awsDrv := drv.(*AWSDriver)
 	assert.Empty(t, awsDrv.stsEndpoint)
 	assert.Empty(t, awsDrv.smBaseEndpoint)
+
+	// The option funcs are what actually decide the endpoint, so assert on them
+	// rather than on the fields they read: with nothing configured they must leave
+	// BaseEndpoint untouched, so the SDK resolves the real regional endpoint.
+	stsOpts := sts.Options{}
+	awsDrv.stsOptions()(&stsOpts)
+	assert.Nil(t, stsOpts.BaseEndpoint)
+
+	smOpts := secretsmanager.Options{}
+	awsDrv.smOptions()(&smOpts)
+	assert.Nil(t, smOpts.BaseEndpoint)
+}
+
+// =============================================================================
+// Client generations: concurrency, timeouts, transport
+// =============================================================================
+
+// concurrentSTSStub is stsStub's thread-safe sibling. The concurrency tests drive
+// it from many goroutines at once, so it records under a mutex and reports the
+// SigV4 scope of every request it saw.
+type concurrentSTSStub struct {
+	mu     sync.Mutex
+	scopes []string
+	srv    *httptest.Server
+	// beforeRespond, when set, runs while the AssumeRole request is in flight —
+	// the seam a rotation needs to land in the middle of a mint.
+	beforeRespond func()
+	once          sync.Once
+}
+
+func newConcurrentSTSStub(t *testing.T) *concurrentSTSStub {
+	t.Helper()
+	s := &concurrentSTSStub{}
+	s.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		action := r.Form.Get("Action")
+
+		s.mu.Lock()
+		s.scopes = append(s.scopes, r.Header.Get("Authorization"))
+		hook := s.beforeRespond
+		s.mu.Unlock()
+
+		if action == "AssumeRole" && hook != nil {
+			s.once.Do(hook)
+		}
+
+		w.Header().Set("Content-Type", "text/xml")
+		switch action {
+		case "GetCallerIdentity":
+			_, _ = w.Write([]byte(`<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetCallerIdentityResult><Arn>arn:aws:iam::123456789012:user/w</Arn><UserId>AIDA</UserId><Account>123456789012</Account></GetCallerIdentityResult>
+</GetCallerIdentityResponse>`))
+		default:
+			_, _ = w.Write([]byte(`<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>
+    <Credentials>
+      <AccessKeyId>ASIAEXAMPLE</AccessKeyId>
+      <SecretAccessKey>secretexample</SecretAccessKey>
+      <SessionToken>tokenexample</SessionToken>
+      <Expiration>2035-01-01T00:00:00Z</Expiration>
+    </Credentials>
+    <AssumedRoleUser><Arn>arn:aws:sts::123456789012:assumed-role/App/w</Arn><AssumedRoleId>AROA:w</AssumedRoleId></AssumedRoleUser>
+  </AssumeRoleResult>
+</AssumeRoleResponse>`))
+		}
+	}))
+	t.Cleanup(s.srv.Close)
+	return s
+}
+
+func (s *concurrentSTSStub) scopesSeen() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.scopes...)
+}
+
+// TestAWSDriver_ConcurrentMintAndRotationCommit drives mints and rotation commits
+// against one driver instance, which is how the registry hands drivers out. The
+// assertion that matters is -race staying quiet: before the client generations
+// were snapshotted, every commit rebuilt fields that in-flight mints were reading
+// without the lock.
+func TestAWSDriver_ConcurrentMintAndRotationCommit(t *testing.T) {
+	sts := newConcurrentSTSStub(t)
+
+	var target, authScope string
+	var smMu sync.Mutex
+	smSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		smMu.Lock()
+		target, authScope = r.Header.Get("X-Amz-Target"), r.Header.Get("Authorization")
+		smMu.Unlock()
+		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+		_, _ = w.Write([]byte(`{"Name":"prod/app","SecretString":"{\"api_key\":\"k\"}"}`))
+	}))
+	defer smSrv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	baseConfig := map[string]string{
+		"access_key_id":           "AKIAIOSFODNN7EXAMPLE",
+		"secret_access_key":       "secret0",
+		"region":                  "us-east-1",
+		"sts_endpoint":            sts.srv.URL,
+		"secretsmanager_endpoint": smSrv.URL,
+	}
+	drv, err := (&AWSDriverFactory{}).Create(baseConfig, log)
+	require.NoError(t, err)
+	awsDrv := drv.(*AWSDriver)
+
+	roleSpec := &credential.CredSpec{Name: "role", Config: map[string]string{
+		"mint_method": "sts_assume_role", "role_arn": "arn:aws:iam::123456789012:role/App", "ttl": "1h",
+	}}
+	smSpec := &credential.CredSpec{Name: "sm", Config: map[string]string{
+		"mint_method": "secrets_manager", "secret_id": "prod/app",
+	}}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			spec := roleSpec
+			if i%2 == 0 {
+				spec = smSpec
+			}
+			for n := 0; n < 15; n++ {
+				if _, _, _, _, err := drv.MintCredential(context.TODO(), spec); err != nil {
+					t.Errorf("mint failed: %v", err)
+					return
+				}
+			}
+		}(i)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for n := 0; n < 15; n++ {
+			rotated := make(map[string]string, len(baseConfig))
+			for k, v := range baseConfig {
+				rotated[k] = v
+			}
+			rotated["secret_access_key"] = fmt.Sprintf("secret%d", n+1)
+			if err := awsDrv.CommitRotation(context.TODO(), rotated); err != nil {
+				t.Errorf("commit failed: %v", err)
+				return
+			}
+		}
+	}()
+	wg.Wait()
+
+	smMu.Lock()
+	defer smMu.Unlock()
+	assert.Contains(t, target, "GetSecretValue")
+	assert.NotEmpty(t, authScope)
+}
+
+// TestAWSDriver_MintSignsWithOneGeneration pins the property the snapshot exists
+// for: a commit landing in the middle of a mint must not change which credentials
+// that mint's request is signed with. The stub gives the rotation a deterministic
+// seam rather than racing it with a sleep.
+func TestAWSDriver_MintSignsWithOneGeneration(t *testing.T) {
+	sts := newConcurrentSTSStub(t)
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	baseConfig := map[string]string{
+		"access_key_id":     "AKIAOLDEXAMPLEKEY000",
+		"secret_access_key": "old-secret",
+		"region":            "us-east-1",
+		"sts_endpoint":      sts.srv.URL,
+	}
+	drv, err := (&AWSDriverFactory{}).Create(baseConfig, log)
+	require.NoError(t, err)
+	awsDrv := drv.(*AWSDriver)
+
+	rotated := make(map[string]string, len(baseConfig))
+	for k, v := range baseConfig {
+		rotated[k] = v
+	}
+	rotated["access_key_id"] = "AKIANEWEXAMPLEKEY000"
+	rotated["secret_access_key"] = "new-secret"
+
+	// Commit the rotation while the mint's AssumeRole is in flight.
+	sts.mu.Lock()
+	sts.beforeRespond = func() {
+		if err := awsDrv.CommitRotation(context.TODO(), rotated); err != nil {
+			t.Errorf("commit failed: %v", err)
+		}
+	}
+	sts.mu.Unlock()
+
+	spec := &credential.CredSpec{Name: "role", Config: map[string]string{
+		"mint_method": "sts_assume_role", "role_arn": "arn:aws:iam::123456789012:role/App", "ttl": "1h",
+	}}
+	_, _, _, _, err = drv.MintCredential(context.TODO(), spec)
+	require.NoError(t, err)
+
+	var assumeRoleScope string
+	for _, s := range sts.scopesSeen() {
+		if strings.Contains(s, "AKIAOLDEXAMPLEKEY000") {
+			assumeRoleScope = s
+		}
+	}
+	assert.NotEmpty(t, assumeRoleScope,
+		"the in-flight mint must stay signed with the key its snapshot was built from, not the one committed mid-request")
+
+	// And the next mint picks up the new generation.
+	_, _, _, _, err = drv.MintCredential(context.TODO(), spec)
+	require.NoError(t, err)
+	last := sts.scopesSeen()
+	assert.Contains(t, last[len(last)-1], "AKIANEWEXAMPLEKEY000")
+}
+
+// TestAWSDriver_Create_ProbeTimesOut: an endpoint that accepts the connection and
+// never answers must fail the source write, not hold it open.
+func TestAWSDriver_Create_ProbeTimesOut(t *testing.T) {
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	}))
+	// Release the handler before closing: Close waits for it to return.
+	defer srv.Close()
+	defer close(block)
+
+	orig := awsCreateProbeTimeout
+	awsCreateProbeTimeout = 200 * time.Millisecond
+	defer func() { awsCreateProbeTimeout = orig }()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	start := time.Now()
+	_, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
+		"secret_access_key": "secret",
+		"region":            "us-east-1",
+		"sts_endpoint":      srv.URL,
+	}, log)
+	require.Error(t, err)
+	assert.Less(t, time.Since(start), 10*time.Second, "Create must give up on the probe timeout")
+}
+
+// TestAWSDriver_HTTPClientReachesClients proves the configured transport is the one
+// the SDK uses: the stub speaks TLS with an untrusted certificate, so the probe can
+// only succeed if the driver's own client (built with tls_skip_verify) is in play.
+func TestAWSDriver_HTTPClientReachesClients(t *testing.T) {
+	var actions []string
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		actions = append(actions, r.Form.Get("Action"))
+		w.Header().Set("Content-Type", "text/xml")
+		_, _ = w.Write([]byte(`<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetCallerIdentityResult><Arn>arn:aws:iam::123456789012:user/w</Arn><UserId>AIDA</UserId><Account>123456789012</Account></GetCallerIdentityResult>
+</GetCallerIdentityResponse>`))
+	}))
+	defer srv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	cfg := map[string]string{
+		"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
+		"secret_access_key": "secret",
+		"region":            "us-east-1",
+		"sts_endpoint":      srv.URL,
+	}
+
+	_, err := (&AWSDriverFactory{}).Create(cfg, log)
+	require.Error(t, err, "without tls_skip_verify the untrusted certificate must be rejected")
+
+	cfg["tls_skip_verify"] = "true"
+	_, err = (&AWSDriverFactory{}).Create(cfg, log)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"GetCallerIdentity"}, actions)
+}
+
+// TestAWSDriver_MintViaRDSIAMToken_HappyPath covers the RDS path under the snapshot
+// signature. The token is signed locally, so no endpoint is involved.
+func TestAWSDriver_MintViaRDSIAMToken_HappyPath(t *testing.T) {
+	driver := &AWSDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeAWS, Config: map[string]string{
+			"access_key_id": "AKIAIOSFODNN7EXAMPLE", "secret_access_key": "secret", "region": "us-east-1",
+		}},
+		baseCreds: credentials.NewStaticCredentialsProvider("AKIAIOSFODNN7EXAMPLE", "secret", ""),
+		region:    "us-east-1",
+	}
+	primeClients(driver)
+
+	rawData, metadata, ttl, leaseID, err := driver.MintCredential(context.TODO(), &credential.CredSpec{
+		Name: "db",
+		Config: map[string]string{
+			"mint_method": "rds_iam_token",
+			"db_endpoint": "mydb.abc123.us-east-1.rds.amazonaws.com",
+			"db_user":     "app",
+		},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, rawData["auth_token"], "X-Amz-Signature=")
+	assert.Equal(t, "5432", rawData["db_port"])
+	assert.Equal(t, "rds_iam", rawData["token_type"])
+	assert.Nil(t, metadata)
+	assert.Equal(t, 15*time.Minute, ttl)
+	assert.Equal(t, "", leaseID)
 }


### PR DESCRIPTION
Stacked on #600.

The registry hands a single driver instance to every concurrent request, and on a source without `assume_role_arn` the client fields were rebuilt on **every** authenticate — that is, every mint. Meanwhile each mint helper read those fields, and the base credentials and config map, with no lock at all.

This is not theoretical. Running the new concurrency test against the pre-fix code, the race detector reports it immediately, on exactly the two predicted pairs:

```
Write at 0x00c000301cd0 by goroutine 23:   aws_driver.go:1033  (CommitRotation swapping credSource.Config)
Previous read at 0x00c000301cd0 by g 20:   aws_driver.go:373   (MintCredential reading it)

Write at 0x00c0001294e8 by goroutine 20:   aws_driver.go:363   (buildClients writing stsClient)
```

### The fix

Rather than lock each field, `authenticate` returns the whole generation of clients and the credentials they were built from, and a mint carries that for the rest of its call. Signing stays consistent across a rotation, and no lock is held while a request is in flight.

An `RWMutex` was the alternative and would have left torn reads *across* fields — a mint reading `stsClient` then `baseCreds` around a commit still mixes generations — unless every helper held it across its network call, which is the stall this avoids.

Two things fall out of the restructure. The no-role path no longer rebuilds five clients per mint, only when a rotation drops the generation — guarded on `assumeRoleArn == ""` so it can never answer for an elevated session, whose expiry it cannot see. And `iamClient` turned out to be dead: assigned, never read, since rotation builds its own.

### Also

Nothing bounded a request. Every client now carries a 30s HTTP client, matching every other driver, and the probe that runs when a source is written gets its own deadline — so an endpoint that accepts the connection and never answers fails the write instead of hanging it. Rotation's IAM calls no longer hold the lock while they wait.

The 30s is hardcoded, as it is at all 18 other `BuildHTTPClient` call sites. Making it configurable would make aws the one driver that behaves differently; if it should be configurable it should be so everywhere, which is its own change.

### Verification

`go test -race ./credential/drivers/` clean. The concurrency test's value is the race detector staying quiet — verified it fires without the fix.