### PR TITLE
fix(cred): close the gaps review found in the aws client snapshot

### DIFF
--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -75,6 +75,12 @@ type AWSDriver struct {
 	// ones used to validate the source at write time.
 	smBaseEndpoint string
 	stsEndpoint    string
+
+	// iamTestEndpoint redirects the IAM calls rotation makes. Set only by tests in
+	// this package: unlike the STS and Secrets Manager overrides there is
+	// deliberately no source-config key, because rotation acts on the real account
+	// whatever else a source is pointed at.
+	iamTestEndpoint string
 }
 
 // awsAuthMethodStatic and awsAuthMethodOIDCFederation select how the source
@@ -103,16 +109,11 @@ const awsRequestTimeout = 30 * time.Second
 var awsCreateProbeTimeout = 30 * time.Second
 
 // awsClients is one coherent generation of service clients, together with the
-// config and base credentials they were built from. It is built under authMu and
-// then used without it: a mint takes the whole snapshot up front, so every call it
-// makes signs with a single generation even if a rotation commit swaps the driver
+// base credentials they were built from. It is built under authMu and then used
+// without it: a mint takes the whole snapshot up front, so every call it makes
+// signs with a single generation even if a rotation commit swaps the driver
 // underneath it mid-request.
-//
-// cfg is safe to read unlocked because a source's config map is never written in
-// place — a rotation builds a fresh map and swaps the whole thing — so a snapshot
-// of the pointer is a snapshot of the contents.
 type awsClients struct {
-	cfg        map[string]string
 	baseCreds  aws.CredentialsProvider
 	sts        *sts.Client
 	sm         *secretsmanager.Client
@@ -176,6 +177,15 @@ func (f *AWSDriverFactory) ValidateConfig(config map[string]string) error {
 		credential.StringField("secretsmanager_endpoint").
 			Describe("Override where Secrets Manager calls are sent (default: the SDK's regional endpoint)").
 			Example("https://secretsmanager.us-east-1.amazonaws.com"),
+
+		credential.StringField("ca_data").
+			Custom(ValidateCAData).
+			Describe("Base64-encoded PEM CA certificate for custom/self-signed CAs").
+			Example(""),
+
+		credential.BoolField("tls_skip_verify").
+			Describe("Skip TLS certificate verification (development only)").
+			Example("false"),
 	); err != nil {
 		return err
 	}
@@ -206,7 +216,7 @@ func (f *AWSDriverFactory) ValidateConfig(config map[string]string) error {
 
 // SensitiveConfigFields returns the list of config keys that should be masked in output
 func (f *AWSDriverFactory) SensitiveConfigFields() []string {
-	return []string{"secret_access_key"}
+	return []string{"secret_access_key", "ca_data"}
 }
 
 // InferCredentialType infers the credential type from the spec's mint_method.
@@ -274,11 +284,8 @@ func (f *AWSDriverFactory) Create(config map[string]string, log *logger.GatedLog
 
 	// AssumeRoleWithWebIdentity is unsigned: anonymous credentials skip SigV4.
 	// Built after the literal so it picks up the resolved endpoint override.
-	driver.anonSTSClient = sts.NewFromConfig(aws.Config{
-		Region:      region,
-		Credentials: aws.AnonymousCredentials{},
-		HTTPClient:  httpClient,
-	}, driver.stsOptions())
+	driver.anonSTSClient = sts.NewFromConfig(
+		driver.awsConfig(aws.AnonymousCredentials{}), driver.stsOptions())
 
 	// A federation source holds no IAM keys: skip the eager credential probe. All
 	// authentication happens per-request from the caller's identity assertion.
@@ -321,11 +328,7 @@ func (d *AWSDriver) authenticateLocked(ctx context.Context) (*awsClients, error)
 
 		// Verify base credentials are valid once with a lightweight API call
 		if !d.baseCredsVerified {
-			baseSTS := sts.NewFromConfig(aws.Config{
-				Region:      d.region,
-				Credentials: d.baseCreds,
-				HTTPClient:  d.httpClient,
-			}, d.stsOptions())
+			baseSTS := sts.NewFromConfig(d.awsConfig(d.baseCreds), d.stsOptions())
 			if _, err := baseSTS.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}); err != nil {
 				return nil, fmt.Errorf("invalid AWS credentials: %w", err)
 			}
@@ -345,11 +348,7 @@ func (d *AWSDriver) authenticateLocked(ctx context.Context) (*awsClients, error)
 	sessionDuration := credential.GetDuration(d.credSource.Config, "session_duration", 1*time.Hour)
 	externalID := credential.GetString(d.credSource.Config, "external_id", "")
 
-	baseSTS := sts.NewFromConfig(aws.Config{
-		Region:      d.region,
-		Credentials: d.baseCreds,
-		HTTPClient:  d.httpClient,
-	}, d.stsOptions())
+	baseSTS := sts.NewFromConfig(d.awsConfig(d.baseCreds), d.stsOptions())
 
 	input := &sts.AssumeRoleInput{
 		RoleArn:         &assumeRoleArn,
@@ -415,13 +414,8 @@ func (d *AWSDriver) smOptions() func(*secretsmanager.Options) {
 // The Redshift clients keep their resolved endpoints — the endpoint overrides
 // cover only the mint and source-validation paths.
 func (d *AWSDriver) buildClientsLocked(creds aws.CredentialsProvider) *awsClients {
-	cfg := aws.Config{
-		Region:      d.region,
-		Credentials: creds,
-		HTTPClient:  d.httpClient,
-	}
+	cfg := d.awsConfig(creds)
 	d.clients = &awsClients{
-		cfg:        d.credSource.Config,
 		baseCreds:  d.baseCreds,
 		sts:        sts.NewFromConfig(cfg, d.stsOptions()),
 		sm:         secretsmanager.NewFromConfig(cfg, d.smOptions()),
@@ -429,6 +423,34 @@ func (d *AWSDriver) buildClientsLocked(creds aws.CredentialsProvider) *awsClient
 		redshiftSL: redshiftserverless.NewFromConfig(cfg),
 	}
 	return d.clients
+}
+
+// awsConfig builds the SDK config every client in this driver is constructed
+// from. HTTPClient is set only when one was actually built: aws.Config takes an
+// interface, and a nil *http.Client stored in it reads as non-nil to the SDK,
+// which then panics on the first request instead of using its own default.
+func (d *AWSDriver) awsConfig(creds aws.CredentialsProvider) aws.Config {
+	cfg := aws.Config{
+		Region:      d.region,
+		Credentials: creds,
+	}
+	if d.httpClient != nil {
+		cfg.HTTPClient = d.httpClient
+	}
+	return cfg
+}
+
+// newIAMClient builds the IAM client rotation uses, from the base credentials —
+// an elevated session acts as the role principal and cannot manage the user's own
+// access keys.
+func (d *AWSDriver) newIAMClient(creds aws.CredentialsProvider) *iam.Client {
+	cfg := d.awsConfig(creds)
+	if d.iamTestEndpoint != "" {
+		return iam.NewFromConfig(cfg, func(o *iam.Options) {
+			o.BaseEndpoint = aws.String(d.iamTestEndpoint)
+		})
+	}
+	return iam.NewFromConfig(cfg)
 }
 
 // sourceConfig returns the current source config for callers that need it before
@@ -762,7 +784,7 @@ func (d *AWSDriver) credsFromWebIdentity(spec *credential.CredSpec, result *sts.
 // (e.g. freshly federated temporary credentials), honouring the source's endpoint
 // override when it set one.
 func (d *AWSDriver) newSecretsManagerClient(creds aws.CredentialsProvider) *secretsmanager.Client {
-	return secretsmanager.NewFromConfig(aws.Config{Region: d.region, Credentials: creds}, d.smOptions())
+	return secretsmanager.NewFromConfig(d.awsConfig(creds), d.smOptions())
 }
 
 // mintViaSecretsManager fetches a secret using the source's authenticated client (static
@@ -1036,11 +1058,7 @@ func (d *AWSDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 	oldAccessKeyID := credential.GetString(cfg, "access_key_id", "")
 
 	// Use base credentials (not elevated) for IAM operations on the user's own keys
-	iamClient := iam.NewFromConfig(aws.Config{
-		Region:      d.region,
-		Credentials: baseCreds,
-		HTTPClient:  d.httpClient,
-	})
+	iamClient := d.newIAMClient(baseCreds)
 
 	// IAM users can have max 2 keys. If there are already 2 (e.g., from a
 	// previously failed rotation), delete the orphaned key before creating a new one.
@@ -1075,9 +1093,11 @@ func (d *AWSDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 
 	newKey := result.AccessKey
 
-	// Build new config (copy all, replace key fields)
+	// Build new config (copy all, replace key fields). Copied from the snapshot,
+	// not the live field: a commit landing mid-prepare would otherwise derive the
+	// new config from one generation while cleanup names another generation's key.
 	newConfig := make(map[string]string)
-	for k, v := range d.credSource.Config {
+	for k, v := range cfg {
 		newConfig[k] = v
 	}
 	newConfig["access_key_id"] = *newKey.AccessKeyId
@@ -1090,7 +1110,7 @@ func (d *AWSDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 
 	// Return activateAfter to let the rotation manager schedule activation
 	// after AWS IAM eventual consistency has propagated the new key.
-	activateAfter := credential.GetDuration(d.credSource.Config, "activation_delay", DefaultAWSActivationDelay)
+	activateAfter := credential.GetDuration(cfg, "activation_delay", DefaultAWSActivationDelay)
 
 	if d.logger != nil {
 		d.logger.Debug("prepared new IAM access key for rotation",
@@ -1151,14 +1171,8 @@ func (d *AWSDriver) CleanupRotation(ctx context.Context, cleanupConfig map[strin
 	baseCreds := d.baseCreds
 	d.authMu.Unlock()
 
-	// Use base credentials (not elevated) for IAM operations on the user's own keys,
-	// matching PrepareRotation. Elevated/assumed-role creds operate as the role
-	// principal and cannot delete the IAM user's access keys.
-	iamClient := iam.NewFromConfig(aws.Config{
-		Region:      d.region,
-		Credentials: baseCreds,
-		HTTPClient:  d.httpClient,
-	})
+	// Matches PrepareRotation: the user's own keys, from the base credentials.
+	iamClient := d.newIAMClient(baseCreds)
 
 	_, err := iamClient.DeleteAccessKey(ctx, &iam.DeleteAccessKeyInput{
 		AccessKeyId: &oldAccessKeyID,

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1051,7 +1050,7 @@ func TestAWSDriver_EndpointOverride_AssumeRoleSource(t *testing.T) {
 }
 
 // TestAWSDriver_EndpointOverride_SecretsManagerMint proves the override reaches the
-// Secrets Manager client built by buildClients, i.e. the static mint path.
+// Secrets Manager client in the driver's client generation, i.e. the static mint path.
 func TestAWSDriver_EndpointOverride_SecretsManagerMint(t *testing.T) {
 	var actions []string
 	stsSrv := stsStub(t, &actions)
@@ -1151,13 +1150,16 @@ func TestAWSDriver_EndpointOverride_AbsentLeavesResolverAlone(t *testing.T) {
 // it from many goroutines at once, so it records under a mutex and reports the
 // SigV4 scope of every request it saw.
 type concurrentSTSStub struct {
-	mu     sync.Mutex
-	scopes []string
-	srv    *httptest.Server
-	// beforeRespond, when set, runs while the AssumeRole request is in flight —
-	// the seam a rotation needs to land in the middle of a mint.
-	beforeRespond func()
-	once          sync.Once
+	mu       sync.Mutex
+	requests []stsRequest
+	srv      *httptest.Server
+}
+
+// stsRequest is one call the stub saw: the action and the SigV4 scope it was
+// signed with, which is how a test tells one key generation from another.
+type stsRequest struct {
+	action string
+	scope  string
 }
 
 func newConcurrentSTSStub(t *testing.T) *concurrentSTSStub {
@@ -1168,13 +1170,8 @@ func newConcurrentSTSStub(t *testing.T) *concurrentSTSStub {
 		action := r.Form.Get("Action")
 
 		s.mu.Lock()
-		s.scopes = append(s.scopes, r.Header.Get("Authorization"))
-		hook := s.beforeRespond
+		s.requests = append(s.requests, stsRequest{action: action, scope: r.Header.Get("Authorization")})
 		s.mu.Unlock()
-
-		if action == "AssumeRole" && hook != nil {
-			s.once.Do(hook)
-		}
 
 		w.Header().Set("Content-Type", "text/xml")
 		switch action {
@@ -1200,11 +1197,6 @@ func newConcurrentSTSStub(t *testing.T) *concurrentSTSStub {
 	return s
 }
 
-func (s *concurrentSTSStub) scopesSeen() []string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return append([]string(nil), s.scopes...)
-}
 
 // TestAWSDriver_ConcurrentMintAndRotationCommit drives mints and rotation commits
 // against one driver instance, which is how the registry hands drivers out. The
@@ -1212,7 +1204,7 @@ func (s *concurrentSTSStub) scopesSeen() []string {
 // were snapshotted, every commit rebuilt fields that in-flight mints were reading
 // without the lock.
 func TestAWSDriver_ConcurrentMintAndRotationCommit(t *testing.T) {
-	sts := newConcurrentSTSStub(t)
+	stub := newConcurrentSTSStub(t)
 
 	var target, authScope string
 	var smMu sync.Mutex
@@ -1230,7 +1222,7 @@ func TestAWSDriver_ConcurrentMintAndRotationCommit(t *testing.T) {
 		"access_key_id":           "AKIAIOSFODNN7EXAMPLE",
 		"secret_access_key":       "secret0",
 		"region":                  "us-east-1",
-		"sts_endpoint":            sts.srv.URL,
+		"sts_endpoint":            stub.srv.URL,
 		"secretsmanager_endpoint": smSrv.URL,
 	}
 	drv, err := (&AWSDriverFactory{}).Create(baseConfig, log)
@@ -1288,15 +1280,15 @@ func TestAWSDriver_ConcurrentMintAndRotationCommit(t *testing.T) {
 // for: a commit landing in the middle of a mint must not change which credentials
 // that mint's request is signed with. The stub gives the rotation a deterministic
 // seam rather than racing it with a sleep.
-func TestAWSDriver_MintSignsWithOneGeneration(t *testing.T) {
-	sts := newConcurrentSTSStub(t)
+func TestAWSDriver_SnapshotSurvivesRotationCommit(t *testing.T) {
+	stub := newConcurrentSTSStub(t)
 
 	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
 	baseConfig := map[string]string{
 		"access_key_id":     "AKIAOLDEXAMPLEKEY000",
 		"secret_access_key": "old-secret",
 		"region":            "us-east-1",
-		"sts_endpoint":      sts.srv.URL,
+		"sts_endpoint":      stub.srv.URL,
 	}
 	drv, err := (&AWSDriverFactory{}).Create(baseConfig, log)
 	require.NoError(t, err)
@@ -1309,35 +1301,50 @@ func TestAWSDriver_MintSignsWithOneGeneration(t *testing.T) {
 	rotated["access_key_id"] = "AKIANEWEXAMPLEKEY000"
 	rotated["secret_access_key"] = "new-secret"
 
-	// Commit the rotation while the mint's AssumeRole is in flight.
-	sts.mu.Lock()
-	sts.beforeRespond = func() {
-		if err := awsDrv.CommitRotation(context.TODO(), rotated); err != nil {
-			t.Errorf("commit failed: %v", err)
+	// Take a generation the way a mint does, then rotate underneath it.
+	held, err := awsDrv.authenticate(context.TODO())
+	require.NoError(t, err)
+	require.NoError(t, awsDrv.CommitRotation(context.TODO(), rotated))
+
+	// The held generation still signs with the key it was built from. This is the
+	// property the snapshot exists for: a mint that authenticated before a commit
+	// finishes its calls on one set of credentials rather than a mixture.
+	_, err = held.sts.AssumeRole(context.TODO(), &sts.AssumeRoleInput{
+		RoleArn:         aws.String("arn:aws:iam::123456789012:role/App"),
+		RoleSessionName: aws.String("held"),
+	})
+	require.NoError(t, err)
+	assert.Contains(t, lastAssumeRoleScope(t, stub),"AKIAOLDEXAMPLEKEY000",
+		"a generation taken before the commit must keep signing with its own key")
+
+	// A fresh generation picks up the rotated key, and is not the held one.
+	fresh, err := awsDrv.authenticate(context.TODO())
+	require.NoError(t, err)
+	assert.NotSame(t, held, fresh, "the commit must drop the stale generation")
+
+	_, err = fresh.sts.AssumeRole(context.TODO(), &sts.AssumeRoleInput{
+		RoleArn:         aws.String("arn:aws:iam::123456789012:role/App"),
+		RoleSessionName: aws.String("fresh"),
+	})
+	require.NoError(t, err)
+	assert.Contains(t, lastAssumeRoleScope(t, stub),"AKIANEWEXAMPLEKEY000")
+}
+
+// lastAssumeRoleScope returns the SigV4 scope of the most recent AssumeRole the
+// stub saw. Filtering by action matters: the Create-time probe signs a
+// GetCallerIdentity with the pre-rotation key, so scanning every request would
+// find the old key whatever the code under test did.
+func lastAssumeRoleScope(t *testing.T, s *concurrentSTSStub) string {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := len(s.requests) - 1; i >= 0; i-- {
+		if s.requests[i].action == "AssumeRole" {
+			return s.requests[i].scope
 		}
 	}
-	sts.mu.Unlock()
-
-	spec := &credential.CredSpec{Name: "role", Config: map[string]string{
-		"mint_method": "sts_assume_role", "role_arn": "arn:aws:iam::123456789012:role/App", "ttl": "1h",
-	}}
-	_, _, _, _, err = drv.MintCredential(context.TODO(), spec)
-	require.NoError(t, err)
-
-	var assumeRoleScope string
-	for _, s := range sts.scopesSeen() {
-		if strings.Contains(s, "AKIAOLDEXAMPLEKEY000") {
-			assumeRoleScope = s
-		}
-	}
-	assert.NotEmpty(t, assumeRoleScope,
-		"the in-flight mint must stay signed with the key its snapshot was built from, not the one committed mid-request")
-
-	// And the next mint picks up the new generation.
-	_, _, _, _, err = drv.MintCredential(context.TODO(), spec)
-	require.NoError(t, err)
-	last := sts.scopesSeen()
-	assert.Contains(t, last[len(last)-1], "AKIANEWEXAMPLEKEY000")
+	t.Fatal("stub saw no AssumeRole request")
+	return ""
 }
 
 // TestAWSDriver_Create_ProbeTimesOut: an endpoint that accepts the connection and
@@ -1426,4 +1433,139 @@ func TestAWSDriver_MintViaRDSIAMToken_HappyPath(t *testing.T) {
 	assert.Nil(t, metadata)
 	assert.Equal(t, 15*time.Minute, ttl)
 	assert.Equal(t, "", leaseID)
+}
+
+// iamStub answers the IAM calls rotation makes, recording each action. IAM speaks
+// the same query/XML protocol as STS.
+// onCreateKey, when set, runs while the CreateAccessKey call is in flight — the
+// seam a rotation commit needs to land inside a prepare, after it has snapshotted
+// the config and before it builds its result from it.
+func iamStub(t *testing.T, actions *[]string, mu *sync.Mutex, onCreateKey func()) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		action := r.Form.Get("Action")
+		mu.Lock()
+		*actions = append(*actions, action)
+		mu.Unlock()
+
+		if action == "CreateAccessKey" && onCreateKey != nil {
+			onCreateKey()
+		}
+
+		w.Header().Set("Content-Type", "text/xml")
+		switch action {
+		case "ListAccessKeys":
+			_, _ = w.Write([]byte(`<ListAccessKeysResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+  <ListAccessKeysResult><IsTruncated>false</IsTruncated><AccessKeyMetadata>
+    <member><UserName>w</UserName><AccessKeyId>AKIAOLDEXAMPLEKEY000</AccessKeyId><Status>Active</Status></member>
+  </AccessKeyMetadata></ListAccessKeysResult>
+</ListAccessKeysResponse>`))
+		case "CreateAccessKey":
+			_, _ = w.Write([]byte(`<CreateAccessKeyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+  <CreateAccessKeyResult><AccessKey>
+    <UserName>w</UserName><AccessKeyId>AKIAMINTEDEXAMPLE000</AccessKeyId>
+    <SecretAccessKey>minted-secret</SecretAccessKey><Status>Active</Status>
+  </AccessKey></CreateAccessKeyResult>
+</CreateAccessKeyResponse>`))
+		default:
+			_, _ = w.Write([]byte(`<Response xmlns="https://iam.amazonaws.com/doc/2010-05-08/"><ResponseMetadata><RequestId>r</RequestId></ResponseMetadata></Response>`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestAWSDriver_PrepareRotation_UsesOneConfigGeneration pins that prepare builds
+// its result from the config it snapshotted, not from whatever is live when it
+// finishes. Reading the live field would let a commit landing mid-prepare produce
+// a new config derived from one generation while cleanup names another's key.
+func TestAWSDriver_PrepareRotation_UsesOneConfigGeneration(t *testing.T) {
+	stsSrv := newConcurrentSTSStub(t)
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	baseConfig := map[string]string{
+		"access_key_id":     "AKIAOLDEXAMPLEKEY000",
+		"secret_access_key": "old-secret",
+		"region":            "us-east-1",
+		"sts_endpoint":      stsSrv.srv.URL,
+		"activation_delay":  "7m",
+	}
+
+	var awsDrv *AWSDriver
+	var iamActions []string
+	var iamMu sync.Mutex
+
+	// The interloping commit fires while prepare's CreateAccessKey is in flight:
+	// after prepare snapshotted the config, before it builds its result from it.
+	iamSrv := iamStub(t, &iamActions, &iamMu, func() {
+		if err := awsDrv.CommitRotation(context.TODO(), map[string]string{
+			"access_key_id":     "AKIAINTERLOPERKEY000",
+			"secret_access_key": "interloper-secret",
+			"region":            "us-east-1",
+			"sts_endpoint":      stsSrv.srv.URL,
+			"activation_delay":  "99m",
+		}); err != nil {
+			t.Errorf("interloping commit failed: %v", err)
+		}
+	})
+
+	drv, err := (&AWSDriverFactory{}).Create(baseConfig, log)
+	require.NoError(t, err)
+	awsDrv = drv.(*AWSDriver)
+	awsDrv.iamTestEndpoint = iamSrv.URL
+
+	newConfig, cleanupConfig, activateAfter, err := awsDrv.PrepareRotation(context.TODO())
+	require.NoError(t, err)
+
+	// Everything prepare returns must come from one generation: the key it minted,
+	// plus the config it snapshotted — never the one the commit installed midway.
+	assert.Equal(t, "AKIAMINTEDEXAMPLE000", newConfig["access_key_id"])
+	assert.Equal(t, "minted-secret", newConfig["secret_access_key"])
+	assert.Equal(t, "AKIAOLDEXAMPLEKEY000", cleanupConfig["access_key_id"],
+		"cleanup must name the key that was current when prepare snapshotted")
+	assert.Equal(t, "7m", newConfig["activation_delay"],
+		"the carried-over config must come from the same snapshot as the old key id")
+	assert.Equal(t, 7*time.Minute, activateAfter)
+}
+
+// TestAWSDriver_FederatedSecretsManagerUsesConfiguredTransport: the keyless fetch
+// builds its Secrets Manager client per request, so it has to pick up the source's
+// transport too — otherwise the STS leg honours a custom CA and the fetch does not.
+func TestAWSDriver_FederatedSecretsManagerUsesConfiguredTransport(t *testing.T) {
+	var stsActions []string
+	stsSrv := stsStub(t, &stsActions)
+	defer stsSrv.Close()
+
+	var target, authScope string
+	smSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		target, authScope = r.Header.Get("X-Amz-Target"), r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+		_, _ = w.Write([]byte(`{"Name":"prod/app","SecretString":"{\"api_key\":\"federated\"}"}`))
+	}))
+	defer smSrv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"auth_method":             "oidc_federation",
+		"region":                  "us-east-1",
+		"sts_endpoint":            stsSrv.URL,
+		"secretsmanager_endpoint": smSrv.URL,
+		"tls_skip_verify":         "true",
+	}, log)
+	require.NoError(t, err)
+
+	spec := &credential.CredSpec{Name: "sm", Config: map[string]string{
+		"mint_method": "secrets_manager",
+		"secret_id":   "prod/app",
+		"role_arn":    "arn:aws:iam::123456789012:role/App",
+	}}
+	rawData, _, _, _, err := drv.(*AWSDriver).MintCredentialWithExchange(context.TODO(), spec, &credential.ExchangeInputs{
+		SubjectToken:     "eyJ.warden.assertion",
+		SubjectTokenType: credential.TokenTypeJWT,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, target, "GetSecretValue")
+	assert.Contains(t, authScope, "ASIAEXAMPLE")
+	assert.Equal(t, "federated", rawData["api_key"])
 }


### PR DESCRIPTION
Stacked on #601. Corrections to that PR's own code, kept separate so #601's diff stays reviewable on its own terms.

Three real ones.

**`PrepareRotation` still had the race #601 exists to close.** It took a config snapshot and then went on reading the live field two lines later. Worse than a torn read: a commit landing mid-prepare produced a new config derived from one generation while the cleanup config named another generation's key.

**The Secrets Manager client built per request on the keyless path never got the configured transport.** #601's message claims every client carries a 30s HTTP client; that one did not. So the federated fetch stayed unbounded and ignored a custom CA while the STS leg beside it honoured both.

Fixing that surfaced a latent panic: `aws.Config.HTTPClient` is an interface, so a nil `*http.Client` stored in it reads as non-nil to the SDK and panics on first use rather than falling back to a default. Every client now goes through one constructor that sets it only when non-nil.

**The test that claimed to pin the snapshot property pinned nothing.** It scanned every recorded request for the old key, and the probe run at `Create` always puts it there. Deeper: the SigV4 header is captured when the request *arrives*, so a commit fired from the handler could never have changed it — the seam was too late by construction. Replaced with one that takes a generation, rotates underneath it, and checks that generation still signs with its own key, filtering by action.

Both replacement tests were verified to fail with their fix reverted (`99m` instead of `7m`; `certificate signed by unknown authority`). The first version of the rotation test passed on reverted code, which is what prompted moving the commit inside the `CreateAccessKey` call.

### Also

`ca_data` and `tls_skip_verify` are now declared in the schema, since #601 made `Create` consume them — shipping a consumed-but-undeclared key is the same smell as `activation_delay`, which a later PR in this stack fixes. A field on the snapshot struct that nothing read is dropped. `iamTestEndpoint` comes forward from the rotation PR, because the `PrepareRotation` fix is untestable without it.