### PR TITLE
feat(cred): resolve claim templates in an aws secret_id

### DIFF
--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -747,7 +747,10 @@ func (d *AWSDriver) MintCredentialWithExchange(ctx context.Context, spec *creden
 			aws.ToString(creds.SecretAccessKey),
 			aws.ToString(creds.SessionToken),
 		)
-		return d.fetchSecret(ctx, d.newSecretsManagerClient(provider), spec)
+		// The claims carried on the exchange are what a templated secret_id
+		// resolves from, so the fetch is scoped to the principals on this request.
+		return d.fetchSecret(ctx, d.newSecretsManagerClient(provider), spec,
+			inputs.UserClaims, inputs.AgentClaims)
 	default:
 		return nil, nil, 0, "", fmt.Errorf("aws: mint_method %q is not supported over auth_method=oidc_federation (supported: sts_assume_role, secrets_manager)", mintMethod)
 	}
@@ -779,6 +782,12 @@ func awsAssertionAudience(sourceCfg map[string]string) (string, bool) {
 func awsAssertionResource(specCfg map[string]string) (string, bool) {
 	switch credential.GetString(specCfg, "mint_method", "") {
 	case "secrets_manager":
+		// A templated secret_id is carried unresolved, as every templated
+		// coordinate is here: this runs before the exchange that produces the
+		// claims it would resolve from. A downstream policy conditioning on this
+		// claim therefore pins the spec, not the individual secret — per-principal
+		// scoping is enforced where the resolved read happens, by the permissions
+		// on the assumed role.
 		if id := credential.GetString(specCfg, "secret_id", ""); id != "" {
 			return "aws-secretsmanager:" + id, true
 		}
@@ -908,14 +917,30 @@ func (d *AWSDriver) newSecretsManagerClient(creds aws.CredentialsProvider) *secr
 
 // mintViaSecretsManager fetches a secret using the source's authenticated client (static
 // auth). The keyless (federation) path fetches with a temp-credential client instead.
+//
+// Neither principal's claims are available here: this path runs when the spec sets no
+// subject_token_source, so nothing on the request was verified into claims. Passing
+// nil means a templated secret_id fails closed rather than being sent literally —
+// which matters, because a store will happily return a secret actually named
+// "prod/{{user.sub}}/keys" to whoever can create one.
 func (d *AWSDriver) mintViaSecretsManager(ctx context.Context, c *awsClients, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	return d.fetchSecret(ctx, c.sm, spec)
+	return d.fetchSecret(ctx, c.sm, spec, nil, nil)
 }
 
 // fetchSecret reads and parses a Secrets Manager secret with the given client. The client
 // may be the source's own (static auth) or one bound to freshly federated credentials.
-func (d *AWSDriver) fetchSecret(ctx context.Context, sm *secretsmanager.Client, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+//
+// userClaims and agentClaims, when non-nil, supply the values for any {{user.<claim>}}
+// or {{agent.<claim>}} token in secret_id, so one spec can serve many callers and each
+// reads only its own secret.
+func (d *AWSDriver) fetchSecret(ctx context.Context, sm *secretsmanager.Client, spec *credential.CredSpec,
+	userClaims, agentClaims map[string]string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+
 	secretID, err := credential.GetStringRequired(spec.Config, "secret_id")
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+	secretID, err = resolveClaimTemplate(secretID, userClaims, agentClaims, "secret_id")
 	if err != nil {
 		return nil, nil, 0, "", err
 	}

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -1176,23 +1176,27 @@ func newConcurrentSTSStub(t *testing.T) *concurrentSTSStub {
 		s.requests = append(s.requests, stsRequest{action: action, scope: r.Header.Get("Authorization")})
 		s.mu.Unlock()
 
+		const credsXML = `<Credentials>
+      <AccessKeyId>ASIAEXAMPLE</AccessKeyId>
+      <SecretAccessKey>secretexample</SecretAccessKey>
+      <SessionToken>tokenexample</SessionToken>
+      <Expiration>2035-01-01T00:00:00Z</Expiration>
+    </Credentials>
+    <AssumedRoleUser><Arn>arn:aws:sts::123456789012:assumed-role/App/w</Arn><AssumedRoleId>AROA:w</AssumedRoleId></AssumedRoleUser>`
+
 		w.Header().Set("Content-Type", "text/xml")
 		switch action {
 		case "GetCallerIdentity":
 			_, _ = w.Write([]byte(`<GetCallerIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
   <GetCallerIdentityResult><Arn>arn:aws:iam::123456789012:user/w</Arn><UserId>AIDA</UserId><Account>123456789012</Account></GetCallerIdentityResult>
 </GetCallerIdentityResponse>`))
+		case "AssumeRoleWithWebIdentity":
+			_, _ = w.Write([]byte(`<AssumeRoleWithWebIdentityResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
+  <AssumeRoleWithWebIdentityResult>` + credsXML + `</AssumeRoleWithWebIdentityResult>
+</AssumeRoleWithWebIdentityResponse>`))
 		default:
 			_, _ = w.Write([]byte(`<AssumeRoleResponse xmlns="https://sts.amazonaws.com/doc/2011-06-15/">
-  <AssumeRoleResult>
-    <Credentials>
-      <AccessKeyId>ASIAEXAMPLE</AccessKeyId>
-      <SecretAccessKey>secretexample</SecretAccessKey>
-      <SessionToken>tokenexample</SessionToken>
-      <Expiration>2035-01-01T00:00:00Z</Expiration>
-    </Credentials>
-    <AssumedRoleUser><Arn>arn:aws:sts::123456789012:assumed-role/App/w</Arn><AssumedRoleId>AROA:w</AssumedRoleId></AssumedRoleUser>
-  </AssumeRoleResult>
+  <AssumeRoleResult>` + credsXML + `</AssumeRoleResult>
 </AssumeRoleResponse>`))
 		}
 	}))
@@ -2342,4 +2346,180 @@ func TestAWSValidateRotationConfig(t *testing.T) {
 			assert.Contains(t, err.Error(), "rotation_period cannot be set")
 		})
 	}
+}
+
+// =============================================================================
+// Templated secret_id
+// =============================================================================
+
+// recordingSMStub records the SecretId of every GetSecretValue it is asked for, so
+// a test can tell which secret a templated spec actually reached for — and whether
+// it reached for one at all.
+func recordingSMStub(t *testing.T, secretIDs *[]string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			SecretId string `json:"SecretId"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		*secretIDs = append(*secretIDs, body.SecretId)
+
+		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+		_, _ = w.Write([]byte(`{"Name":"` + body.SecretId + `","SecretString":"{\"api_key\":\"k-for-` + body.SecretId + `\"}"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// federatedSecretsManagerDriver builds a keyless driver whose STS and Secrets
+// Manager calls both land on stubs.
+func federatedSecretsManagerDriver(t *testing.T, stsURL, smURL string) *AWSDriver {
+	t.Helper()
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"auth_method":             "oidc_federation",
+		"region":                  "us-east-1",
+		"sts_endpoint":            stsURL,
+		"secretsmanager_endpoint": smURL,
+	}, log)
+	require.NoError(t, err)
+	return drv.(*AWSDriver)
+}
+
+func TestAWSDriver_TemplatedSecretID(t *testing.T) {
+	tests := []struct {
+		name        string
+		secretID    string
+		userClaims  map[string]string
+		agentClaims map[string]string
+		wantFetched string
+		errMsg      string
+	}{
+		{
+			name:        "user claim selects the secret",
+			secretID:    "prod/users/{{user.sub}}/datadog",
+			userClaims:  map[string]string{"sub": "alice"},
+			agentClaims: map[string]string{"sub": "runner"},
+			wantFetched: "prod/users/alice/datadog",
+		},
+		{
+			name:        "agent claim selects the secret",
+			secretID:    "prod/agents/{{agent.sub}}/keys",
+			agentClaims: map[string]string{"sub": "build-runner"},
+			wantFetched: "prod/agents/build-runner/keys",
+		},
+		{
+			name:        "both namespaces compose",
+			secretID:    "{{agent.team}}/{{user.sub}}",
+			userClaims:  map[string]string{"sub": "alice"},
+			agentClaims: map[string]string{"team": "platform"},
+			wantFetched: "platform/alice",
+		},
+		{
+			name:        "untemplated id is unchanged",
+			secretID:    "prod/datadog/keys",
+			userClaims:  map[string]string{"sub": "alice"},
+			agentClaims: map[string]string{"sub": "runner"},
+			wantFetched: "prod/datadog/keys",
+		},
+		{
+			// An ARN carries ':' and '/', neither of which the template scanner
+			// touches, so it must pass through byte for byte.
+			name:        "arn form is unchanged",
+			secretID:    "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/datadog-AbCdEf",
+			agentClaims: map[string]string{"sub": "runner"},
+			wantFetched: "arn:aws:secretsmanager:us-east-1:123456789012:secret:prod/datadog-AbCdEf",
+		},
+		{
+			name:        "absent claim fails closed",
+			secretID:    "prod/users/{{user.sub}}/datadog",
+			agentClaims: map[string]string{"sub": "runner"},
+			errMsg:      "absent from the user's projected claims",
+		},
+		{
+			name:        "value that would escape the path fails closed",
+			secretID:    "prod/users/{{user.sub}}/datadog",
+			userClaims:  map[string]string{"sub": "../admin"},
+			agentClaims: map[string]string{"sub": "runner"},
+			errMsg:      "rejected by the allow-list",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stsSrv := newConcurrentSTSStub(t)
+			var fetched []string
+			smSrv := recordingSMStub(t, &fetched)
+
+			drv := federatedSecretsManagerDriver(t, stsSrv.srv.URL, smSrv.URL)
+			spec := &credential.CredSpec{Name: "sm", Config: map[string]string{
+				"mint_method": "secrets_manager",
+				"secret_id":   tt.secretID,
+				"role_arn":    "arn:aws:iam::123456789012:role/App",
+			}}
+
+			rawData, _, _, _, err := drv.MintCredentialWithExchange(context.TODO(), spec,
+				&credential.ExchangeInputs{
+					SubjectToken:     "eyJ.warden.assertion",
+					SubjectTokenType: credential.TokenTypeJWT,
+					UserClaims:       tt.userClaims,
+					AgentClaims:      tt.agentClaims,
+				})
+
+			if tt.errMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.Contains(t, err.Error(), "secret_id", "the error must name the config key")
+				assert.Empty(t, fetched, "a template that cannot be resolved must reach no store")
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, []string{tt.wantFetched}, fetched)
+			assert.Equal(t, "k-for-"+tt.wantFetched, rawData["api_key"])
+		})
+	}
+}
+
+// TestAWSDriver_TemplatedSecretID_StaticPathFailsClosed: the non-exchange path has
+// no verified claims to resolve from, so a templated id must fail rather than be
+// sent as written. A store would return a secret literally named "{{user.sub}}" to
+// anyone able to create one.
+func TestAWSDriver_TemplatedSecretID_StaticPathFailsClosed(t *testing.T) {
+	stsSrv := newConcurrentSTSStub(t)
+	var fetched []string
+	smSrv := recordingSMStub(t, &fetched)
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"access_key_id":           "AKIAIOSFODNN7EXAMPLE",
+		"secret_access_key":       "secret",
+		"region":                  "us-east-1",
+		"sts_endpoint":            stsSrv.srv.URL,
+		"secretsmanager_endpoint": smSrv.URL,
+	}, log)
+	require.NoError(t, err)
+
+	_, _, _, _, err = drv.MintCredential(context.TODO(), &credential.CredSpec{
+		Name: "sm",
+		Config: map[string]string{
+			"mint_method": "secrets_manager",
+			"secret_id":   "prod/users/{{user.sub}}/datadog",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "absent from the user's projected claims")
+	assert.Empty(t, fetched, "nothing may be fetched when the template cannot resolve")
+}
+
+// TestAWSAssertionResource_TemplatedSecretIDStaysRaw pins the deliberate choice:
+// the claim is minted before the exchange that would produce the claims, so it
+// carries the spec's coordinate rather than the resolved one — the same as every
+// other templated coordinate in the assertion layer.
+func TestAWSAssertionResource_TemplatedSecretIDStaysRaw(t *testing.T) {
+	got, ok := awsAssertionResource(map[string]string{
+		"mint_method": "secrets_manager",
+		"secret_id":   "prod/users/{{user.sub}}/datadog",
+	})
+	require.True(t, ok)
+	assert.Equal(t, "aws-secretsmanager:prod/users/{{user.sub}}/datadog", got)
 }

--- a/credential/drivers/claim_template.go
+++ b/credential/drivers/claim_template.go
@@ -1,0 +1,137 @@
+package drivers
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Claim templating lets a spec select what it fetches from the verified claims of
+// the principals on the request, so one spec can serve many callers and each
+// reaches only its own material. It is shared by every driver whose fetch
+// coordinate is a string the operator writes — a secret path, a stored-secret id,
+// a signing key name — and the rules below are the same wherever it is used.
+
+// claimTemplate matches a {{user.<claim>}} or {{agent.<claim>}} token in a request
+// coordinate. The claim name is a conservative identifier (letters, digits, '_',
+// '.', '-').
+//
+// One expression rather than one per principal: every rule that follows a
+// substitution — the value allow-list, the traversal check, the leftover-fragment
+// check — is the same whichever principal supplied the value, and a single pass makes
+// a coordinate mixing both namespaces order-independent.
+var claimTemplate = regexp.MustCompile(`\{\{(user|agent)\.([A-Za-z0-9_.-]+)\}\}`)
+
+// claimTemplatePrefixes are the literal openings claimTemplate can match. Both the
+// fast path and the leftover check scan for them, so a malformed token (a missing
+// brace, an empty claim name) is refused rather than sent as literal bytes.
+var claimTemplatePrefixes = []string{"{{user.", "{{agent."}
+
+// claimValuePattern is the strict allow-list a substituted claim value must
+// match before it can be placed into a request coordinate. It excludes '/' (which
+// would let one value span segments) and every other separator. '.' is allowed
+// (e.g. first.last), so a value or adjacent values could still compose a "."/".."
+// segment — that is caught after substitution by the segment check below, not here.
+var claimValuePattern = regexp.MustCompile(`^[A-Za-z0-9._@-]+$`)
+
+// containsClaimTemplate reports whether raw opens either namespace's token.
+func containsClaimTemplate(raw string) bool {
+	for _, prefix := range claimTemplatePrefixes {
+		if strings.Contains(raw, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolveClaimTemplate substitutes any {{user.<claim>}} or {{agent.<claim>}} token in
+// raw from the projected claims of the principal each names. A value with no such
+// token is returned verbatim (byte-identical to the pre-templating behaviour). It FAILS
+// CLOSED when a referenced claim is absent, when a value is empty or not in the strict
+// allow-list, or when the RESOLVED value contains a "." / ".." segment or a leftover
+// template fragment.
+//
+// The last check is the real boundary. A coordinate is frequently a path, and a
+// client that cleans one before sending it would resolve a claim value of "."
+// (which collapses its segment) or two adjacent tokens composing ".." into a
+// different, likely shared or parent, target — so a per-principal value that could
+// compose one must deny instead. field names the config key for error messages.
+func resolveClaimTemplate(raw string, userClaims, agentClaims map[string]string, field string) (string, error) {
+	if !containsClaimTemplate(raw) {
+		return raw, nil
+	}
+	// Deliberately NOT an ErrUserRequired case, however tempting: an empty claim
+	// map does not mean the request lacked a principal. Claims are projected only
+	// when the spec opts in, and when it does, core has already rejected a
+	// principal-less request before the driver runs — and a present principal
+	// always yields at least "sub". So reaching here with no claims means the
+	// spec structurally cannot project any, which no amount of authenticating
+	// will change. Returning a 401 challenge would send the caller into an OAuth
+	// loop it cannot escape while hiding the real fix from the operator. That
+	// holds doubly for the agent, which is present on every request.
+	var subErr error
+	resolved := claimTemplate.ReplaceAllStringFunc(raw, func(match string) string {
+		groups := claimTemplate.FindStringSubmatch(match)
+		principal, claim := groups[1], groups[2]
+
+		claims, fix := userClaims, "list it in assertion_user_claims, which requires subject_token_source=warden_identity"
+		if principal == "agent" {
+			claims = agentClaims
+			switch {
+			case len(agentClaims) == 0:
+				// Nothing was projected at all, so the subject source is the fault,
+				// not the list — and for "sub", which needs no listing, it is the
+				// only possible fault. Sending an operator to the allow-list here
+				// would have them add an entry that changes nothing.
+				fix = "the agent's claims are projected only when subject_token_source is agent_identity or warden_identity"
+			case claim == "sub":
+				// Projection ran and still produced no sub. It is written
+				// unconditionally from the principal, so this is unreachable
+				// short of a construction bug — say that rather than blame config.
+				fix = "the agent's principal is always projected, so this indicates an internal error rather than a configuration one"
+			default:
+				// Projection ran without this claim. Listing it is necessary but
+				// may not be sufficient: an absent metadata key is skipped rather
+				// than rejected, so the login may simply not carry it.
+				fix = "list it in assertion_metadata_claims, and check the agent's login provides it"
+			}
+		}
+
+		v, ok := claims[claim]
+		if !ok {
+			// The principal IS present; this claim was simply never projected. For
+			// the user, note that assertion_user_claims only applies to a
+			// warden_identity subject — pairing {{user.…}} with
+			// subject_token_source=user_identity cannot populate claims at all,
+			// which is the likelier mistake.
+			subErr = fmt.Errorf("%s references {{%s.%s}} but that claim is absent from the %s's projected claims (%s)",
+				field, principal, claim, principal, fix)
+			return ""
+		}
+		// The value becomes request bytes: a single non-empty allow-listed token
+		// that cannot span segments (no '/'). Dot-only / traversal segments it might
+		// compose are rejected after substitution.
+		if v == "" || !claimValuePattern.MatchString(v) {
+			subErr = fmt.Errorf("%s claim %q has a value rejected by the allow-list", field, claim)
+			return ""
+		}
+		return v
+	})
+	if subErr != nil {
+		return "", subErr
+	}
+	// A leftover fragment means a malformed token (e.g. a missing brace or an empty
+	// claim name) — fail closed rather than use a literal "{{user.…" value.
+	if containsClaimTemplate(resolved) {
+		return "", fmt.Errorf("%s has an unresolved template fragment after substitution", field)
+	}
+	// Reject any "." or ".." segment the substituted value(s) may have composed —
+	// a client that cleans the coordinate would otherwise resolve it into a
+	// different target.
+	for _, seg := range strings.Split(resolved, "/") {
+		if seg == "." || seg == ".." {
+			return "", fmt.Errorf("%s resolves to a %q path segment (traversal)", field, seg)
+		}
+	}
+	return resolved, nil
+}

--- a/credential/drivers/claim_template_test.go
+++ b/credential/drivers/claim_template_test.go
@@ -1,0 +1,133 @@
+package drivers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The tests below exercise the shared claim-templating mechanism through
+// resolveSecretPath, the thin alias the KV read uses. They moved here with the
+// mechanism itself; what they cover is the rule set, not that one caller.
+
+// TestResolveSecretPath covers per-user secret_path templating and its fail-closed
+// sanitization (the security boundary that keeps one user from reading another's
+// secret or escaping the intended path).
+func TestResolveSecretPath(t *testing.T) {
+	claims := map[string]string{"username": "alice", "email": "alice@example.com", "dept": "eng-team"}
+	agentClaims := map[string]string{"sub": "build-runner", "team": "platform"}
+
+	tests := []struct {
+		name    string
+		path    string
+		claims  map[string]string
+		agent   map[string]string
+		want    string
+		wantErr string
+	}{
+		{"no template returned verbatim", "slack/refresh_token", claims, agentClaims, "slack/refresh_token", ""},
+		{"no template needs no claims", "slack/refresh_token", nil, agentClaims, "slack/refresh_token", ""},
+		{"single substitution", "slack/{{user.username}}/refresh_token", claims, agentClaims, "slack/alice/refresh_token", ""},
+		{"multiple tokens resolved", "{{user.username}}/{{user.dept}}", claims, agentClaims, "alice/eng-team", ""},
+		{"email value allowed", "kv/{{user.email}}", claims, agentClaims, "kv/alice@example.com", ""},
+		{"hyphen value allowed", "kv/{{user.dept}}", claims, agentClaims, "kv/eng-team", ""},
+		{"literal dots within a segment allowed", "kv/{{user.username}}", map[string]string{"username": "a..b"}, agentClaims, "kv/a..b", ""},
+		// Both are spec/config mismatches, not missing-user cases: claims are
+		// projected only when the spec asks for them, and core rejects a
+		// user-less request before the driver runs. Neither is fixed by
+		// authenticating, so neither may carry a 401 challenge.
+		{"absent claim fails closed", "slack/{{user.missing}}/x", claims, agentClaims, "", "absent"},
+		{"nil claims with template fails closed", "slack/{{user.username}}/x", nil, agentClaims, "", "absent"},
+		{"slash in value rejected", "kv/{{user.username}}", map[string]string{"username": "a/b"}, agentClaims, "", "allow-list"},
+		{"curly brace in value rejected", "kv/{{user.username}}", map[string]string{"username": "a{b"}, agentClaims, "", "allow-list"},
+		{"empty value rejected", "kv/{{user.username}}", map[string]string{"username": ""}, agentClaims, "", "allow-list"},
+		// The security boundary: values that compose a "." or ".." segment which the
+		// Vault client's path.Clean would resolve into a shared/parent path.
+		{"dot value collapses a segment", "slack/{{user.username}}/rt", map[string]string{"username": "."}, agentClaims, "", "traversal"},
+		{"dotdot value traverses", "slack/{{user.username}}/rt", map[string]string{"username": ".."}, agentClaims, "", "traversal"},
+		{"adjacent tokens compose dotdot", "slack/{{user.a}}{{user.b}}/rt", map[string]string{"a": ".", "b": "."}, agentClaims, "", "traversal"},
+		{"unresolved fragment fails closed", "slack/{{user.username}/rt", map[string]string{"username": "alice"}, agentClaims, "", "unresolved"},
+
+		// The agent namespace. Same rules and same failure modes — only the map a
+		// value is looked up in differs.
+		{"agent sub substitution", "agents/{{agent.sub}}/key", claims, agentClaims, "agents/build-runner/key", ""},
+		{"agent metadata substitution", "teams/{{agent.team}}/key", claims, agentClaims, "teams/platform/key", ""},
+		{"both namespaces compose", "teams/{{agent.team}}/users/{{user.username}}", claims, agentClaims, "teams/platform/users/alice", ""},
+		{"absent agent claim fails closed", "agents/{{agent.missing}}/k", claims, agentClaims, "", "absent"},
+		{"nil agent claims with template fails closed", "agents/{{agent.sub}}/k", claims, nil, "", "absent"},
+		{"slash in agent value rejected", "kv/{{agent.team}}", claims, map[string]string{"team": "a/b"}, "", "allow-list"},
+		{"empty agent value rejected", "kv/{{agent.team}}", claims, map[string]string{"team": ""}, "", "allow-list"},
+		{"agent dotdot value traverses", "kv/{{agent.team}}/x", claims, map[string]string{"team": ".."}, "", "traversal"},
+		{"agent and user values compose dotdot", "kv/{{agent.team}}{{user.a}}/x", map[string]string{"a": "."}, map[string]string{"team": "."}, "", "traversal"},
+		{"unresolved agent fragment fails closed", "agents/{{agent.sub}/k", claims, agentClaims, "", "unresolved"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveSecretPath(tt.path, tt.claims, tt.agent)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestVaultDriver_OAuth2_PerUserCredentialName proves the oauth2 mint method templates
+
+// The absent-claim error has to name the config key that fixes it, and the two
+// namespaces are fixed by different keys — an operator who reads "absent" without
+// being told where to list it has to guess.
+func TestResolveSecretPath_AbsentClaimNamesItsOwnConfigKey(t *testing.T) {
+	_, err := resolveSecretPath("kv/{{user.missing}}", map[string]string{"sub": "u"}, map[string]string{"sub": "a"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "assertion_user_claims")
+
+	_, err = resolveSecretPath("kv/{{agent.missing}}", map[string]string{"sub": "u"}, map[string]string{"sub": "a"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "assertion_metadata_claims")
+	assert.NotContains(t, err.Error(), "assertion_user_claims",
+		"the agent's guidance must not point at the user's config key")
+}
+
+// The guidance has to match which of the three ways it failed, or it sends the
+// operator to a config change that cannot help.
+func TestResolveSecretPath_AgentGuidanceMatchesTheFailure(t *testing.T) {
+	t.Run("nothing projected blames the subject source", func(t *testing.T) {
+		_, err := resolveSecretPath("kv/{{agent.sub}}", nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "subject_token_source")
+		assert.NotContains(t, err.Error(), "list it in assertion_metadata_claims",
+			"sub needs no allow-list entry, so telling an operator to add one is a dead end")
+	})
+	t.Run("a missing metadata claim blames the list and the login", func(t *testing.T) {
+		_, err := resolveSecretPath("kv/{{agent.team}}", nil, map[string]string{"sub": "a"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "assertion_metadata_claims")
+		assert.Contains(t, err.Error(), "login",
+			"listing the claim is necessary but not sufficient — an absent one is skipped, not rejected")
+	})
+}
+
+// A path with no template must come back byte-identical whatever the claim maps
+// hold — the guarantee that adding this feature changed nothing for specs that do
+// not use it.
+func TestResolveSecretPath_UntemplatedIsByteIdentical(t *testing.T) {
+	const raw = "kv/data/service/config"
+	for _, maps := range []struct {
+		name        string
+		user, agent map[string]string
+	}{
+		{"both nil", nil, nil},
+		{"both populated", map[string]string{"sub": "u"}, map[string]string{"sub": "a"}},
+	} {
+		t.Run(maps.name, func(t *testing.T) {
+			got, err := resolveSecretPath(raw, maps.user, maps.agent)
+			require.NoError(t, err)
+			assert.Equal(t, raw, got)
+		})
+	}
+}

--- a/credential/drivers/vault_driver.go
+++ b/credential/drivers/vault_driver.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -583,132 +582,11 @@ func (d *VaultDriver) revokeLoginToken(accessor string, client *api.Client) {
 	}
 }
 
-// claimTemplate matches a {{user.<claim>}} or {{agent.<claim>}} token in a request
-// path. The claim name is a conservative identifier (letters, digits, '_', '.', '-').
-//
-// One expression rather than one per principal: every rule that follows a
-// substitution — the value allow-list, the traversal check, the leftover-fragment
-// check — is the same whichever principal supplied the value, and a single pass makes
-// a path mixing both namespaces order-independent.
-var claimTemplate = regexp.MustCompile(`\{\{(user|agent)\.([A-Za-z0-9_.-]+)\}\}`)
-
-// claimTemplatePrefixes are the literal openings claimTemplate can match. Both the
-// fast path and the leftover check scan for them, so a malformed token (a missing
-// brace, an empty claim name) is refused rather than sent as literal path bytes.
-var claimTemplatePrefixes = []string{"{{user.", "{{agent."}
-
-// claimValuePattern is the strict allow-list a substituted claim value must
-// match before it can be placed into a KV path segment. It excludes '/' (which
-// would let one value span segments) and every other separator. '.' is allowed
-// (e.g. first.last), so a value or adjacent values could still compose a "."/".."
-// segment — that is caught after substitution by the segment check below, not here.
-var claimValuePattern = regexp.MustCompile(`^[A-Za-z0-9._@-]+$`)
-
 // resolveSecretPath returns the KV secret path for a kv2_read, substituting any
 // {{user.<claim>}} or {{agent.<claim>}} token from the projected claims. See
 // resolveClaimTemplate for the fail-closed rules.
 func resolveSecretPath(rawPath string, userClaims, agentClaims map[string]string) (string, error) {
 	return resolveClaimTemplate(rawPath, userClaims, agentClaims, "secret_path")
-}
-
-// containsClaimTemplate reports whether raw opens either namespace's token.
-func containsClaimTemplate(raw string) bool {
-	for _, prefix := range claimTemplatePrefixes {
-		if strings.Contains(raw, prefix) {
-			return true
-		}
-	}
-	return false
-}
-
-// resolveClaimTemplate substitutes any {{user.<claim>}} or {{agent.<claim>}} token in
-// raw from the projected claims of the principal each names, for a Vault request path
-// segment (a KV secret_path, an OAuth engine credential_name, …). A value with no such
-// token is returned verbatim (byte-identical to the pre-templating behaviour). It FAILS
-// CLOSED when a referenced claim is absent, when a value is empty or not in the strict
-// allow-list, or when the RESOLVED value contains a "." / ".." segment or a leftover
-// template fragment. The last check is the real boundary: the Vault API client runs
-// path.Clean on the request path, so a claim value of "." (which collapses its segment)
-// or two adjacent tokens composing ".." would otherwise silently retarget the request at
-// a shared/parent path — the per-principal value must deny instead. field names the
-// config key for error messages.
-func resolveClaimTemplate(raw string, userClaims, agentClaims map[string]string, field string) (string, error) {
-	if !containsClaimTemplate(raw) {
-		return raw, nil
-	}
-	// Deliberately NOT an ErrUserRequired case, however tempting: an empty claim
-	// map does not mean the request lacked a principal. Claims are projected only
-	// when the spec opts in, and when it does, core has already rejected a
-	// principal-less request before the driver runs — and a present principal
-	// always yields at least "sub". So reaching here with no claims means the
-	// spec structurally cannot project any, which no amount of authenticating
-	// will change. Returning a 401 challenge would send the caller into an OAuth
-	// loop it cannot escape while hiding the real fix from the operator. That
-	// holds doubly for the agent, which is present on every request.
-	var subErr error
-	resolved := claimTemplate.ReplaceAllStringFunc(raw, func(match string) string {
-		groups := claimTemplate.FindStringSubmatch(match)
-		principal, claim := groups[1], groups[2]
-
-		claims, fix := userClaims, "list it in assertion_user_claims, which requires subject_token_source=warden_identity"
-		if principal == "agent" {
-			claims = agentClaims
-			switch {
-			case len(agentClaims) == 0:
-				// Nothing was projected at all, so the subject source is the fault,
-				// not the list — and for "sub", which needs no listing, it is the
-				// only possible fault. Sending an operator to the allow-list here
-				// would have them add an entry that changes nothing.
-				fix = "the agent's claims are projected only when subject_token_source is agent_identity or warden_identity"
-			case claim == "sub":
-				// Projection ran and still produced no sub. It is written
-				// unconditionally from the principal, so this is unreachable
-				// short of a construction bug — say that rather than blame config.
-				fix = "the agent's principal is always projected, so this indicates an internal error rather than a configuration one"
-			default:
-				// Projection ran without this claim. Listing it is necessary but
-				// may not be sufficient: an absent metadata key is skipped rather
-				// than rejected, so the login may simply not carry it.
-				fix = "list it in assertion_metadata_claims, and check the agent's login provides it"
-			}
-		}
-
-		v, ok := claims[claim]
-		if !ok {
-			// The principal IS present; this claim was simply never projected. For
-			// the user, note that assertion_user_claims only applies to a
-			// warden_identity subject — pairing {{user.…}} with
-			// subject_token_source=user_identity cannot populate claims at all,
-			// which is the likelier mistake.
-			subErr = fmt.Errorf("%s references {{%s.%s}} but that claim is absent from the %s's projected claims (%s)",
-				field, principal, claim, principal, fix)
-			return ""
-		}
-		// The value becomes path bytes: a single non-empty allow-listed token that
-		// cannot span segments (no '/'). Dot-only / traversal segments it might
-		// compose are rejected after substitution.
-		if v == "" || !claimValuePattern.MatchString(v) {
-			subErr = fmt.Errorf("%s claim %q has a value rejected by the allow-list", field, claim)
-			return ""
-		}
-		return v
-	})
-	if subErr != nil {
-		return "", subErr
-	}
-	// A leftover fragment means a malformed token (e.g. a missing brace or an empty
-	// claim name) — fail closed rather than use a literal "{{user.…" value.
-	if containsClaimTemplate(resolved) {
-		return "", fmt.Errorf("%s has an unresolved template fragment after substitution", field)
-	}
-	// Reject any "." or ".." segment the substituted value(s) may have composed —
-	// path.Clean would otherwise resolve it into a different (shared/parent) path.
-	for _, seg := range strings.Split(resolved, "/") {
-		if seg == "." || seg == ".." {
-			return "", fmt.Errorf("%s resolves to a %q path segment (traversal)", field, seg)
-		}
-	}
-	return resolved, nil
 }
 
 // fetchStaticKVSecret fetches static secrets from Vault KV v2. userClaims and

--- a/credential/drivers/vault_driver_test.go
+++ b/credential/drivers/vault_driver_test.go
@@ -1130,72 +1130,6 @@ func TestVaultDriver_MintCredentialWithExchange_UnsupportedMintMethod(t *testing
 	assert.Contains(t, err.Error(), "not supported over auth_method=oidc_federation")
 }
 
-// TestResolveSecretPath covers per-user secret_path templating and its fail-closed
-// sanitization (the security boundary that keeps one user from reading another's
-// secret or escaping the intended path).
-func TestResolveSecretPath(t *testing.T) {
-	claims := map[string]string{"username": "alice", "email": "alice@example.com", "dept": "eng-team"}
-	agentClaims := map[string]string{"sub": "build-runner", "team": "platform"}
-
-	tests := []struct {
-		name    string
-		path    string
-		claims  map[string]string
-		agent   map[string]string
-		want    string
-		wantErr string
-	}{
-		{"no template returned verbatim", "slack/refresh_token", claims, agentClaims, "slack/refresh_token", ""},
-		{"no template needs no claims", "slack/refresh_token", nil, agentClaims, "slack/refresh_token", ""},
-		{"single substitution", "slack/{{user.username}}/refresh_token", claims, agentClaims, "slack/alice/refresh_token", ""},
-		{"multiple tokens resolved", "{{user.username}}/{{user.dept}}", claims, agentClaims, "alice/eng-team", ""},
-		{"email value allowed", "kv/{{user.email}}", claims, agentClaims, "kv/alice@example.com", ""},
-		{"hyphen value allowed", "kv/{{user.dept}}", claims, agentClaims, "kv/eng-team", ""},
-		{"literal dots within a segment allowed", "kv/{{user.username}}", map[string]string{"username": "a..b"}, agentClaims, "kv/a..b", ""},
-		// Both are spec/config mismatches, not missing-user cases: claims are
-		// projected only when the spec asks for them, and core rejects a
-		// user-less request before the driver runs. Neither is fixed by
-		// authenticating, so neither may carry a 401 challenge.
-		{"absent claim fails closed", "slack/{{user.missing}}/x", claims, agentClaims, "", "absent"},
-		{"nil claims with template fails closed", "slack/{{user.username}}/x", nil, agentClaims, "", "absent"},
-		{"slash in value rejected", "kv/{{user.username}}", map[string]string{"username": "a/b"}, agentClaims, "", "allow-list"},
-		{"curly brace in value rejected", "kv/{{user.username}}", map[string]string{"username": "a{b"}, agentClaims, "", "allow-list"},
-		{"empty value rejected", "kv/{{user.username}}", map[string]string{"username": ""}, agentClaims, "", "allow-list"},
-		// The security boundary: values that compose a "." or ".." segment which the
-		// Vault client's path.Clean would resolve into a shared/parent path.
-		{"dot value collapses a segment", "slack/{{user.username}}/rt", map[string]string{"username": "."}, agentClaims, "", "traversal"},
-		{"dotdot value traverses", "slack/{{user.username}}/rt", map[string]string{"username": ".."}, agentClaims, "", "traversal"},
-		{"adjacent tokens compose dotdot", "slack/{{user.a}}{{user.b}}/rt", map[string]string{"a": ".", "b": "."}, agentClaims, "", "traversal"},
-		{"unresolved fragment fails closed", "slack/{{user.username}/rt", map[string]string{"username": "alice"}, agentClaims, "", "unresolved"},
-
-		// The agent namespace. Same rules and same failure modes — only the map a
-		// value is looked up in differs.
-		{"agent sub substitution", "agents/{{agent.sub}}/key", claims, agentClaims, "agents/build-runner/key", ""},
-		{"agent metadata substitution", "teams/{{agent.team}}/key", claims, agentClaims, "teams/platform/key", ""},
-		{"both namespaces compose", "teams/{{agent.team}}/users/{{user.username}}", claims, agentClaims, "teams/platform/users/alice", ""},
-		{"absent agent claim fails closed", "agents/{{agent.missing}}/k", claims, agentClaims, "", "absent"},
-		{"nil agent claims with template fails closed", "agents/{{agent.sub}}/k", claims, nil, "", "absent"},
-		{"slash in agent value rejected", "kv/{{agent.team}}", claims, map[string]string{"team": "a/b"}, "", "allow-list"},
-		{"empty agent value rejected", "kv/{{agent.team}}", claims, map[string]string{"team": ""}, "", "allow-list"},
-		{"agent dotdot value traverses", "kv/{{agent.team}}/x", claims, map[string]string{"team": ".."}, "", "traversal"},
-		{"agent and user values compose dotdot", "kv/{{agent.team}}{{user.a}}/x", map[string]string{"a": "."}, map[string]string{"team": "."}, "", "traversal"},
-		{"unresolved agent fragment fails closed", "agents/{{agent.sub}/k", claims, agentClaims, "", "unresolved"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := resolveSecretPath(tt.path, tt.claims, tt.agent)
-			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
-				return
-			}
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-// TestVaultDriver_OAuth2_PerUserCredentialName proves the oauth2 mint method templates
 // credential_name from the caller's projected claims — one spec, per-user OpenBao OAuth
 // engine credentials (scoped by a templated policy on oauth2/creds/<sub>).
 func TestVaultDriver_OAuth2_PerUserCredentialName(t *testing.T) {
@@ -1248,60 +1182,6 @@ func TestVaultDriver_OAuth2_TemplatedNameFailsClosedWithoutClaims(t *testing.T) 
 	// the missing-user sentinel here would turn it into a 401 challenge and send
 	// the caller into an OAuth loop that cannot fix a spec.
 	assert.NotErrorIs(t, err, credential.ErrUserRequired)
-}
-
-// The absent-claim error has to name the config key that fixes it, and the two
-// namespaces are fixed by different keys — an operator who reads "absent" without
-// being told where to list it has to guess.
-func TestResolveSecretPath_AbsentClaimNamesItsOwnConfigKey(t *testing.T) {
-	_, err := resolveSecretPath("kv/{{user.missing}}", map[string]string{"sub": "u"}, map[string]string{"sub": "a"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "assertion_user_claims")
-
-	_, err = resolveSecretPath("kv/{{agent.missing}}", map[string]string{"sub": "u"}, map[string]string{"sub": "a"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "assertion_metadata_claims")
-	assert.NotContains(t, err.Error(), "assertion_user_claims",
-		"the agent's guidance must not point at the user's config key")
-}
-
-// The guidance has to match which of the three ways it failed, or it sends the
-// operator to a config change that cannot help.
-func TestResolveSecretPath_AgentGuidanceMatchesTheFailure(t *testing.T) {
-	t.Run("nothing projected blames the subject source", func(t *testing.T) {
-		_, err := resolveSecretPath("kv/{{agent.sub}}", nil, nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "subject_token_source")
-		assert.NotContains(t, err.Error(), "list it in assertion_metadata_claims",
-			"sub needs no allow-list entry, so telling an operator to add one is a dead end")
-	})
-	t.Run("a missing metadata claim blames the list and the login", func(t *testing.T) {
-		_, err := resolveSecretPath("kv/{{agent.team}}", nil, map[string]string{"sub": "a"})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "assertion_metadata_claims")
-		assert.Contains(t, err.Error(), "login",
-			"listing the claim is necessary but not sufficient — an absent one is skipped, not rejected")
-	})
-}
-
-// A path with no template must come back byte-identical whatever the claim maps
-// hold — the guarantee that adding this feature changed nothing for specs that do
-// not use it.
-func TestResolveSecretPath_UntemplatedIsByteIdentical(t *testing.T) {
-	const raw = "kv/data/service/config"
-	for _, maps := range []struct {
-		name        string
-		user, agent map[string]string
-	}{
-		{"both nil", nil, nil},
-		{"both populated", map[string]string{"sub": "u"}, map[string]string{"sub": "a"}},
-	} {
-		t.Run(maps.name, func(t *testing.T) {
-			got, err := resolveSecretPath(raw, maps.user, maps.agent)
-			require.NoError(t, err)
-			assert.Equal(t, raw, got)
-		})
-	}
 }
 
 // staticKVServer serves one multi-key secret, recording the version query the driver


### PR DESCRIPTION
Stacked on #605. First of the three feature PRs; the six before it are defect fixes.

A stored-secret id can now carry `{{user.<claim>}}` and `{{agent.<claim>}}` tokens, so one spec serves many callers and each reads only its own secret, the way a KV path already could.

### The mechanism moves out of the vault driver first

It was never vault-specific — the transit signer already used it for two more fields — and a second driver reaching into a neighbour for it is the point at which that stops being tidy. Pure move: same package, same unexported names, no caller changed, verified behaviour-neutral before anything else was touched.

Its tests move with it, since what they cover is the rule set rather than the one caller they happen to go through. The doc comments lose their references to one particular client's path handling; the rule they describe was always general.

### The feature

Resolution happens inside the shared fetch, so both mint methods that read a stored secret get it, and the one added in the next PR inherits it without knowing.

The non-exchange path passes no claims, which makes a templated id fail closed there rather than be sent as written. That matters more than it looks: a store will return a secret genuinely named `prod/{{user.sub}}/keys` to whoever can create one.

### One thing left as it is

The assertion's resource claim keeps carrying the unresolved id, as every templated coordinate in that layer does — it is built before the exchange that would produce the claims. So a downstream policy conditioning on it pins the spec rather than the secret, and per-principal scoping is left to the permissions on the assumed role, which is where the resolved read happens.

(I initially wrote this up as an aws-specific decision. It is not — `vaultAssertionResource` does the same for its own templated `secret_path` and `credential_name`. The comment says so now.)

### Verification

Cross-product over both namespaces, composition, an ARN-form id passing through byte for byte, absent claims and allow-list violations failing closed with the store seeing zero requests, and the assertion claim staying raw.
