### PR TITLE
fix(cred): stop rotation destroying an IAM key it cannot attribute

### DIFF
--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -3,6 +3,7 @@ package drivers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -906,6 +907,15 @@ func accountIDFromARN(arn string) string {
 // mintViaRDSIAMToken generates a short-lived IAM authentication token for RDS.
 // The token is a pre-signed STS GetCallerIdentity URL that RDS accepts as a password.
 // This is a local SigV4 signing operation — no network call to RDS.
+//
+// The token is a signature, not credential material, so its lifetime is bounded by
+// the signing key rather than by the fifteen minutes reported below: RDS validates
+// the signature at connection time, and cleanup deleting (or deactivating) the key
+// invalidates every token still signed by it. Cleanup runs right after a commit, so
+// a token minted moments earlier can be reported valid for fifteen minutes and be
+// unusable seconds later. Nothing here can see cleanup's schedule; closing the
+// window means delaying source-key cleanup by at least this lifetime, which is the
+// rotation manager's to arrange.
 func (d *AWSDriver) mintViaRDSIAMToken(ctx context.Context, c *awsClients, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	dbEndpoint, err := credential.GetStringRequired(spec.Config, "db_endpoint")
 	if err != nil {
@@ -1098,6 +1108,104 @@ func (d *AWSDriver) SupportsRotation() bool {
 	return strings.HasPrefix(accessKeyID, "AKIA")
 }
 
+// isIAMNoSuchEntity reports whether an error means the key is already gone, which
+// for cleanup is success rather than failure — it is retried on a schedule, and a
+// key deleted out of band should not keep it retrying forever.
+func isIAMNoSuchEntity(err error) bool {
+	var notFound *iamtypes.NoSuchEntityException
+	return errors.As(err, &notFound)
+}
+
+// maxIAMKeysPerUser is the hard cap IAM places on an user's access keys, which is
+// why a rotation has to free a slot before it can mint one.
+const maxIAMKeysPerUser = 2
+
+// makeRoomForNewKey frees a slot so CreateAccessKey can succeed, without
+// destroying a key it cannot attribute to this source's own rotation.
+//
+// It acts only at the cap, touches at most one key per attempt, and deletes only
+// a key that is already Inactive — the state an interrupted cleanup leaves
+// behind, since CleanupRotation now deactivates before it deletes. An Active key
+// that is not the current one is deactivated instead and the attempt stops with
+// an error; the retry finds it Inactive and reclaims the slot. A failed prepare
+// is retried on a backoff starting around twenty seconds, so that detour costs
+// one short retry rather than a rotation period.
+//
+// The alternative — refusing to touch an Active key at all — would wedge rotation
+// permanently, because two paths leave an Active key of this source's own behind:
+// a crash between CreateAccessKey and the staged persist, and a staged activation
+// exhausting its attempts, after which the manager resets to idle and prepares
+// afresh. Deactivating someone else's key is disruptive but reversible; deleting
+// it is not, and that is the trade being made.
+func (d *AWSDriver) makeRoomForNewKey(ctx context.Context, iamClient *iam.Client,
+	currentKeyID string, keys []iamtypes.AccessKeyMetadata) error {
+
+	if len(keys) < maxIAMKeysPerUser {
+		return nil
+	}
+
+	// The current key must be among the ones listed. If it is not, the source's
+	// credentials belong to a different IAM user than the one being listed, so
+	// every key here belongs to someone else — touch none of them and say why.
+	var candidate *iamtypes.AccessKeyMetadata
+	currentFound := false
+	for i := range keys {
+		keyID := aws.ToString(keys[i].AccessKeyId)
+		if keyID == "" {
+			continue
+		}
+		switch {
+		case keyID == currentKeyID:
+			currentFound = true
+		case candidate == nil:
+			candidate = &keys[i]
+		}
+	}
+	if !currentFound {
+		return fmt.Errorf(
+			"IAM user holds %d access keys, none of them the configured access_key_id %s: "+
+				"refusing to remove a key this source does not own",
+			len(keys), truncateID(currentKeyID, 8))
+	}
+	if candidate == nil {
+		return nil
+	}
+	candidateID := aws.ToString(candidate.AccessKeyId)
+
+	if candidate.Status == iamtypes.StatusTypeInactive {
+		if d.logger != nil {
+			d.logger.Warn("deleting inactive orphaned IAM access key from an interrupted rotation",
+				logger.String("orphaned_key_id", truncateID(candidateID, 8)),
+			)
+		}
+		if _, err := iamClient.DeleteAccessKey(ctx, &iam.DeleteAccessKeyInput{
+			AccessKeyId: candidate.AccessKeyId,
+		}); err != nil {
+			return fmt.Errorf("failed to delete orphaned IAM access key %s: %w", truncateID(candidateID, 8), err)
+		}
+		return nil
+	}
+
+	if d.logger != nil {
+		d.logger.Warn("deactivating an active non-current IAM access key to free a rotation slot; "+
+			"it will be deleted on the next rotation attempt",
+			logger.String("key_id", truncateID(candidateID, 8)),
+		)
+	}
+	if _, err := iamClient.UpdateAccessKey(ctx, &iam.UpdateAccessKeyInput{
+		AccessKeyId: candidate.AccessKeyId,
+		Status:      iamtypes.StatusTypeInactive,
+	}); err != nil {
+		return fmt.Errorf("failed to deactivate non-current IAM access key %s: %w", truncateID(candidateID, 8), err)
+	}
+
+	return fmt.Errorf(
+		"IAM user is at the %d-key limit and the non-current key %s was still active; "+
+			"it has been deactivated and will be removed on the next rotation attempt. "+
+			"If it is not this source's, reactivate it and give the source a dedicated IAM user",
+		maxIAMKeysPerUser, truncateID(candidateID, 8))
+}
+
 // PrepareRotation creates a new IAM access key without destroying the old one.
 // Both old and new keys remain valid during the overlap period.
 // Returns activateAfter to allow time for AWS IAM eventual consistency propagation.
@@ -1114,33 +1222,12 @@ func (d *AWSDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 	// Use base credentials (not elevated) for IAM operations on the user's own keys
 	iamClient := d.newIAMClient(baseCreds)
 
-	// IAM users can have max 2 keys. If there are already 2 (e.g., from a
-	// previously failed rotation), delete the orphaned key before creating a new one.
 	listResult, err := iamClient.ListAccessKeys(ctx, &iam.ListAccessKeysInput{})
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("failed to list IAM access keys: %w", err)
 	}
-	if len(listResult.AccessKeyMetadata) >= 2 {
-		for _, key := range listResult.AccessKeyMetadata {
-			keyID := aws.ToString(key.AccessKeyId)
-			if keyID == "" {
-				continue
-			}
-			if keyID != oldAccessKeyID {
-				if d.logger != nil {
-					d.logger.Warn("deleting orphaned IAM access key from previous failed rotation",
-						logger.String("orphaned_key_id", truncateID(keyID, 8)),
-					)
-				}
-				_, err := iamClient.DeleteAccessKey(ctx, &iam.DeleteAccessKeyInput{
-					AccessKeyId: key.AccessKeyId,
-				})
-				if err != nil {
-					return nil, nil, 0, fmt.Errorf("failed to delete orphaned IAM access key: %w", err)
-				}
-				break
-			}
-		}
+	if err := d.makeRoomForNewKey(ctx, iamClient, oldAccessKeyID, listResult.AccessKeyMetadata); err != nil {
+		return nil, nil, 0, err
 	}
 
 	// Create new access key
@@ -1186,28 +1273,38 @@ func (d *AWSDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 // CommitRotation activates the new IAM keys in driver state.
 // Called after the new config has been persisted to storage.
 func (d *AWSDriver) CommitRotation(ctx context.Context, newConfig map[string]string) error {
+	newAccessKeyID := credential.GetString(newConfig, "access_key_id", "")
+	newSecretAccessKey := credential.GetString(newConfig, "secret_access_key", "")
+	newCreds := credentials.NewStaticCredentialsProvider(newAccessKeyID, newSecretAccessKey, "")
+
+	// Verify before touching any driver state, and outside the lock so minting
+	// keeps flowing while IAM answers. On failure this instance is left whole:
+	// in-flight mints holding a generation finish on the credentials they started
+	// with, rather than on a driver switched half-way to a key that does not work.
+	//
+	// That is the whole of what this buys, and it is worth being exact about:
+	// the manager persists the new config before calling here and closes the
+	// driver when it does, so a later request is served by a fresh instance built
+	// from the persisted key whatever this call concludes. Durable state is the
+	// manager's ordering to fix, not this driver's.
+	probe := sts.NewFromConfig(d.awsConfig(newCreds), d.stsOptions())
+	if _, err := probe.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}); err != nil {
+		return fmt.Errorf("failed to authenticate with new IAM keys: %w", err)
+	}
+
 	d.authMu.Lock()
 	defer d.authMu.Unlock()
 
-	// Update internal config
 	d.credSource.Config = newConfig
+	d.baseCreds = newCreds
+	d.baseCredsVerified = true
 
-	// Rebuild base credentials provider
-	newAccessKeyID := credential.GetString(newConfig, "access_key_id", "")
-	newSecretAccessKey := credential.GetString(newConfig, "secret_access_key", "")
-	d.baseCreds = credentials.NewStaticCredentialsProvider(newAccessKeyID, newSecretAccessKey, "")
-
-	// Invalidate elevated session and base-creds flag to force full re-authentication
+	// Drop the elevated session and the client generation built from the old key.
+	// The next mint rebuilds both; for an assume-role source that re-establishes
+	// the session lazily, exactly as it does after an expiry.
 	d.elevatedCreds = nil
 	d.elevatedExpiry = time.Time{}
-	d.baseCredsVerified = false
-
-	// Drop the stale client generation, then re-authenticate to build a new one
-	// (we already hold authMu, so use the locked variant).
 	d.clients = nil
-	if _, err := d.authenticateLocked(ctx); err != nil {
-		return fmt.Errorf("failed to authenticate with new IAM keys: %w", err)
-	}
 
 	if d.logger != nil {
 		d.logger.Debug("committed rotated IAM access key",
@@ -1235,10 +1332,24 @@ func (d *AWSDriver) CleanupRotation(ctx context.Context, cleanupConfig map[strin
 	// Matches PrepareRotation: the user's own keys, from the base credentials.
 	iamClient := d.newIAMClient(baseCreds)
 
+	// Deactivate before deleting, so an interrupted cleanup leaves the key in a
+	// state the next prepare can attribute to this source. A key found Active is
+	// indistinguishable from a stranger's, and prepare will not delete it.
+	if _, err := iamClient.UpdateAccessKey(ctx, &iam.UpdateAccessKeyInput{
+		AccessKeyId: &oldAccessKeyID,
+		Status:      iamtypes.StatusTypeInactive,
+	}); err != nil && !isIAMNoSuchEntity(err) {
+		return fmt.Errorf("failed to deactivate old IAM access key %s: %w", truncateID(oldAccessKeyID, 8), err)
+	}
+
 	_, err := iamClient.DeleteAccessKey(ctx, &iam.DeleteAccessKeyInput{
 		AccessKeyId: &oldAccessKeyID,
 	})
 	if err != nil {
+		// Already gone is the outcome cleanup wanted.
+		if isIAMNoSuchEntity(err) {
+			return nil
+		}
 		if d.logger != nil {
 			d.logger.Warn("failed to delete old IAM access key during cleanup",
 				logger.Err(err),

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -1437,31 +1438,70 @@ func TestAWSDriver_MintViaRDSIAMToken_HappyPath(t *testing.T) {
 	assert.Equal(t, "", leaseID)
 }
 
-// iamStub answers the IAM calls rotation makes, recording each action. IAM speaks
-// the same query/XML protocol as STS.
-// onCreateKey, when set, runs while the CreateAccessKey call is in flight — the
-// seam a rotation commit needs to land inside a prepare, after it has snapshotted
-// the config and before it builds its result from it.
-func iamStub(t *testing.T, actions *[]string, mu *sync.Mutex, onCreateKey func()) *httptest.Server {
+// iamKey is one entry the IAM stub reports from ListAccessKeys.
+type iamKey struct {
+	id     string
+	status string // "Active" or "Inactive"
+}
+
+// iamCall is one request the stub saw: the action and the key it named, which is
+// how a test checks that rotation touched the key it meant to and no other.
+type iamCall struct {
+	action string
+	keyID  string
+	status string // the Status parameter, for UpdateAccessKey
+}
+
+// iamStubOpts configures the stub for one test.
+type iamStubOpts struct {
+	keys []iamKey
+	// onCreateKey, when set, runs while the CreateAccessKey call is in flight —
+	// the seam a rotation commit needs to land inside a prepare, after it has
+	// snapshotted the config and before it builds its result from it.
+	onCreateKey func()
+	// noSuchEntity makes every mutating call report the key as already gone.
+	noSuchEntity bool
+}
+
+// iamStub answers the IAM calls rotation makes, recording each one. IAM speaks the
+// same query/XML protocol as STS.
+func iamStub(t *testing.T, calls *[]iamCall, mu *sync.Mutex, opts iamStubOpts) *httptest.Server {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
 		action := r.Form.Get("Action")
 		mu.Lock()
-		*actions = append(*actions, action)
+		*calls = append(*calls, iamCall{
+			action: action,
+			keyID:  r.Form.Get("AccessKeyId"),
+			status: r.Form.Get("Status"),
+		})
 		mu.Unlock()
 
-		if action == "CreateAccessKey" && onCreateKey != nil {
-			onCreateKey()
+		if action == "CreateAccessKey" && opts.onCreateKey != nil {
+			opts.onCreateKey()
 		}
 
 		w.Header().Set("Content-Type", "text/xml")
+
+		if opts.noSuchEntity && (action == "DeleteAccessKey" || action == "UpdateAccessKey") {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`<ErrorResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+  <Error><Type>Sender</Type><Code>NoSuchEntity</Code><Message>key not found</Message></Error>
+</ErrorResponse>`))
+			return
+		}
+
 		switch action {
 		case "ListAccessKeys":
+			members := ""
+			for _, k := range opts.keys {
+				members += `<member><UserName>w</UserName><AccessKeyId>` + k.id +
+					`</AccessKeyId><Status>` + k.status + `</Status></member>`
+			}
 			_, _ = w.Write([]byte(`<ListAccessKeysResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
-  <ListAccessKeysResult><IsTruncated>false</IsTruncated><AccessKeyMetadata>
-    <member><UserName>w</UserName><AccessKeyId>AKIAOLDEXAMPLEKEY000</AccessKeyId><Status>Active</Status></member>
-  </AccessKeyMetadata></ListAccessKeysResult>
+  <ListAccessKeysResult><IsTruncated>false</IsTruncated><AccessKeyMetadata>` + members +
+				`</AccessKeyMetadata></ListAccessKeysResult>
 </ListAccessKeysResponse>`))
 		case "CreateAccessKey":
 			_, _ = w.Write([]byte(`<CreateAccessKeyResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
@@ -1495,21 +1535,24 @@ func TestAWSDriver_PrepareRotation_UsesOneConfigGeneration(t *testing.T) {
 	}
 
 	var awsDrv *AWSDriver
-	var iamActions []string
+	var iamCalls []iamCall
 	var iamMu sync.Mutex
 
 	// The interloping commit fires while prepare's CreateAccessKey is in flight:
 	// after prepare snapshotted the config, before it builds its result from it.
-	iamSrv := iamStub(t, &iamActions, &iamMu, func() {
-		if err := awsDrv.CommitRotation(context.TODO(), map[string]string{
-			"access_key_id":     "AKIAINTERLOPERKEY000",
-			"secret_access_key": "interloper-secret",
-			"region":            "us-east-1",
-			"sts_endpoint":      stsSrv.srv.URL,
-			"activation_delay":  "99m",
-		}); err != nil {
-			t.Errorf("interloping commit failed: %v", err)
-		}
+	iamSrv := iamStub(t, &iamCalls, &iamMu, iamStubOpts{
+		keys: []iamKey{{id: "AKIAOLDEXAMPLEKEY000", status: "Active"}},
+		onCreateKey: func() {
+			if err := awsDrv.CommitRotation(context.TODO(), map[string]string{
+				"access_key_id":     "AKIAINTERLOPERKEY000",
+				"secret_access_key": "interloper-secret",
+				"region":            "us-east-1",
+				"sts_endpoint":      stsSrv.srv.URL,
+				"activation_delay":  "99m",
+			}); err != nil {
+				t.Errorf("interloping commit failed: %v", err)
+			}
+		},
 	})
 
 	drv, err := (&AWSDriverFactory{}).Create(baseConfig, log)
@@ -1825,4 +1868,265 @@ func TestAWSDriver_PrepareRotation_MalformedCreateKeyResponse(t *testing.T) {
 	_, _, _, err = awsDrv.PrepareRotation(context.TODO())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no SecretAccessKey")
+}
+
+// =============================================================================
+// Rotation safety
+// =============================================================================
+
+// rotationDriver builds a driver wired to an STS stub and the given IAM stub,
+// configured with a rotatable (AKIA-prefixed) key.
+func rotationDriver(t *testing.T, stsURL, iamURL, accessKeyID string) *AWSDriver {
+	t.Helper()
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"access_key_id":     accessKeyID,
+		"secret_access_key": "old-secret",
+		"region":            "us-east-1",
+		"sts_endpoint":      stsURL,
+	}, log)
+	require.NoError(t, err)
+	awsDrv := drv.(*AWSDriver)
+	awsDrv.iamTestEndpoint = iamURL
+	return awsDrv
+}
+
+func iamActionsOf(calls []iamCall) []string {
+	out := make([]string, 0, len(calls))
+	for _, c := range calls {
+		out = append(out, c.action)
+	}
+	return out
+}
+
+// TestAWSDriver_PrepareRotation_RefusesUnownedKeyList: if the configured key is not
+// among the ones listed, the source's credentials belong to a different IAM user
+// than the one being listed. Every key there is someone else's, so touch none.
+func TestAWSDriver_PrepareRotation_RefusesUnownedKeyList(t *testing.T) {
+	stsSrv := newConcurrentSTSStub(t)
+	var calls []iamCall
+	var mu sync.Mutex
+	iamSrv := iamStub(t, &calls, &mu, iamStubOpts{keys: []iamKey{
+		{id: "AKIASTRANGERONE00000", status: "Active"},
+		{id: "AKIASTRANGERTWO00000", status: "Active"},
+	}})
+
+	awsDrv := rotationDriver(t, stsSrv.srv.URL, iamSrv.URL, "AKIAOLDEXAMPLEKEY000")
+
+	_, _, _, err := awsDrv.PrepareRotation(context.TODO())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "refusing to remove a key this source does not own")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"ListAccessKeys"}, iamActionsOf(calls),
+		"a list it does not recognise must be read and nothing else")
+}
+
+// TestAWSDriver_PrepareRotation_DeactivatesActiveStranger: an active non-current
+// key is disabled rather than destroyed, and the attempt stops so the retry can
+// reclaim the slot once the key is safely inactive.
+func TestAWSDriver_PrepareRotation_DeactivatesActiveStranger(t *testing.T) {
+	stsSrv := newConcurrentSTSStub(t)
+	var calls []iamCall
+	var mu sync.Mutex
+	iamSrv := iamStub(t, &calls, &mu, iamStubOpts{keys: []iamKey{
+		{id: "AKIAOLDEXAMPLEKEY000", status: "Active"},
+		{id: "AKIASTRANGERONE00000", status: "Active"},
+	}})
+
+	awsDrv := rotationDriver(t, stsSrv.srv.URL, iamSrv.URL, "AKIAOLDEXAMPLEKEY000")
+
+	_, _, _, err := awsDrv.PrepareRotation(context.TODO())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "deactivated and will be removed on the next rotation attempt")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"ListAccessKeys", "UpdateAccessKey"}, iamActionsOf(calls),
+		"nothing may be deleted, and no key minted, on this attempt")
+	assert.Equal(t, "AKIASTRANGERONE00000", calls[1].keyID)
+	assert.Equal(t, "Inactive", calls[1].status)
+}
+
+// TestAWSDriver_PrepareRotation_ReclaimsInactiveOrphan: an inactive non-current key
+// is what an interrupted cleanup leaves behind, so it is attributable and can be
+// deleted to free the slot.
+func TestAWSDriver_PrepareRotation_ReclaimsInactiveOrphan(t *testing.T) {
+	stsSrv := newConcurrentSTSStub(t)
+	var calls []iamCall
+	var mu sync.Mutex
+	iamSrv := iamStub(t, &calls, &mu, iamStubOpts{keys: []iamKey{
+		{id: "AKIAOLDEXAMPLEKEY000", status: "Active"},
+		{id: "AKIAORPHANKEY0000000", status: "Inactive"},
+	}})
+
+	awsDrv := rotationDriver(t, stsSrv.srv.URL, iamSrv.URL, "AKIAOLDEXAMPLEKEY000")
+
+	newConfig, cleanupConfig, _, err := awsDrv.PrepareRotation(context.TODO())
+	require.NoError(t, err)
+	assert.Equal(t, "AKIAMINTEDEXAMPLE000", newConfig["access_key_id"])
+	assert.Equal(t, "AKIAOLDEXAMPLEKEY000", cleanupConfig["access_key_id"])
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"ListAccessKeys", "DeleteAccessKey", "CreateAccessKey"}, iamActionsOf(calls))
+	assert.Equal(t, "AKIAORPHANKEY0000000", calls[1].keyID, "only the orphan may be deleted")
+}
+
+// TestAWSDriver_CommitRotation_VerifyFailureKeepsInstanceOnOldKey: a commit whose
+// verification fails must leave this driver instance whole, so in-flight and
+// subsequent mints on it keep working with the credentials it already had.
+//
+// This is deliberately a claim about the instance, not about what the next request
+// sees: the manager persists the new config and closes the driver before calling
+// commit, so a later request is served by a fresh instance built from the persisted
+// key regardless.
+func TestAWSDriver_CommitRotation_VerifyFailureKeepsInstanceOnOldKey(t *testing.T) {
+	var mu sync.Mutex
+	var requests []stsRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		action, auth := r.Form.Get("Action"), r.Header.Get("Authorization")
+		mu.Lock()
+		requests = append(requests, stsRequest{action: action, scope: auth})
+		mu.Unlock()
+
+		w.Header().Set("Content-Type", "text/xml")
+		// The new key is rejected; the old one still works.
+		if strings.Contains(auth, "AKIANEWEXAMPLEKEY000") {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`<ErrorResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <Error><Type>Sender</Type><Code>InvalidClientTokenId</Code><Message>invalid key</Message></Error>
+</ErrorResponse>`))
+			return
+		}
+		switch action {
+		case "GetCallerIdentity":
+			_, _ = w.Write([]byte(`<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <GetCallerIdentityResult><Arn>arn:aws:iam::123456789012:user/w</Arn><UserId>AIDA</UserId><Account>123456789012</Account></GetCallerIdentityResult>
+</GetCallerIdentityResponse>`))
+		default:
+			_, _ = w.Write([]byte(`<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleResult><Credentials>
+    <AccessKeyId>ASIAEXAMPLE</AccessKeyId><SecretAccessKey>s</SecretAccessKey>
+    <SessionToken>t</SessionToken><Expiration>2035-01-01T00:00:00Z</Expiration>
+  </Credentials><AssumedRoleUser><Arn>arn:aws:sts::1:assumed-role/App/w</Arn><AssumedRoleId>AROA:w</AssumedRoleId></AssumedRoleUser></AssumeRoleResult>
+</AssumeRoleResponse>`))
+		}
+	}))
+	defer srv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"access_key_id":     "AKIAOLDEXAMPLEKEY000",
+		"secret_access_key": "old-secret",
+		"region":            "us-east-1",
+		"sts_endpoint":      srv.URL,
+	}, log)
+	require.NoError(t, err)
+	awsDrv := drv.(*AWSDriver)
+
+	err = awsDrv.CommitRotation(context.TODO(), map[string]string{
+		"access_key_id":     "AKIANEWEXAMPLEKEY000",
+		"secret_access_key": "new-secret",
+		"region":            "us-east-1",
+		"sts_endpoint":      srv.URL,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to authenticate with new IAM keys")
+
+	// The instance still mints, still on the old key.
+	_, _, _, _, err = drv.MintCredential(context.TODO(), &credential.CredSpec{
+		Name: "role",
+		Config: map[string]string{
+			"mint_method": "sts_assume_role",
+			"role_arn":    "arn:aws:iam::123456789012:role/App",
+			"ttl":         "1h",
+		},
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	var lastAssume string
+	for _, r := range requests {
+		if r.action == "AssumeRole" {
+			lastAssume = r.scope
+		}
+	}
+	assert.Contains(t, lastAssume, "AKIAOLDEXAMPLEKEY000",
+		"a failed commit must not leave the instance signing with the key it could not verify")
+}
+
+// TestAWSDriver_CommitRotation_SwapsAfterVerify: the happy path still swaps, and
+// the next mint signs with the new key.
+func TestAWSDriver_CommitRotation_SwapsAfterVerify(t *testing.T) {
+	stub := newConcurrentSTSStub(t)
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"access_key_id":     "AKIAOLDEXAMPLEKEY000",
+		"secret_access_key": "old-secret",
+		"region":            "us-east-1",
+		"sts_endpoint":      stub.srv.URL,
+	}, log)
+	require.NoError(t, err)
+	awsDrv := drv.(*AWSDriver)
+
+	require.NoError(t, awsDrv.CommitRotation(context.TODO(), map[string]string{
+		"access_key_id":     "AKIANEWEXAMPLEKEY000",
+		"secret_access_key": "new-secret",
+		"region":            "us-east-1",
+		"sts_endpoint":      stub.srv.URL,
+	}))
+
+	_, _, _, _, err = drv.MintCredential(context.TODO(), &credential.CredSpec{
+		Name: "role",
+		Config: map[string]string{
+			"mint_method": "sts_assume_role",
+			"role_arn":    "arn:aws:iam::123456789012:role/App",
+			"ttl":         "1h",
+		},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, lastAssumeRoleScope(t, stub), "AKIANEWEXAMPLEKEY000")
+}
+
+// TestAWSDriver_CleanupRotation_DeactivatesThenDeletes: the order is what makes an
+// interrupted cleanup attributable to this source at the next prepare.
+func TestAWSDriver_CleanupRotation_DeactivatesThenDeletes(t *testing.T) {
+	stsSrv := newConcurrentSTSStub(t)
+	var calls []iamCall
+	var mu sync.Mutex
+	iamSrv := iamStub(t, &calls, &mu, iamStubOpts{})
+
+	awsDrv := rotationDriver(t, stsSrv.srv.URL, iamSrv.URL, "AKIANEWEXAMPLEKEY000")
+
+	require.NoError(t, awsDrv.CleanupRotation(context.TODO(), map[string]string{
+		"access_key_id": "AKIAOLDEXAMPLEKEY000",
+	}))
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"UpdateAccessKey", "DeleteAccessKey"}, iamActionsOf(calls))
+	assert.Equal(t, "Inactive", calls[0].status)
+	for _, c := range calls {
+		assert.Equal(t, "AKIAOLDEXAMPLEKEY000", c.keyID)
+	}
+}
+
+// TestAWSDriver_CleanupRotation_ToleratesAlreadyGone: cleanup is retried on a
+// schedule, so a key deleted out of band must not keep it retrying forever.
+func TestAWSDriver_CleanupRotation_ToleratesAlreadyGone(t *testing.T) {
+	stsSrv := newConcurrentSTSStub(t)
+	var calls []iamCall
+	var mu sync.Mutex
+	iamSrv := iamStub(t, &calls, &mu, iamStubOpts{noSuchEntity: true})
+
+	awsDrv := rotationDriver(t, stsSrv.srv.URL, iamSrv.URL, "AKIANEWEXAMPLEKEY000")
+
+	require.NoError(t, awsDrv.CleanupRotation(context.TODO(), map[string]string{
+		"access_key_id": "AKIAOLDEXAMPLEKEY000",
+	}))
 }


### PR DESCRIPTION
Stacked on #603.

At the two-key cap, prepare deleted the first key that was not the configured one, on the assumption it was an orphan from an interrupted rotation. On a shared IAM user that silently destroys another system's key, with a warning log as the only trace.

It now follows the rule the alicloud source already uses, which IAM supports through key status. Only a key that is already **Inactive** is deleted — the state an interrupted cleanup leaves behind, now that cleanup deactivates before it deletes. An Active non-current key is deactivated and the attempt stops; the retry, twenty-odd seconds later, finds it Inactive and reclaims the slot. If the configured key is not in the list at all, the source's credentials belong to a different IAM user than the one being listed, so every key there is someone else's and none is touched.

Refusing to touch Active keys outright was the safer-looking option and would have wedged rotation permanently: a crash between creating a key and persisting it, and a staged activation exhausting its attempts, both leave an Active key of this source's own behind. Deactivating a stranger's key is disruptive and reversible; deleting it is neither. A stranger's key can stay deactivated across roughly hour-long windows if prepare keeps failing.

IAM access keys carry no description field, so the lineage-stamp approach the IBM source uses is not available here.

### Verify-then-commit, and what it actually buys

Commit now verifies the new key before it changes anything, so a verification that fails leaves the instance whole rather than switched to a key that does not work.

Worth being exact, because the obvious claim is false here: the manager persists the new config and **closes the driver** before calling commit, so a later request is served by a fresh instance built from the persisted key either way. What this protects is the mints still running on the instance in hand. A test asserting "the next request sees the old key" would have been green against a property production does not have.

The durable-state exposure — persist-first, then a commit that may fail — is a manager-ordering problem, not a driver one.

### Deferred, deliberately

An RDS token is a *signature*, so its fifteen-minute lease dies the moment cleanup deletes the signing key — and cleanup runs right after a commit. Deactivate-before-delete does not help; deactivation invalidates signatures too. Nothing in the driver can see cleanup's schedule. Recorded in a comment on the mint; the fix is delaying source-key cleanup in `core/rotation.go`.

### Verification

Nine tests, the first in the package to drive rotation against a stub IAM: unowned key list, active stranger, inactive orphan, commit verify-failure, commit happy path, cleanup ordering, already-deleted tolerance. `e2e/rotation` passes unchanged.
