### PR TITLE
fix(cred): validate the aws source config that was silently tolerated

### DIFF
--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -174,12 +176,18 @@ func (f *AWSDriverFactory) ValidateConfig(config map[string]string) error {
 			Example("sts.amazonaws.com"),
 
 		credential.StringField("sts_endpoint").
+			Custom(validateAWSEndpoint).
 			Describe("Override where STS calls are sent, including the credential probe run when this source is written (default: the SDK's regional endpoint). Does not apply to the IAM, Redshift or RDS clients").
 			Example("https://sts.us-east-1.amazonaws.com"),
 
 		credential.StringField("secretsmanager_endpoint").
+			Custom(validateAWSEndpoint).
 			Describe("Override where Secrets Manager calls are sent (default: the SDK's regional endpoint)").
 			Example("https://secretsmanager.us-east-1.amazonaws.com"),
+
+		credential.DurationField("activation_delay").
+			Describe("Wait between creating a new IAM key and activating it, for propagation (default: 5m)").
+			Example("5m"),
 
 		credential.StringField("ca_data").
 			Custom(ValidateCAData).
@@ -215,6 +223,38 @@ func (f *AWSDriverFactory) ValidateConfig(config map[string]string) error {
 		}
 	}
 	return nil
+}
+
+// validateAWSEndpoint checks an endpoint override is a URL the SDK can actually
+// send to. A keyless source runs no probe when it is written, so without this a
+// typo surfaces only on the first request that needs it.
+func validateAWSEndpoint(v string) error {
+	u, err := url.Parse(v)
+	if err != nil {
+		return fmt.Errorf("endpoint is not a valid URL: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("endpoint must use http or https scheme, got: %s", v)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("endpoint has no host: %s", v)
+	}
+	return nil
+}
+
+// ValidateRotationConfig refuses a rotation period on a source whose STS calls are
+// redirected. Rotation acts on the real account through IAM, which deliberately has
+// no override, so a source pointed at a stand-in would mint and verify against it
+// while trying to rotate keys that only exist somewhere else — failing on a loop
+// with no indication of why.
+func (f *AWSDriverFactory) ValidateRotationConfig(config map[string]string) error {
+	if credential.GetString(config, "sts_endpoint", "") == "" &&
+		credential.GetString(config, "secretsmanager_endpoint", "") == "" {
+		return nil
+	}
+	return fmt.Errorf("rotation_period cannot be set on a source that overrides sts_endpoint or " +
+		"secretsmanager_endpoint: rotation manages IAM keys in the real account, which those " +
+		"overrides do not redirect")
 }
 
 // SensitiveConfigFields returns the list of config keys that should be masked in output
@@ -351,12 +391,17 @@ func (d *AWSDriver) authenticateLocked(ctx context.Context) (*awsClients, error)
 	sessionDuration := credential.GetDuration(d.credSource.Config, "session_duration", 1*time.Hour)
 	externalID := credential.GetString(d.credSource.Config, "external_id", "")
 
+	durationSeconds, err := awsSessionSeconds(sessionDuration, "session_duration")
+	if err != nil {
+		return nil, err
+	}
+
 	baseSTS := sts.NewFromConfig(d.awsConfig(d.baseCreds), d.stsOptions())
 
 	input := &sts.AssumeRoleInput{
 		RoleArn:         &assumeRoleArn,
 		RoleSessionName: &sessionName,
-		DurationSeconds: aws.Int32(int32(sessionDuration.Seconds())),
+		DurationSeconds: aws.Int32(durationSeconds),
 	}
 	if externalID != "" {
 		input.ExternalId = &externalID
@@ -555,7 +600,10 @@ func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, c *awsClients, spe
 		return nil, nil, 0, "", err
 	}
 
-	sessionName := credential.GetString(spec.Config, "session_name", fmt.Sprintf("warden-%s", spec.Name))
+	sessionName, err := awsSessionName(spec)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
 
 	ttlStr := credential.GetString(spec.Config, "ttl", "1h")
 	ttl, err := time.ParseDuration(ttlStr)
@@ -571,10 +619,15 @@ func (d *AWSDriver) mintViaSTSAssumeRole(ctx context.Context, c *awsClients, spe
 		return nil, nil, 0, "", fmt.Errorf("requested TTL %s exceeds maximum %s", ttl, spec.MaxTTL)
 	}
 
+	durationSeconds, err := awsSessionSeconds(ttl, "ttl")
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+
 	input := &sts.AssumeRoleInput{
 		RoleArn:         &roleArn,
 		RoleSessionName: &sessionName,
-		DurationSeconds: aws.Int32(int32(ttl.Seconds())),
+		DurationSeconds: aws.Int32(durationSeconds),
 	}
 
 	if extID := credential.GetString(spec.Config, "external_id", ""); extID != "" {
@@ -763,13 +816,20 @@ func (d *AWSDriver) assumeRoleWithWebIdentity(ctx context.Context, spec *credent
 	if err != nil {
 		return nil, err
 	}
-	sessionName := credential.GetString(spec.Config, "session_name", fmt.Sprintf("warden-%s", spec.Name))
+	sessionName, err := awsSessionName(spec)
+	if err != nil {
+		return nil, err
+	}
+	durationSeconds, err := awsSessionSeconds(dur, "ttl")
+	if err != nil {
+		return nil, err
+	}
 
 	input := &sts.AssumeRoleWithWebIdentityInput{
 		RoleArn:          &roleArn,
 		RoleSessionName:  &sessionName,
 		WebIdentityToken: &webIdentityToken,
-		DurationSeconds:  aws.Int32(int32(dur.Seconds())),
+		DurationSeconds:  aws.Int32(durationSeconds),
 	}
 	if policy := credential.GetString(spec.Config, "policy", ""); policy != "" {
 		input.Policy = &policy
@@ -793,7 +853,11 @@ func (d *AWSDriver) assumeRoleWithWebIdentity(ctx context.Context, spec *credent
 // credential (mint_method=sts_assume_role over oidc_federation).
 func (d *AWSDriver) credsFromWebIdentity(spec *credential.CredSpec, result *sts.AssumeRoleWithWebIdentityOutput) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
 	roleArn := credential.GetString(spec.Config, "role_arn", "")
-	sessionName := credential.GetString(spec.Config, "session_name", fmt.Sprintf("warden-%s", spec.Name))
+	// Already validated by assumeRoleWithWebIdentity, which had to send it.
+	sessionName, err := awsSessionName(spec)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
 
 	creds := result.Credentials
 	leaseTTL := time.Until(*creds.Expiration)
@@ -1039,11 +1103,9 @@ func (d *AWSDriver) mintViaRedshiftIAMToken(ctx context.Context, c *awsClients, 
 		deployment = "serverless"
 	}
 
-	leaseTTL := time.Duration(durationSeconds) * time.Second
-	if expiration != nil {
-		if remaining := time.Until(*expiration); remaining > 0 {
-			leaseTTL = remaining
-		}
+	leaseTTL, err := redshiftLeaseTTL(durationSeconds, expiration)
+	if err != nil {
+		return nil, nil, 0, "", err
 	}
 
 	rawData := map[string]interface{}{
@@ -1106,6 +1168,65 @@ func (d *AWSDriver) Cleanup(ctx context.Context) error {
 func (d *AWSDriver) SupportsRotation() bool {
 	accessKeyID := credential.GetString(d.sourceConfig(), "access_key_id", "")
 	return strings.HasPrefix(accessKeyID, "AKIA")
+}
+
+// STS accepts a session duration between 15 minutes and 12 hours. A role's own
+// maximum may be lower, which stays AWS's error to raise — this only rejects what
+// no role could accept.
+const (
+	minSTSSessionDuration = 15 * time.Minute
+	maxSTSSessionDuration = 12 * time.Hour
+)
+
+// awsSessionSeconds converts a session duration for an STS DurationSeconds field.
+// Rejecting out-of-range values here turns an opaque service-side ValidationError
+// into one naming the config key, and stops an absurd duration from wrapping the
+// int32 conversion into a negative number the service would read as something else
+// entirely.
+func awsSessionSeconds(dur time.Duration, field string) (int32, error) {
+	if dur < minSTSSessionDuration {
+		return 0, fmt.Errorf("'%s' must be at least %s (the AWS STS minimum), got %s", field, minSTSSessionDuration, dur)
+	}
+	if dur > maxSTSSessionDuration {
+		return 0, fmt.Errorf("'%s' must be at most %s (the AWS STS maximum), got %s", field, maxSTSSessionDuration, dur)
+	}
+	return int32(dur.Seconds()), nil
+}
+
+// awsSessionNamePattern is the character set and length AWS accepts for a
+// RoleSessionName.
+var awsSessionNamePattern = regexp.MustCompile(`^[\w+=,.@-]{2,64}$`)
+
+// awsSessionName resolves the session name for an assume-role and checks it
+// against what AWS will accept. The default is derived from the spec's name, so a
+// spec named in a way AWS rejects would otherwise fail every mint with a service
+// error that never mentions the spec. Validated rather than sanitised: a silently
+// rewritten session name is what shows up in the audit trail on the other side.
+func awsSessionName(spec *credential.CredSpec) (string, error) {
+	name := credential.GetString(spec.Config, "session_name", fmt.Sprintf("warden-%s", spec.Name))
+	if !awsSessionNamePattern.MatchString(name) {
+		return "", fmt.Errorf(
+			"session name %q is not accepted by AWS (2-64 characters of [A-Za-z0-9_+=,.@-]); "+
+				"set 'session_name' on the spec to override the default derived from its name", name)
+	}
+	return name, nil
+}
+
+// redshiftLeaseTTL derives the lease from what Redshift reported. An expiration
+// already in the past means the credentials are dead on arrival — clock skew, or a
+// cached response — and reporting the full requested duration for them would hand
+// out a lease that was never valid. Mirrors the assume-role path, which rejects a
+// non-positive TTL rather than substituting one.
+func redshiftLeaseTTL(durationSeconds int, expiration *time.Time) (time.Duration, error) {
+	if expiration == nil {
+		return time.Duration(durationSeconds) * time.Second, nil
+	}
+	remaining := time.Until(*expiration)
+	if remaining <= 0 {
+		return 0, fmt.Errorf("Redshift credentials expired at %s, before they could be issued",
+			expiration.UTC().Format(time.RFC3339))
+	}
+	return remaining, nil
 }
 
 // isIAMNoSuchEntity reports whether an error means the key is already gone, which

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -2130,3 +2130,216 @@ func TestAWSDriver_CleanupRotation_ToleratesAlreadyGone(t *testing.T) {
 		"access_key_id": "AKIAOLDEXAMPLEKEY000",
 	}))
 }
+
+// =============================================================================
+// Config validation
+// =============================================================================
+
+func TestAWSSessionSeconds(t *testing.T) {
+	tests := []struct {
+		name   string
+		dur    time.Duration
+		want   int32
+		errMsg string
+	}{
+		{name: "minimum", dur: 15 * time.Minute, want: 900},
+		{name: "typical", dur: time.Hour, want: 3600},
+		{name: "maximum", dur: 12 * time.Hour, want: 43200},
+		{name: "below minimum", dur: 899 * time.Second, errMsg: "at least 15m0s"},
+		{name: "far below minimum", dur: 5 * time.Minute, errMsg: "at least 15m0s"},
+		{name: "above maximum", dur: 12*time.Hour + time.Second, errMsg: "at most 12h0m0s"},
+		// Without the range check this wraps int32 into a negative number, which
+		// the service would read as something else entirely.
+		{name: "would overflow int32", dur: 100000 * time.Hour, errMsg: "at most 12h0m0s"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := awsSessionSeconds(tt.dur, "ttl")
+			if tt.errMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.Contains(t, err.Error(), "'ttl'", "the error must name the config key")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAWSSessionName(t *testing.T) {
+	tests := []struct {
+		name     string
+		specName string
+		override string
+		want     string
+		wantErr  bool
+	}{
+		{name: "derived from spec name", specName: "prod-keys", want: "warden-prod-keys"},
+		{name: "explicit override", specName: "x", override: "my.session@1", want: "my.session@1"},
+		{name: "override at max length", specName: "x", override: strings.Repeat("a", 64), want: strings.Repeat("a", 64)},
+		{name: "override too long", specName: "x", override: strings.Repeat("a", 65), wantErr: true},
+		{name: "override too short", specName: "x", override: "a", wantErr: true},
+		{name: "illegal character", specName: "x", override: "has space", wantErr: true},
+		// A spec name AWS will not accept must be reported against the spec, not
+		// left to fail every mint with a service-side error.
+		{name: "spec name yields an invalid default", specName: "keys/for/prod", wantErr: true},
+		{name: "spec name too long for the default", specName: strings.Repeat("a", 60), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := map[string]string{}
+			if tt.override != "" {
+				cfg["session_name"] = tt.override
+			}
+			got, err := awsSessionName(&credential.CredSpec{Name: tt.specName, Config: cfg})
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "not accepted by AWS")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRedshiftLeaseTTL(t *testing.T) {
+	t.Run("no expiration falls back to the requested duration", func(t *testing.T) {
+		ttl, err := redshiftLeaseTTL(1800, nil)
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Minute, ttl)
+	})
+
+	t.Run("future expiration wins", func(t *testing.T) {
+		exp := time.Now().Add(10 * time.Minute)
+		ttl, err := redshiftLeaseTTL(1800, &exp)
+		require.NoError(t, err)
+		assert.Less(t, ttl, 30*time.Minute)
+		assert.Greater(t, ttl, 9*time.Minute)
+	})
+
+	t.Run("past expiration is an error, not the full duration", func(t *testing.T) {
+		exp := time.Now().Add(-time.Minute)
+		_, err := redshiftLeaseTTL(1800, &exp)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expired")
+	})
+}
+
+// TestAWSDriver_MintViaSTSAssumeRole_TTLBelowSTSMinimum: a sub-15m ttl reaches the
+// operator as an error naming the key, instead of an opaque service rejection.
+func TestAWSDriver_MintViaSTSAssumeRole_TTLBelowSTSMinimum(t *testing.T) {
+	stub := newConcurrentSTSStub(t)
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
+		"secret_access_key": "secret",
+		"region":            "us-east-1",
+		"sts_endpoint":      stub.srv.URL,
+	}, log)
+	require.NoError(t, err)
+
+	_, _, _, _, err = drv.MintCredential(context.TODO(), &credential.CredSpec{
+		Name: "role",
+		Config: map[string]string{
+			"mint_method": "sts_assume_role",
+			"role_arn":    "arn:aws:iam::123456789012:role/App",
+			"ttl":         "5m",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least 15m0s")
+
+	mu := &stub.mu
+	mu.Lock()
+	defer mu.Unlock()
+	for _, r := range stub.requests {
+		assert.NotEqual(t, "AssumeRole", r.action, "an out-of-range ttl must not reach the service")
+	}
+}
+
+func TestAWSValidateConfig_EndpointAndActivationDelay(t *testing.T) {
+	factory := &AWSDriverFactory{}
+	base := func() map[string]string {
+		return map[string]string{
+			"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
+			"secret_access_key": "secret",
+			"region":            "us-east-1",
+		}
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(map[string]string)
+		errMsg string
+	}{
+		{name: "valid activation delay", mutate: func(c map[string]string) { c["activation_delay"] = "10m" }},
+		{
+			name:   "malformed activation delay",
+			mutate: func(c map[string]string) { c["activation_delay"] = "5 minutes" },
+			errMsg: "activation_delay",
+		},
+		{name: "valid endpoints", mutate: func(c map[string]string) {
+			c["sts_endpoint"] = "https://sts.us-east-1.amazonaws.com"
+			c["secretsmanager_endpoint"] = "http://127.0.0.1:4566"
+		}},
+		{
+			name:   "endpoint without a scheme",
+			mutate: func(c map[string]string) { c["sts_endpoint"] = "sts.us-east-1.amazonaws.com" },
+			errMsg: "http or https",
+		},
+		{
+			name:   "endpoint with an unsupported scheme",
+			mutate: func(c map[string]string) { c["secretsmanager_endpoint"] = "ftp://example.com" },
+			errMsg: "http or https",
+		},
+		{
+			name:   "endpoint with no host",
+			mutate: func(c map[string]string) { c["sts_endpoint"] = "https://" },
+			errMsg: "no host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := base()
+			tt.mutate(cfg)
+			err := factory.ValidateConfig(cfg)
+			if tt.errMsg == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMsg)
+		})
+	}
+}
+
+// TestAWSValidateRotationConfig: rotation reaches the real account through IAM,
+// which has no override, so pairing it with a redirected source would loop.
+func TestAWSValidateRotationConfig(t *testing.T) {
+	factory := &AWSDriverFactory{}
+
+	require.NoError(t, factory.ValidateRotationConfig(map[string]string{
+		"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
+		"secret_access_key": "secret",
+		"region":            "us-east-1",
+	}))
+
+	for _, key := range []string{"sts_endpoint", "secretsmanager_endpoint"} {
+		t.Run(key, func(t *testing.T) {
+			err := factory.ValidateRotationConfig(map[string]string{
+				"access_key_id":     "AKIAIOSFODNN7EXAMPLE",
+				"secret_access_key": "secret",
+				"region":            "us-east-1",
+				key:                 "http://127.0.0.1:4566",
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "rotation_period cannot be set")
+		})
+	}
+}


### PR DESCRIPTION
Stacked on #604.

Four things the driver read but never checked, each failing in a way that points away from the cause.

**Session duration** went to STS as a raw `int32` conversion. Below the fifteen-minute minimum it came back as a service validation error naming neither the spec nor the key; above about sixty-eight years it wrapped negative and became a number the service would read as something else entirely. Both now fail against the config key that set them.

**Session name** defaults to the spec's own name, so a spec named in a way AWS does not accept — a slash, or simply long — failed every mint with an error that never mentioned the spec. Validated rather than sanitised: a session name quietly rewritten here is what someone reads out of the audit trail on the far side.

**Redshift** reporting an expiration already in the past kept the full requested duration as the lease, handing out a credential that was never valid. It now errors, matching the assume-role path, which has always refused a non-positive lease rather than substituting one.

**`activation_delay`** was read but never declared, so a value the duration parser could not read silently became the default — the spelling looked honoured and was not.

### Also

The endpoint overrides added at the base of this stack are now validated as URLs, since a keyless source runs no probe when written and a typo would otherwise surface on the first request that needed it.

And `rotation_period` is refused on a source that sets one: rotation reaches the real account through IAM, which those overrides deliberately do not redirect, so the pair would fail on a loop with nothing to point at.

### Verification

Table tests for each helper, including the duration that would wrap `int32` and a spec name that yields an invalid default. New `ValidateConfig` rows for both endpoint keys and `activation_delay`.
