### PR TITLE
fix(cred): reject malformed STS and IAM responses instead of dereferencing them

### DIFF
--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -13,10 +13,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	rdsauth "github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/redshift"
 	"github.com/aws/aws-sdk-go-v2/service/redshiftserverless"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/logger"
 )
@@ -363,6 +365,9 @@ func (d *AWSDriver) authenticateLocked(ctx context.Context) (*awsClients, error)
 	if err != nil {
 		return nil, fmt.Errorf("failed to assume role %s: %w", assumeRoleArn, err)
 	}
+	if err := validSTSCredentials(result.Credentials, "STS AssumeRole for "+assumeRoleArn); err != nil {
+		return nil, err
+	}
 
 	d.elevatedCreds = &aws.Credentials{
 		AccessKeyID:     *result.Credentials.AccessKeyId,
@@ -423,6 +428,51 @@ func (d *AWSDriver) buildClientsLocked(creds aws.CredentialsProvider) *awsClient
 		redshiftSL: redshiftserverless.NewFromConfig(cfg),
 	}
 	return d.clients
+}
+
+// validSTSCredentials rejects a structurally incomplete credentials block. A
+// malformed 200 — an intercepting proxy, an endpoint override pointed at
+// something that only half speaks the protocol — yields a response whose missing
+// fields the SDK leaves nil, and every consumer here dereferences them. op names
+// the call for the error, which names the first field that is absent.
+//
+// The fields are checked in a fixed order rather than by map iteration so the
+// error a given response produces is always the same one.
+func validSTSCredentials(creds *ststypes.Credentials, op string) error {
+	if creds == nil {
+		return fmt.Errorf("%s returned no credentials block", op)
+	}
+	for _, f := range []struct {
+		name  string
+		value *string
+	}{
+		{"AccessKeyId", creds.AccessKeyId},
+		{"SecretAccessKey", creds.SecretAccessKey},
+		{"SessionToken", creds.SessionToken},
+	} {
+		if f.value == nil {
+			return fmt.Errorf("%s returned credentials with no %s", op, f.name)
+		}
+	}
+	if creds.Expiration == nil {
+		return fmt.Errorf("%s returned credentials with no Expiration", op)
+	}
+	return nil
+}
+
+// validNewIAMAccessKey rejects a CreateAccessKey response that does not carry the
+// key material a rotation is about to persist as the source's only credential.
+func validNewIAMAccessKey(key *iamtypes.AccessKey) error {
+	if key == nil {
+		return fmt.Errorf("IAM CreateAccessKey returned no access key")
+	}
+	if key.AccessKeyId == nil {
+		return fmt.Errorf("IAM CreateAccessKey returned a key with no AccessKeyId")
+	}
+	if key.SecretAccessKey == nil {
+		return fmt.Errorf("IAM CreateAccessKey returned a key with no SecretAccessKey")
+	}
+	return nil
 }
 
 // awsConfig builds the SDK config every client in this driver is constructed
@@ -536,6 +586,9 @@ func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, c *awsClients, spe
 	result, err := c.sts.AssumeRole(ctx, input)
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("STS AssumeRole failed for %s: %w", roleArn, err)
+	}
+	if err := validSTSCredentials(result.Credentials, "STS AssumeRole for "+roleArn); err != nil {
+		return nil, nil, 0, "", err
 	}
 
 	creds := result.Credentials
@@ -725,10 +778,11 @@ func (d *AWSDriver) assumeRoleWithWebIdentity(ctx context.Context, spec *credent
 	if err != nil {
 		return nil, fmt.Errorf("STS AssumeRoleWithWebIdentity failed for %s: %w", roleArn, err)
 	}
-	// A malformed 200 (e.g. an intercepting proxy) can omit the credentials block;
-	// guard here so both consumers dereference a non-nil struct.
-	if result.Credentials == nil {
-		return nil, fmt.Errorf("STS AssumeRoleWithWebIdentity for %s returned no credentials", roleArn)
+	// The single choke point for both consumers: the shaping in credsFromWebIdentity
+	// and the credential provider the federated secret fetch is built from. Checking
+	// the whole block here means neither has to.
+	if err := validSTSCredentials(result.Credentials, "STS AssumeRoleWithWebIdentity for "+roleArn); err != nil {
+		return nil, err
 	}
 	return result, nil
 }
@@ -1068,10 +1122,14 @@ func (d *AWSDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 	}
 	if len(listResult.AccessKeyMetadata) >= 2 {
 		for _, key := range listResult.AccessKeyMetadata {
-			if *key.AccessKeyId != oldAccessKeyID {
+			keyID := aws.ToString(key.AccessKeyId)
+			if keyID == "" {
+				continue
+			}
+			if keyID != oldAccessKeyID {
 				if d.logger != nil {
 					d.logger.Warn("deleting orphaned IAM access key from previous failed rotation",
-						logger.String("orphaned_key_id", truncateID(*key.AccessKeyId, 8)),
+						logger.String("orphaned_key_id", truncateID(keyID, 8)),
 					)
 				}
 				_, err := iamClient.DeleteAccessKey(ctx, &iam.DeleteAccessKeyInput{
@@ -1091,6 +1149,9 @@ func (d *AWSDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 		return nil, nil, 0, fmt.Errorf("failed to create new IAM access key: %w", err)
 	}
 
+	if err := validNewIAMAccessKey(result.AccessKey); err != nil {
+		return nil, nil, 0, err
+	}
 	newKey := result.AccessKey
 
 	// Build new config (copy all, replace key fields). Copied from the snapshot,

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -12,8 +12,10 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/credentials"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/stephnangue/warden/credential"
 	"github.com/stephnangue/warden/credential/types"
 	"github.com/stephnangue/warden/logger"
@@ -1568,4 +1570,259 @@ func TestAWSDriver_FederatedSecretsManagerUsesConfiguredTransport(t *testing.T) 
 	assert.Contains(t, target, "GetSecretValue")
 	assert.Contains(t, authScope, "ASIAEXAMPLE")
 	assert.Equal(t, "federated", rawData["api_key"])
+}
+
+// =============================================================================
+// Malformed responses
+// =============================================================================
+
+func TestValidSTSCredentials(t *testing.T) {
+	full := func() *ststypes.Credentials {
+		return &ststypes.Credentials{
+			AccessKeyId:     aws.String("ASIA"),
+			SecretAccessKey: aws.String("s"),
+			SessionToken:    aws.String("t"),
+			Expiration:      aws.Time(time.Now().Add(time.Hour)),
+		}
+	}
+
+	tests := []struct {
+		name   string
+		creds  func() *ststypes.Credentials
+		errMsg string
+	}{
+		{name: "complete", creds: full},
+		{
+			name:   "no block",
+			creds:  func() *ststypes.Credentials { return nil },
+			errMsg: "returned no credentials block",
+		},
+		{
+			name:   "no access key id",
+			creds:  func() *ststypes.Credentials { c := full(); c.AccessKeyId = nil; return c },
+			errMsg: "no AccessKeyId",
+		},
+		{
+			name:   "no secret access key",
+			creds:  func() *ststypes.Credentials { c := full(); c.SecretAccessKey = nil; return c },
+			errMsg: "no SecretAccessKey",
+		},
+		{
+			name:   "no session token",
+			creds:  func() *ststypes.Credentials { c := full(); c.SessionToken = nil; return c },
+			errMsg: "no SessionToken",
+		},
+		{
+			name:   "no expiration",
+			creds:  func() *ststypes.Credentials { c := full(); c.Expiration = nil; return c },
+			errMsg: "no Expiration",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validSTSCredentials(tt.creds(), "STS AssumeRole for arn:x")
+			if tt.errMsg == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+			assert.Contains(t, err.Error(), "arn:x", "the error must name the call it came from")
+		})
+	}
+}
+
+// malformedSTSStub answers the assume-role calls with the given credentials XML
+// fragment, so a test can omit the block entirely or leave one field out of it.
+// GetCallerIdentity always succeeds, so Create gets far enough to reach the call
+// under test.
+func malformedSTSStub(t *testing.T, credsXML string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "text/xml")
+		switch r.Form.Get("Action") {
+		case "GetCallerIdentity":
+			_, _ = w.Write([]byte(`<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetCallerIdentityResult><Arn>arn:aws:iam::123456789012:user/w</Arn><UserId>AIDA</UserId><Account>123456789012</Account></GetCallerIdentityResult>
+</GetCallerIdentityResponse>`))
+		case "AssumeRoleWithWebIdentity":
+			_, _ = w.Write([]byte(`<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>` + credsXML + `</AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>`))
+		default:
+			_, _ = w.Write([]byte(`<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult>` + credsXML + `</AssumeRoleResult>
+</AssumeRoleResponse>`))
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+const (
+	// noCredentialsBlock is a 200 whose result carries no <Credentials> at all —
+	// the SDK leaves the struct nil.
+	noCredentialsBlock = `<AssumedRoleUser><Arn>arn:aws:sts::1:assumed-role/App/w</Arn><AssumedRoleId>AROA:w</AssumedRoleId></AssumedRoleUser>`
+
+	// partialCredentialsBlock has the struct but omits one field, which the SDK
+	// leaves as a nil pointer inside a non-nil struct.
+	partialCredentialsBlock = `<Credentials>
+      <AccessKeyId>ASIAEXAMPLE</AccessKeyId>
+      <SessionToken>tokenexample</SessionToken>
+      <Expiration>2035-01-01T00:00:00Z</Expiration>
+    </Credentials>`
+)
+
+// TestAWSDriver_MintViaSTSAssumeRole_MalformedResponse: a half-formed 200 must
+// surface as an error naming the missing field, not a panic in the broker.
+func TestAWSDriver_MintViaSTSAssumeRole_MalformedResponse(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		xml    string
+		errMsg string
+	}{
+		{"no credentials block", noCredentialsBlock, "returned no credentials block"},
+		{"missing secret access key", partialCredentialsBlock, "no SecretAccessKey"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := malformedSTSStub(t, tt.xml)
+
+			log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+			drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+				"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
+				"secret_access_key": "secret",
+				"region":            "us-east-1",
+				"sts_endpoint":      srv.URL,
+			}, log)
+			require.NoError(t, err)
+
+			_, _, _, _, err = drv.MintCredential(context.TODO(), &credential.CredSpec{
+				Name: "role",
+				Config: map[string]string{
+					"mint_method": "sts_assume_role",
+					"role_arn":    "arn:aws:iam::123456789012:role/App",
+					"ttl":         "1h",
+				},
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+// TestAWSDriver_WebIdentity_MalformedResponse covers the same on the keyless path.
+// The guard there also protects the credential provider the federated secret fetch
+// is built from, whose fields are read through aws.ToString and would otherwise
+// become empty strings rather than panicking — a request signed with nothing.
+func TestAWSDriver_WebIdentity_MalformedResponse(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		xml    string
+		errMsg string
+	}{
+		{"no credentials block", noCredentialsBlock, "returned no credentials block"},
+		{"missing secret access key", partialCredentialsBlock, "no SecretAccessKey"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := malformedSTSStub(t, tt.xml)
+
+			log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+			drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+				"auth_method":  "oidc_federation",
+				"region":       "us-east-1",
+				"sts_endpoint": srv.URL,
+			}, log)
+			require.NoError(t, err)
+
+			spec := &credential.CredSpec{Name: "wid", Config: map[string]string{
+				"mint_method": "sts_assume_role",
+				"role_arn":    "arn:aws:iam::123456789012:role/App",
+				"ttl":         "15m",
+			}}
+			_, _, _, _, err = drv.(*AWSDriver).MintCredentialWithExchange(context.TODO(), spec,
+				&credential.ExchangeInputs{SubjectToken: "eyJ", SubjectTokenType: credential.TokenTypeJWT})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+// TestAWSDriver_Create_AssumeRoleSource_MalformedResponse: the same guard on the
+// source-creation path, where a nil dereference would take down a write rather
+// than a mint.
+func TestAWSDriver_Create_AssumeRoleSource_MalformedResponse(t *testing.T) {
+	srv := malformedSTSStub(t, noCredentialsBlock)
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	_, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
+		"secret_access_key": "secret",
+		"region":            "us-east-1",
+		"assume_role_arn":   "arn:aws:iam::123456789012:role/WardenSourceRole",
+		"sts_endpoint":      srv.URL,
+	}, log)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "returned no credentials block")
+}
+
+func TestValidNewIAMAccessKey(t *testing.T) {
+	require.NoError(t, validNewIAMAccessKey(&iamtypes.AccessKey{
+		AccessKeyId: aws.String("AKIA"), SecretAccessKey: aws.String("s"),
+	}))
+
+	err := validNewIAMAccessKey(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no access key")
+
+	err = validNewIAMAccessKey(&iamtypes.AccessKey{SecretAccessKey: aws.String("s")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no AccessKeyId")
+
+	err = validNewIAMAccessKey(&iamtypes.AccessKey{AccessKeyId: aws.String("AKIA")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no SecretAccessKey")
+}
+
+// TestAWSDriver_PrepareRotation_MalformedCreateKeyResponse: rotation must refuse a
+// key it cannot fully read rather than persist a half-empty credential as the
+// source's only key.
+func TestAWSDriver_PrepareRotation_MalformedCreateKeyResponse(t *testing.T) {
+	stsSrv := newConcurrentSTSStub(t)
+
+	iamSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Header().Set("Content-Type", "text/xml")
+		if r.Form.Get("Action") == "ListAccessKeys" {
+			_, _ = w.Write([]byte(`<ListAccessKeysResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+  <ListAccessKeysResult><IsTruncated>false</IsTruncated><AccessKeyMetadata>
+    <member><UserName>w</UserName><AccessKeyId>AKIAOLDEXAMPLEKEY000</AccessKeyId><Status>Active</Status></member>
+  </AccessKeyMetadata></ListAccessKeysResult>
+</ListAccessKeysResponse>`))
+			return
+		}
+		// A CreateAccessKey whose key carries no secret.
+		_, _ = w.Write([]byte(`<CreateAccessKeyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+  <CreateAccessKeyResult><AccessKey>
+    <UserName>w</UserName><AccessKeyId>AKIAMINTEDEXAMPLE000</AccessKeyId><Status>Active</Status>
+  </AccessKey></CreateAccessKeyResult>
+</CreateAccessKeyResponse>`))
+	}))
+	defer iamSrv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"access_key_id":     "AKIAOLDEXAMPLEKEY000",
+		"secret_access_key": "old-secret",
+		"region":            "us-east-1",
+		"sts_endpoint":      stsSrv.srv.URL,
+	}, log)
+	require.NoError(t, err)
+	awsDrv := drv.(*AWSDriver)
+	awsDrv.iamTestEndpoint = iamSrv.URL
+
+	_, _, _, err = awsDrv.PrepareRotation(context.TODO())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no SecretAccessKey")
 }


### PR DESCRIPTION
Stacked on #602.

A 200 whose body does not carry everything the protocol promises leaves nil pointers in the decoded response, and the assume-role paths dereferenced them unguarded — a panic in the broker rather than an error on one request. Verified: removing the guard turns the new malformed-response test into `SIGSEGV: segmentation violation`.

The endpoint overrides earlier in this stack make it reachable by configuration: anything that only half speaks the protocol, or an intercepting proxy that rewrites a body, now sits where AWS used to.

### What was already there, and why it wasn't enough

`assumeRoleWithWebIdentity` refused a missing credentials block — but `credsFromWebIdentity` then dereferenced the fields *inside* it, so a response carrying a credentials block without an expiration still panicked. One guard now checks the fields, at the single choke point both consumers flow through.

That choke point also covers the federated secret fetch, which reads those fields through `aws.ToString` and so would not have panicked — it would have built a credentials provider of empty strings and signed its request with nothing. A quieter failure, and arguably the worse one.

Rotation gets the same treatment on the key it is about to persist as the source's only credential, and stops assuming every key in a `ListAccessKeys` response has an id.

Fields are checked in a fixed order so a given response always produces the same error, and each error names the call it came from.

### Verification

First malformed-response tests in the package: an absent credentials block (nil struct) and one missing its secret access key (struct with a nil field), across the static mint, the keyless mint, source creation, and rotation.
