### PR TITLE
feat(cred): let an aws source be a credential-chaining source

### DIFF
--- a/core/credential_config_store_test.go
+++ b/core/credential_config_store_test.go
@@ -3054,3 +3054,84 @@ func TestCredentialConfigStore_ValidateSpec_GrafanaChainedTokenExpiryIsCapped(t 
 		require.NoError(t, store.CreateSpec(ctx, spec("gf-short", "gf-chained", "1h")))
 	})
 }
+
+// An aws source can now be a chaining source, which means a key_value spec reading
+// a stored secret must survive the whole write-time chain — the type's own
+// validation, the stored-secret selection keys, and the reference check that runs
+// when a consumer names it. Each layer is unit-tested on its own; only here do they
+// run in the order and combination a real write uses.
+//
+// The driver registry is left nil so the create-time test mint is skipped: what is
+// under test is validation, which needs no account.
+func TestCredentialConfigStore_ValidateSpec_AWSKeyValueChainingSource(t *testing.T) {
+	store, ctx := setupTestCredentialConfigStore(t)
+
+	store.core.credentialTypeRegistry = credential.NewTypeRegistry()
+	require.NoError(t, types.RegisterBuiltinTypes(store.core.credentialTypeRegistry))
+	store.core.credentialDriverRegistry = nil
+
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "aws-fed", Type: credential.SourceTypeAWS,
+		Config: map[string]string{"auth_method": "oidc_federation", "region": "eu-west-1"},
+	}))
+	require.NoError(t, store.CreateSource(ctx, &credential.CredSource{
+		Name: "datadog-src", Type: credential.SourceTypeAPIKey,
+		Config: map[string]string{"credential_fields": "application_key"},
+	}))
+
+	referenced := func(name string, extra map[string]string) *credential.CredSpec {
+		cfg := map[string]string{
+			"mint_method":          "secret_read",
+			"secret_id":            "prod/datadog/keys",
+			"role_arn":             "arn:aws:iam::123456789012:role/WardenSecretsReader",
+			"subject_token_source": "warden_identity",
+		}
+		for k, v := range extra {
+			cfg[k] = v
+		}
+		return &credential.CredSpec{
+			Name: name, Type: credential.TypeKeyValue, Source: "aws-fed",
+			MinTTL: 5 * time.Minute, MaxTTL: time.Hour, Config: cfg,
+		}
+	}
+
+	t.Run("the referenced spec is writable", func(t *testing.T) {
+		require.NoError(t, store.CreateSpec(ctx, referenced("datadog-keys-in-aws", nil)))
+	})
+
+	t.Run("a consumer may chain off it", func(t *testing.T) {
+		require.NoError(t, store.CreateSpec(ctx, &credential.CredSpec{
+			Name: "datadog-cred", Type: credential.TypeAPIKey, Source: "datadog-src",
+			MinTTL: 5 * time.Minute, MaxTTL: time.Hour,
+			Config: map[string]string{
+				credential.ConfigSecretSpec:  "datadog-keys-in-aws",
+				credential.ConfigSecretField: "api_key",
+			},
+		}))
+	})
+
+	t.Run("and cannot be deleted while it is consumed", func(t *testing.T) {
+		err := store.DeleteSpec(ctx, "datadog-keys-in-aws")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "referenced")
+	})
+
+	// The selection keys are owned by a validator outside the type, so a spec that
+	// reaches for the wrong one has to be refused here rather than by key_value.
+	t.Run("a numbered revision is refused, since this store does not spell one", func(t *testing.T) {
+		err := store.CreateSpec(ctx, referenced("pinned-by-number", map[string]string{"secret_version": "3"}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "'secret_version' pins a revision")
+	})
+
+	t.Run("a field selection is accepted, since the payload is a document", func(t *testing.T) {
+		require.NoError(t, store.CreateSpec(ctx,
+			referenced("projected", map[string]string{"json_key_map": "api_key=api_key"})))
+	})
+
+	t.Run("a locator belonging to the other store is refused", func(t *testing.T) {
+		err := store.CreateSpec(ctx, referenced("wrong-store", map[string]string{"kv2_mount": "secret"}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "'kv2_mount' does not apply to mint_method=secret_read")
+	})
+}

--- a/credential/config_helpers.go
+++ b/credential/config_helpers.go
@@ -174,7 +174,7 @@ var (
 	// returns a whole document to pick from.
 	mintMethodsHonoringKeyMap = map[string]map[string]struct{}{
 		SourceTypeVault: {"static_aws": {}, "static_apikey": {}, "kv2_read": {}},
-		SourceTypeAWS:   {"secrets_manager": {}},
+		SourceTypeAWS:   {"secrets_manager": {}, "secret_read": {}},
 	}
 
 	// secret_version pins a revision, which each store spells its own way: a
@@ -202,7 +202,7 @@ func ValidateSecretSelection(config map[string]string, sourceType string) error 
 
 	if keyMap := config["json_key_map"]; keyMap != "" {
 		if _, ok := mintMethodsHonoringKeyMap[sourceType][mintMethod]; !ok {
-			return fmt.Errorf("'json_key_map' selects fields of a stored secret and is not supported by mint_method '%s'; it applies to static_aws, static_apikey and kv2_read on an hvault source, and secrets_manager on an aws source", mintMethod)
+			return fmt.Errorf("'json_key_map' selects fields of a stored secret and is not supported by mint_method '%s'; it applies to static_aws, static_apikey and kv2_read on an hvault source, and secrets_manager and secret_read on an aws source", mintMethod)
 		}
 		if err := validateKeyMapSyntax(keyMap); err != nil {
 			return err

--- a/credential/config_helpers_test.go
+++ b/credential/config_helpers_test.go
@@ -149,6 +149,19 @@ func TestValidateSecretSelection(t *testing.T) {
 			wantErr:    "'secret_version' pins a revision",
 		},
 		{
+			// secret_read reads the same store, so the same projection applies...
+			name:       "json_key_map on a stored-secret read",
+			config:     map[string]string{"mint_method": "secret_read", "json_key_map": "k=api_key"},
+			sourceType: SourceTypeAWS,
+		},
+		{
+			// ...and the same revision addressing, which is not a number.
+			name:       "secret_version on a stored-secret read",
+			config:     map[string]string{"mint_method": "secret_read", "secret_version": "3"},
+			sourceType: SourceTypeAWS,
+			wantErr:    "'secret_version' pins a revision",
+		},
+		{
 			name:       "secret_version on a dynamic mint",
 			config:     map[string]string{"mint_method": "dynamic_ibm", "secret_version": "3"},
 			sourceType: SourceTypeVault,

--- a/credential/drivers/aws_chaining_test.go
+++ b/credential/drivers/aws_chaining_test.go
@@ -1,0 +1,153 @@
+package drivers
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stephnangue/warden/credential/types"
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// chainStore is the smallest ConfigStoreAccessor that will serve a chain: specs
+// and sources by name, and nothing else. The manager's own tests have a richer
+// fake, but it lives in that package.
+type chainStore struct {
+	specs   map[string]*credential.CredSpec
+	sources map[string]*credential.CredSource
+}
+
+func newChainStore() *chainStore {
+	return &chainStore{
+		specs:   map[string]*credential.CredSpec{},
+		sources: map[string]*credential.CredSource{},
+	}
+}
+
+func (s *chainStore) GetSpec(_ context.Context, name string) (*credential.CredSpec, error) {
+	spec, ok := s.specs[name]
+	if !ok {
+		return nil, errors.New("spec not found")
+	}
+	return spec, nil
+}
+
+func (s *chainStore) GetSource(_ context.Context, name string) (*credential.CredSource, error) {
+	src, ok := s.sources[name]
+	if !ok {
+		return nil, errors.New("source not found")
+	}
+	return src, nil
+}
+
+func (s *chainStore) PersistRotatedSpec(_ context.Context, _ *credential.CredSpec) error { return nil }
+
+func (s *chainStore) ReloadSpec(ctx context.Context, name string) (*credential.CredSpec, error) {
+	return s.GetSpec(ctx, name)
+}
+
+func chainNamespaceContext() context.Context {
+	return namespace.ContextWithNamespace(context.Background(),
+		&namespace.Namespace{ID: "chain-ns", Path: "chain/"})
+}
+
+// TestChaining_AWSSecretReadBacksAnAPIKeyConsumer drives a real chain through two
+// real drivers: an aws secret_read spec is the referenced secret, and a static
+// apikey spec carries none of its own and reads one field out of that payload.
+//
+// The unit tests either side of this cover the driver and the machinery
+// separately; what this pins is that an aws source now satisfies what the
+// chaining machinery demands of a referenced spec — chiefly that it vends a
+// multi-field payload with no lease, which is refused outright if it carries one.
+func TestChaining_AWSSecretReadBacksAnAPIKeyConsumer(t *testing.T) {
+	stsSrv := newConcurrentSTSStub(t)
+
+	var mu sync.Mutex
+	var fetches int
+	smSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		fetches++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+		_, _ = w.Write([]byte(`{"Name":"prod/datadog/keys","SecretString":"{\"api_key\":\"dd-key\",\"application_key\":\"dd-app-key\"}"}`))
+	}))
+	defer smSrv.Close()
+
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+
+	typeRegistry := credential.NewTypeRegistry()
+	require.NoError(t, typeRegistry.Register(types.NewKeyValueCredType()))
+	require.NoError(t, typeRegistry.Register(types.NewAPIKeyCredType()))
+
+	driverRegistry := credential.NewDriverRegistry(log)
+	require.NoError(t, driverRegistry.RegisterFactory(&AWSDriverFactory{}))
+	require.NoError(t, driverRegistry.RegisterFactory(&StaticAPIKeyDriverFactory{}))
+
+	store := newChainStore()
+	store.sources["aws-fed"] = &credential.CredSource{
+		Name: "aws-fed", Type: credential.SourceTypeAWS,
+		Config: map[string]string{
+			"auth_method":             "oidc_federation",
+			"region":                  "us-east-1",
+			"sts_endpoint":            stsSrv.srv.URL,
+			"secretsmanager_endpoint": smSrv.URL,
+		},
+	}
+	store.specs["datadog-keys-in-aws"] = &credential.CredSpec{
+		Name: "datadog-keys-in-aws", Type: credential.TypeKeyValue, Source: "aws-fed",
+		Config: map[string]string{
+			"mint_method":          "secret_read",
+			"secret_id":            "prod/datadog/keys",
+			"role_arn":             "arn:aws:iam::123456789012:role/WardenSecretsReader",
+			"subject_token_source": "warden_identity",
+		},
+	}
+	store.sources["datadog-src"] = &credential.CredSource{
+		Name: "datadog-src", Type: credential.SourceTypeAPIKey,
+		Config: map[string]string{"credential_fields": "application_key"},
+	}
+	store.specs["datadog-cred"] = &credential.CredSpec{
+		Name: "datadog-cred", Type: credential.TypeAPIKey, Source: "datadog-src",
+		Config: map[string]string{
+			credential.ConfigSecretSpec:  "datadog-keys-in-aws",
+			credential.ConfigSecretField: "api_key",
+		},
+	}
+
+	manager, err := credential.NewManager(typeRegistry, driverRegistry, store, log)
+	require.NoError(t, err)
+
+	caller := credential.Caller{
+		TokenID:  "agent-token",
+		TokenTTL: time.Hour,
+		// Only the referenced spec requests an exchange; the consumer holds no
+		// secret of its own and mints from the material.
+		ResolveInputs: func(_ context.Context, specName string) (*credential.ExchangeInputs, error) {
+			if specName != "datadog-keys-in-aws" {
+				return nil, nil
+			}
+			return &credential.ExchangeInputs{
+				SubjectToken:     "eyJ.warden.assertion",
+				SubjectTokenType: credential.TokenTypeJWT,
+			}, nil
+		},
+	}
+
+	cred, err := manager.IssueCredential(chainNamespaceContext(), caller, "datadog-cred", nil)
+	require.NoError(t, err)
+	assert.Equal(t, credential.TypeAPIKey, cred.Type)
+	assert.Equal(t, "dd-key", cred.Data["api_key"],
+		"the consumer must carry the field its secret_field named")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, fetches, "one issuance must read the stored secret once")
+}

--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -273,6 +273,12 @@ func (f *AWSDriverFactory) InferCredentialType(specConfig map[string]string) (st
 	switch mintMethod {
 	case "rds_iam_token", "redshift_iam_token":
 		return credential.TypeDBAuthToken, nil
+	case "secret_read":
+		// The same fetch as secrets_manager, but vended verbatim: an arbitrary
+		// payload under its own key names, with no primary field to select. That is
+		// the shape a chained consumer reads by name, so there is nothing for
+		// credential_type to choose between.
+		return credential.TypeKeyValue, nil
 	case "secrets_manager":
 		// A stored secret can hold different credential shapes; the spec selects one
 		// via credential_type (default: AWS access keys). This mirrors how a Vault
@@ -582,14 +588,14 @@ func (d *AWSDriver) MintCredential(ctx context.Context, spec *credential.CredSpe
 	switch mintMethod {
 	case "sts_assume_role":
 		return d.mintViaSTSAssumeRole(ctx, c, spec)
-	case "secrets_manager":
+	case "secrets_manager", "secret_read":
 		return d.mintViaSecretsManager(ctx, c, spec)
 	case "rds_iam_token":
 		return d.mintViaRDSIAMToken(ctx, c, spec)
 	case "redshift_iam_token":
 		return d.mintViaRedshiftIAMToken(ctx, c, spec)
 	default:
-		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for AWS driver; use 'sts_assume_role', 'secrets_manager', 'rds_iam_token', or 'redshift_iam_token'", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for AWS driver; use 'sts_assume_role', 'secrets_manager', 'secret_read', 'rds_iam_token', or 'redshift_iam_token'", mintMethod)
 	}
 }
 
@@ -733,7 +739,7 @@ func (d *AWSDriver) MintCredentialWithExchange(ctx context.Context, spec *creden
 			return nil, nil, 0, "", err
 		}
 		return d.credsFromWebIdentity(spec, out)
-	case "secrets_manager":
+	case "secrets_manager", "secret_read":
 		// These credentials serve a single GetSecretValue and are then discarded, so
 		// request a short fixed session — the spec's TTL bounds govern the returned
 		// static secret, not this transient assume-role.
@@ -752,7 +758,7 @@ func (d *AWSDriver) MintCredentialWithExchange(ctx context.Context, spec *creden
 		return d.fetchSecret(ctx, d.newSecretsManagerClient(provider), spec,
 			inputs.UserClaims, inputs.AgentClaims)
 	default:
-		return nil, nil, 0, "", fmt.Errorf("aws: mint_method %q is not supported over auth_method=oidc_federation (supported: sts_assume_role, secrets_manager)", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("aws: mint_method %q is not supported over auth_method=oidc_federation (supported: sts_assume_role, secrets_manager, secret_read)", mintMethod)
 	}
 }
 
@@ -781,7 +787,7 @@ func awsAssertionAudience(sourceCfg map[string]string) (string, bool) {
 
 func awsAssertionResource(specCfg map[string]string) (string, bool) {
 	switch credential.GetString(specCfg, "mint_method", "") {
-	case "secrets_manager":
+	case "secrets_manager", "secret_read":
 		// A templated secret_id is carried unresolved, as every templated
 		// coordinate is here: this runs before the exchange that produces the
 		// claims it would resolve from. A downstream policy conditioning on this

--- a/credential/drivers/aws_driver_test.go
+++ b/credential/drivers/aws_driver_test.go
@@ -2523,3 +2523,189 @@ func TestAWSAssertionResource_TemplatedSecretIDStaysRaw(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "aws-secretsmanager:prod/users/{{user.sub}}/datadog", got)
 }
+
+// =============================================================================
+// secret_read
+// =============================================================================
+
+// TestAWSDriver_SecretRead_Static_HappyPath pins the contract that makes this
+// method usable as a chaining source: the whole payload is vended under its own
+// key names, with no lease. A referenced credential carrying a lease is refused
+// outright by the chaining machinery, so the empty leaseID is load-bearing.
+func TestAWSDriver_SecretRead_Static_HappyPath(t *testing.T) {
+	stsSrv := newConcurrentSTSStub(t)
+
+	var target, authScope string
+	smSrv := smStub(t, `{"api_key":"dd-key","application_key":"dd-app-key"}`, &target, &authScope)
+	defer smSrv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"access_key_id":           "AKIAIOSFODNN7EXAMPLE",
+		"secret_access_key":       "secret",
+		"region":                  "us-east-1",
+		"sts_endpoint":            stsSrv.srv.URL,
+		"secretsmanager_endpoint": smSrv.URL,
+	}, log)
+	require.NoError(t, err)
+
+	rawData, metadata, ttl, leaseID, err := drv.MintCredential(context.TODO(), &credential.CredSpec{
+		Name:   "datadog-keys",
+		Config: map[string]string{"mint_method": "secret_read", "secret_id": "prod/datadog/keys"},
+	})
+	require.NoError(t, err)
+	assert.Contains(t, target, "GetSecretValue")
+	assert.Equal(t, "dd-key", rawData["api_key"])
+	assert.Equal(t, "dd-app-key", rawData["application_key"])
+	assert.Nil(t, metadata)
+	assert.Equal(t, time.Duration(0), ttl)
+	assert.Equal(t, "", leaseID, "a chaining source must vend no lease")
+
+	// The payload has to survive parsing with every key intact, which is the whole
+	// point of the type this method infers.
+	cred, err := types.NewKeyValueCredType().Parse(rawData, metadata, ttl, leaseID)
+	require.NoError(t, err)
+	require.NoError(t, types.NewKeyValueCredType().Validate(cred))
+	assert.Equal(t, credential.TypeKeyValue, cred.Type)
+	assert.Equal(t, "dd-key", cred.Data["api_key"])
+	assert.Equal(t, "dd-app-key", cred.Data["application_key"])
+	assert.False(t, cred.Revocable)
+}
+
+func TestAWSDriver_SecretRead_WebIdentity_HappyPath(t *testing.T) {
+	stsSrv := newConcurrentSTSStub(t)
+
+	var target, authScope string
+	smSrv := smStub(t, `{"api_key":"dd-key","application_key":"dd-app-key"}`, &target, &authScope)
+	defer smSrv.Close()
+
+	drv := federatedSecretsManagerDriver(t, stsSrv.srv.URL, smSrv.URL)
+
+	rawData, _, ttl, leaseID, err := drv.MintCredentialWithExchange(context.TODO(),
+		&credential.CredSpec{Name: "datadog-keys", Config: map[string]string{
+			"mint_method": "secret_read",
+			"secret_id":   "prod/datadog/keys",
+			"role_arn":    "arn:aws:iam::123456789012:role/App",
+		}},
+		&credential.ExchangeInputs{SubjectToken: "eyJ.warden.assertion", SubjectTokenType: credential.TokenTypeJWT})
+	require.NoError(t, err)
+	assert.Contains(t, target, "GetSecretValue")
+	assert.Contains(t, authScope, "ASIAEXAMPLE", "the fetch must be signed with the federated credentials")
+	assert.Equal(t, "dd-key", rawData["api_key"])
+	assert.Equal(t, time.Duration(0), ttl)
+	assert.Equal(t, "", leaseID)
+}
+
+// TestAWSDriver_SecretRead_SelectionKeys: secret_read reads the same store as
+// secrets_manager, so it honours the same projection and revision keys.
+func TestAWSDriver_SecretRead_SelectionKeys(t *testing.T) {
+	stsSrv := newConcurrentSTSStub(t)
+
+	var gotBody map[string]string
+	smSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/x-amz-json-1.1")
+		_, _ = w.Write([]byte(`{"Name":"prod/app","SecretString":"{\"k\":\"v\",\"drop\":\"me\"}"}`))
+	}))
+	defer smSrv.Close()
+
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv, err := (&AWSDriverFactory{}).Create(map[string]string{
+		"access_key_id":           "AKIAIOSFODNN7EXAMPLE",
+		"secret_access_key":       "secret",
+		"region":                  "us-east-1",
+		"sts_endpoint":            stsSrv.srv.URL,
+		"secretsmanager_endpoint": smSrv.URL,
+	}, log)
+	require.NoError(t, err)
+
+	rawData, _, _, _, err := drv.MintCredential(context.TODO(), &credential.CredSpec{
+		Name: "sm",
+		Config: map[string]string{
+			"mint_method":   "secret_read",
+			"secret_id":     "prod/app",
+			"version_stage": "AWSPREVIOUS",
+			"version_id":    "abc-123",
+			"json_key_map":  "k=api_key",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "AWSPREVIOUS", gotBody["VersionStage"])
+	assert.Equal(t, "abc-123", gotBody["VersionId"])
+	assert.Equal(t, "v", rawData["api_key"])
+	assert.NotContains(t, rawData, "drop", "an unnamed key must not be vended")
+}
+
+func TestAWSDriverFactory_InferCredentialType_SecretRead(t *testing.T) {
+	factory := &AWSDriverFactory{}
+
+	got, err := factory.InferCredentialType(map[string]string{"mint_method": "secret_read"})
+	require.NoError(t, err)
+	assert.Equal(t, credential.TypeKeyValue, got)
+
+	// There is no shape to select when the payload is vended verbatim.
+	_, err = factory.InferCredentialType(map[string]string{"mint_method": "secret_read", "credential_type": "api_key"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential_type is only valid with mint_method=secrets_manager")
+}
+
+// TestAWSDriver_SecretRead_StaticSourceRefusesExchange: a chaining source must set
+// subject_token_source, which forces the exchange path, which a static source
+// cannot serve. The spec writes fine — the store skips test-minting an exchange
+// spec — so mint time is the only place this is enforced.
+//
+// The guard itself predates secret_read and fires before the mint-method switch;
+// this pins that secret_read inherits it rather than routing around it.
+func TestAWSDriver_SecretRead_StaticSourceRefusesExchange(t *testing.T) {
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+	drv := &AWSDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeAWS, Config: map[string]string{}},
+		logger:     log,
+	}
+
+	_, _, _, _, err := drv.MintCredentialWithExchange(context.TODO(),
+		&credential.CredSpec{Name: "sm", Config: map[string]string{
+			"mint_method": "secret_read", "secret_id": "prod/app", "role_arn": "arn:aws:iam::1:role/R",
+		}},
+		&credential.ExchangeInputs{SubjectToken: "eyJ", SubjectTokenType: credential.TokenTypeJWT})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "requires auth_method=oidc_federation on the source")
+}
+
+func TestAWSAssertionResource_SecretRead(t *testing.T) {
+	got, ok := awsAssertionResource(map[string]string{
+		"mint_method": "secret_read",
+		"secret_id":   "prod/datadog/keys",
+	})
+	require.True(t, ok)
+	assert.Equal(t, "aws-secretsmanager:prod/datadog/keys", got)
+}
+
+func TestAWSDriver_SecretRead_UnsupportedMethodMessages(t *testing.T) {
+	log, _ := logger.NewGatedLogger(nil, logger.GatedWriterConfig{})
+
+	static := &AWSDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeAWS, Config: map[string]string{
+			"access_key_id": "AKIAIOSFODNN7EXAMPLE", "secret_access_key": "secret", "region": "us-east-1",
+		}},
+		logger: log,
+		region: "us-east-1",
+	}
+	primeClients(static)
+
+	_, _, _, _, err := static.MintCredential(context.TODO(),
+		&credential.CredSpec{Name: "x", Config: map[string]string{"mint_method": "nope"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'secret_read'")
+
+	federated := &AWSDriver{
+		credSource: &credential.CredSource{Type: credential.SourceTypeAWS,
+			Config: map[string]string{"auth_method": "oidc_federation"}},
+		logger: log,
+	}
+	_, _, _, _, err = federated.MintCredentialWithExchange(context.TODO(),
+		&credential.CredSpec{Name: "x", Config: map[string]string{"mint_method": "nope"}},
+		&credential.ExchangeInputs{SubjectToken: "eyJ", SubjectTokenType: credential.TokenTypeJWT})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secret_read")
+}

--- a/credential/types/api_key.go
+++ b/credential/types/api_key.go
@@ -275,7 +275,7 @@ func (t *APIKeyCredType) ValidateConfig(config map[string]string, sourceType str
 		if config["mint_method"] != "secrets_manager" {
 			return fmt.Errorf("'mint_method' must be 'secrets_manager' for an aws source, got: %s", config["mint_method"])
 		}
-		return validateAWSSecretsManagerSpecConfig(config)
+		return validateAWSSecretsManagerSpecConfig(config, "secrets_manager")
 	case credential.SourceTypeElastic:
 		// The key is created at the cluster on every mint, so the spec carries
 		// none. What it carries is the shape of the key to create.

--- a/credential/types/aws_iam_keys.go
+++ b/credential/types/aws_iam_keys.go
@@ -204,7 +204,7 @@ func (t *AWSIAMAccessKeysCredType) validateAWSConfig(config map[string]string) e
 			return fmt.Errorf("'role_arn' is required when mint_method is sts_assume_role")
 		}
 	case "secrets_manager":
-		return validateAWSSecretsManagerSpecConfig(config)
+		return validateAWSSecretsManagerSpecConfig(config, "secrets_manager")
 	}
 
 	return nil
@@ -212,11 +212,14 @@ func (t *AWSIAMAccessKeysCredType) validateAWSConfig(config map[string]string) e
 
 // validateAWSSecretsManagerSpecConfig validates the spec config for reading a secret
 // from AWS Secrets Manager. It is shared by every credential type that can be sourced
-// from Secrets Manager (aws_access_keys, api_key, ...), so the fetch-config rules live
-// in one place independent of the shape the secret is parsed into.
-func validateAWSSecretsManagerSpecConfig(config map[string]string) error {
+// from Secrets Manager (aws_access_keys, api_key, key_value, ...), so the fetch-config
+// rules live in one place independent of the shape the secret is parsed into.
+//
+// mintMethod names the caller's method in the errors: more than one reads a stored
+// secret, and an error naming the wrong one sends the operator to the wrong key.
+func validateAWSSecretsManagerSpecConfig(config map[string]string, mintMethod string) error {
 	if config["secret_id"] == "" {
-		return fmt.Errorf("'secret_id' is required when mint_method is secrets_manager")
+		return fmt.Errorf("'secret_id' is required when mint_method is %s", mintMethod)
 	}
 	// The keyless (federation) variant assumes a role via web identity before
 	// reading the secret, so it also needs a role to assume. A spec requests
@@ -224,7 +227,7 @@ func validateAWSSecretsManagerSpecConfig(config map[string]string) error {
 	// unaffected. (The auth_method lives on the source, which this validator does
 	// not see, so the source/exchange pairing is enforced at mint time.)
 	if credential.SpecRequestsExchange(config) && config["role_arn"] == "" {
-		return fmt.Errorf("'role_arn' is required for keyless secrets_manager (a spec with subject_token_source)")
+		return fmt.Errorf("'role_arn' is required for keyless %s (a spec with subject_token_source)", mintMethod)
 	}
 	return nil
 }

--- a/credential/types/builtin.go
+++ b/credential/types/builtin.go
@@ -79,7 +79,7 @@ func RegisterBuiltinTypes(registry *credential.TypeRegistry) error {
 		return err
 	}
 
-	// Register generic key/value type (e.g. Vault KV v2 read via kv2_read)
+	// Register generic key/value type (an arbitrary stored payload, vended verbatim)
 	if err := registry.Register(NewKeyValueCredType()); err != nil {
 		return err
 	}

--- a/credential/types/key_value.go
+++ b/credential/types/key_value.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/stephnangue/warden/credential"
@@ -10,10 +11,10 @@ import (
 )
 
 // KeyValueCredType is a generic, structure-agnostic credential type: its Data is
-// the arbitrary key/value map returned by the source (e.g. a Vault KV v2 read via
-// mint_method=kv2_read), with no required primary field. It lets a referenced
-// "secret spec" (credential chaining) carry secret material under its natural key
-// names instead of being forced into a typed shape like api_key.
+// the arbitrary key/value map the source returned, with no required primary field.
+// It lets a referenced "secret spec" (credential chaining) carry secret material
+// under its natural key names instead of being forced into a typed shape like
+// api_key.
 //
 // It deliberately does NOT embed BaseTokenType: that base requires a primary field
 // and copies only the primary + listed optional fields, dropping every other key —
@@ -28,7 +29,7 @@ func (t *KeyValueCredType) Metadata() credential.TypeMetadata {
 	return credential.TypeMetadata{
 		Name:        credential.TypeKeyValue,
 		Category:    credential.CategoryAPI,
-		Description: "Generic key/value secret material with arbitrary fields (e.g. a Vault KV v2 read via mint_method=kv2_read)",
+		Description: "Generic key/value secret material with arbitrary fields, read from a store that holds it under its own key names",
 		DefaultTTL:  0, // static read, no default TTL
 	}
 }
@@ -39,17 +40,41 @@ func (t *KeyValueCredType) Metadata() credential.TypeMetadata {
 func (t *KeyValueCredType) ConfigSchema() []*credential.FieldValidator {
 	return []*credential.FieldValidator{
 		credential.StringField("mint_method").
-			OneOf("kv2_read", "transit_signer").
-			Describe("Mint method (kv2_read reads a Vault KV v2 secret; transit_signer mints a scoped signing capability)").
+			OneOf("kv2_read", "transit_signer", "secret_read").
+			Describe("Mint method: kv2_read reads a KV v2 secret and transit_signer mints a scoped signing capability, both on an hvault source; secret_read reads a stored secret on an aws source").
 			Example("kv2_read"),
 
 		credential.StringField("kv2_mount").
-			Describe("Vault KV v2 mount path").
+			Describe("KV v2 mount path (hvault source)").
 			Example("secret"),
 
 		credential.StringField("secret_path").
-			Describe("Path to the secret within the KV v2 mount").
+			Describe("Path to the secret within the KV v2 mount (hvault source). Supports {{user.<claim>}} and {{agent.<claim>}} templating").
 			Example("github/ci"),
+
+		credential.StringField("secret_id").
+			Describe("Stored secret to read, by name or ARN (aws source, required for secret_read). Supports {{user.<claim>}} and {{agent.<claim>}} templating").
+			Example("prod/datadog/keys"),
+
+		credential.StringField("version_stage").
+			Describe("Staging label of the revision to read (aws source; default AWSCURRENT)").
+			Example("AWSCURRENT"),
+
+		credential.StringField("version_id").
+			Describe("Pin an exact revision by id (aws source); omit to read the staged one").
+			Example("b3028f1a-1c2d-4e5f-8a9b-0c1d2e3f4a5b"),
+
+		credential.StringField("role_arn").
+			Describe("IAM role to assume via web identity (aws source, required when the spec sets subject_token_source)").
+			Example("arn:aws:iam::123456789012:role/WardenSecretsReader"),
+
+		credential.StringField("session_name").
+			Describe("Session name for the assumed role (aws source; defaults to warden-<spec name>)").
+			Example("warden-datadog-keys"),
+
+		credential.StringField("policy").
+			Describe("Inline IAM policy further restricting the assumed role (aws source)").
+			Example(""),
 
 		credential.StringField("json_key_map").
 			Describe("Comma-separated 'srcKey=destKey' selection of the stored secret's fields; unnamed keys are not vended. Omit to vend the payload verbatim").
@@ -62,21 +87,53 @@ func (t *KeyValueCredType) ConfigSchema() []*credential.FieldValidator {
 	}
 }
 
-// ValidateConfig validates the Config for a key/value credential spec. Only an
-// hvault source is supported (the KV v2 read lives on the Vault driver).
+// Each source's mint methods read their own locator keys, and a spec carrying the
+// other source's is rejected by name. The schema ignores keys it does not know, so
+// such a key would be accepted and then never read — leaving a spec that reads as
+// configured for something it is not doing.
+//
+// secret_version is deliberately absent from the hvault list even though only that
+// source honours it: ValidateSecretSelection already rejects it everywhere else,
+// and one mistake with two error messages is two messages that drift.
+var (
+	vaultKeyValueLocators = []string{
+		"kv2_mount", "secret_path", // kv2_read
+		"transit_key", "transit_key_version", "transit_mount", "signing_alg", "jwt_role", // transit_signer
+	}
+	awsKeyValueLocators = []string{
+		"secret_id", "version_stage", "version_id", "role_arn", "session_name", "policy",
+	}
+)
+
+// ValidateConfig validates the Config for a key/value credential spec. Two source
+// types produce this shape: an hvault source reading KV v2 or minting a signing
+// capability, and an aws source reading a stored secret.
 func (t *KeyValueCredType) ValidateConfig(config map[string]string, sourceType string) error {
-	if sourceType != credential.SourceTypeVault {
-		return fmt.Errorf("key_value credentials require an hvault source, got: %s", sourceType)
+	switch sourceType {
+	case credential.SourceTypeVault, credential.SourceTypeAWS:
+		// Supported
+	default:
+		return fmt.Errorf("key_value credentials require an hvault or aws source, got: %s", sourceType)
 	}
 
 	if err := credential.ValidateSchema(config, t.ConfigSchema()...); err != nil {
 		return err
 	}
 
-	// Both mint methods produce a multi-field payload with no primary field, which is
-	// what this type exists to carry. What they need from the config differs entirely,
-	// so each states its own requirements; the driver checks the rest against the
-	// store, where a locator can actually be resolved.
+	switch sourceType {
+	case credential.SourceTypeVault:
+		return t.validateVaultConfig(config)
+	default:
+		return t.validateAWSConfig(config)
+	}
+}
+
+// validateVaultConfig checks the two mint methods an hvault source offers for this
+// type. Both produce a multi-field payload with no primary field, which is what this
+// type exists to carry. What they need from the config differs entirely, so each
+// states its own requirements; the driver checks the rest against the store, where a
+// locator can actually be resolved.
+func (t *KeyValueCredType) validateVaultConfig(config map[string]string) error {
 	switch config["mint_method"] {
 	case "kv2_read":
 		if config["kv2_mount"] == "" {
@@ -97,9 +154,59 @@ func (t *KeyValueCredType) ValidateConfig(config map[string]string, sourceType s
 			return fmt.Errorf("'jwt_role' is required for mint_method=transit_signer: it must name a role whose policy grants only signing with the key, and inheriting the source's role would grant more")
 		}
 	default:
-		return fmt.Errorf("'mint_method' must be 'kv2_read' or 'transit_signer' for a key_value credential, got: %s", config["mint_method"])
+		return fmt.Errorf("'mint_method' must be 'kv2_read' or 'transit_signer' for a key_value credential on an hvault source, got: %s", config["mint_method"])
 	}
 
+	return rejectForeignLocators(config, awsKeyValueLocators, config["mint_method"])
+}
+
+// validateAWSConfig checks the single mint method an aws source offers for this
+// type: a stored-secret read whose payload is vended under its own key names.
+func (t *KeyValueCredType) validateAWSConfig(config map[string]string) error {
+	if config["mint_method"] != "secret_read" {
+		return fmt.Errorf("'mint_method' must be 'secret_read' for a key_value credential on an aws source, got: %s", config["mint_method"])
+	}
+	if err := rejectForeignLocators(config, vaultKeyValueLocators, "secret_read"); err != nil {
+		return err
+	}
+	if err := rejectForeignPrefixes(config, vaultKeyValuePrefixes, "secret_read"); err != nil {
+		return err
+	}
+	// credential_type selects which shape a stored secret is parsed into, which only
+	// the secrets_manager method offers. This one vends the payload verbatim, so
+	// there is nothing to select. The driver refuses it too, but only when the
+	// operator omits `type` and leaves it to be inferred.
+	if config["credential_type"] != "" {
+		return fmt.Errorf("'credential_type' does not apply to mint_method=secret_read: the payload is vended under its own key names")
+	}
+	return validateAWSSecretsManagerSpecConfig(config, "secret_read")
+}
+
+// vaultKeyValuePrefixes are whole families of keys one source's mint methods read,
+// which cannot be listed individually because the operator names them.
+var vaultKeyValuePrefixes = []string{"payload."}
+
+// rejectForeignLocators refuses config keys belonging to a different source's mint
+// methods, which would be accepted and then never read.
+func rejectForeignLocators(config map[string]string, foreign []string, mintMethod string) error {
+	for _, key := range foreign {
+		if config[key] != "" {
+			return fmt.Errorf("'%s' does not apply to mint_method=%s", key, mintMethod)
+		}
+	}
+	return nil
+}
+
+// rejectForeignPrefixes is the same for a passthrough bag, whose keys are named by
+// the operator and so cannot be enumerated.
+func rejectForeignPrefixes(config map[string]string, prefixes []string, mintMethod string) error {
+	for key := range config {
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(key, prefix) {
+				return fmt.Errorf("'%s' does not apply to mint_method=%s", key, mintMethod)
+			}
+		}
+	}
 	return nil
 }
 
@@ -158,7 +265,7 @@ func (t *KeyValueCredType) Revoke(_ context.Context, _ *credential.Credential, _
 func (t *KeyValueCredType) RequiresSpecRotation() bool { return false }
 
 // SensitiveConfigFields returns nil — the secret lives only in minted Data, never
-// in persisted spec config (kv2_mount/secret_path are non-secret locators).
+// in persisted spec config (every key here is a non-secret locator).
 func (t *KeyValueCredType) SensitiveConfigFields() []string { return nil }
 
 // FieldSchemas returns nil — the field set is arbitrary and unknown at type level.

--- a/credential/types/key_value_test.go
+++ b/credential/types/key_value_test.go
@@ -92,9 +92,9 @@ func TestKeyValueCredType_ValidateConfig(t *testing.T) {
 		{
 			name:       "unsupported source type",
 			config:     map[string]string{"mint_method": "kv2_read", "kv2_mount": "secret", "secret_path": "github/ci"},
-			sourceType: credential.SourceTypeAWS,
+			sourceType: credential.SourceTypeAzure,
 			wantErr:    true,
-			errMsg:     "require an hvault source",
+			errMsg:     "require an hvault or aws source",
 		},
 		{
 			name:       "wrong mint_method",
@@ -116,6 +116,121 @@ func TestKeyValueCredType_ValidateConfig(t *testing.T) {
 			sourceType: credential.SourceTypeVault,
 			wantErr:    true,
 			errMsg:     "secret_path",
+		},
+
+		// An aws source reads a stored secret and vends it verbatim.
+		{
+			name:       "aws secret_read",
+			config:     map[string]string{"mint_method": "secret_read", "secret_id": "prod/datadog/keys"},
+			sourceType: credential.SourceTypeAWS,
+		},
+		{
+			name:       "aws secret_read with selection keys",
+			config:     map[string]string{"mint_method": "secret_read", "secret_id": "prod/app", "version_stage": "AWSCURRENT", "json_key_map": "k=api_key"},
+			sourceType: credential.SourceTypeAWS,
+		},
+		{
+			name:       "aws secret_read without secret_id",
+			config:     map[string]string{"mint_method": "secret_read"},
+			sourceType: credential.SourceTypeAWS,
+			wantErr:    true,
+			errMsg:     "'secret_id' is required when mint_method is secret_read",
+		},
+		{
+			name:       "keyless aws secret_read without role_arn",
+			config:     map[string]string{"mint_method": "secret_read", "secret_id": "prod/app", "subject_token_source": "warden_identity"},
+			sourceType: credential.SourceTypeAWS,
+			wantErr:    true,
+			errMsg:     "'role_arn' is required for keyless secret_read",
+		},
+		{
+			name:       "keyless aws secret_read with role_arn",
+			config: map[string]string{
+				"mint_method": "secret_read", "secret_id": "prod/app",
+				"subject_token_source": "warden_identity", "role_arn": "arn:aws:iam::1:role/R",
+			},
+			sourceType: credential.SourceTypeAWS,
+		},
+
+		// Neither source may claim the other's mint method.
+		{
+			name:       "vault mint method on an aws source",
+			config:     map[string]string{"mint_method": "kv2_read", "kv2_mount": "secret", "secret_path": "github/ci"},
+			sourceType: credential.SourceTypeAWS,
+			wantErr:    true,
+			errMsg:     "must be 'secret_read' for a key_value credential on an aws source",
+		},
+		{
+			name:       "transit_signer on an aws source",
+			config:     map[string]string{"mint_method": "transit_signer", "transit_key": "k", "jwt_role": "r"},
+			sourceType: credential.SourceTypeAWS,
+			wantErr:    true,
+			errMsg:     "must be 'secret_read' for a key_value credential on an aws source",
+		},
+		{
+			name:       "aws mint method on an hvault source",
+			config:     map[string]string{"mint_method": "secret_read", "secret_id": "prod/app"},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "must be 'kv2_read' or 'transit_signer' for a key_value credential on an hvault source",
+		},
+
+		// A locator belonging to the other source would be accepted by the schema and
+		// then never read, leaving a spec that reads as configured for something it
+		// is not doing.
+		{
+			name:       "aws locator on an hvault spec",
+			config:     map[string]string{"mint_method": "kv2_read", "kv2_mount": "secret", "secret_path": "github/ci", "secret_id": "prod/app"},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "'secret_id' does not apply to mint_method=kv2_read",
+		},
+		{
+			name:       "aws role_arn on a transit_signer spec",
+			config:     map[string]string{"mint_method": "transit_signer", "transit_key": "k", "jwt_role": "r", "role_arn": "arn:aws:iam::1:role/R"},
+			sourceType: credential.SourceTypeVault,
+			wantErr:    true,
+			errMsg:     "'role_arn' does not apply to mint_method=transit_signer",
+		},
+		{
+			name:       "vault locator on an aws spec",
+			config:     map[string]string{"mint_method": "secret_read", "secret_id": "prod/app", "kv2_mount": "secret"},
+			sourceType: credential.SourceTypeAWS,
+			wantErr:    true,
+			errMsg:     "'kv2_mount' does not apply to mint_method=secret_read",
+		},
+		{
+			name:       "transit locator on an aws spec",
+			config:     map[string]string{"mint_method": "secret_read", "secret_id": "prod/app", "signing_alg": "rsa-pss-sha256"},
+			sourceType: credential.SourceTypeAWS,
+			wantErr:    true,
+			errMsg:     "'signing_alg' does not apply to mint_method=secret_read",
+		},
+		{
+			name:       "pinned transit key version on an aws spec",
+			config:     map[string]string{"mint_method": "secret_read", "secret_id": "prod/app", "transit_key_version": "3"},
+			sourceType: credential.SourceTypeAWS,
+			wantErr:    true,
+			errMsg:     "'transit_key_version' does not apply to mint_method=secret_read",
+		},
+		{
+			// The passthrough bag is named by the operator, so it is refused by
+			// prefix rather than by enumerating keys that cannot be enumerated.
+			name:       "transit payload passthrough on an aws spec",
+			config:     map[string]string{"mint_method": "secret_read", "secret_id": "prod/app", "payload.client_id": "abc"},
+			sourceType: credential.SourceTypeAWS,
+			wantErr:    true,
+			errMsg:     "'payload.client_id' does not apply to mint_method=secret_read",
+		},
+		{
+			// The driver only refuses credential_type when the operator omits
+			// `type` entirely, so an explicit key_value spec would otherwise carry
+			// a shape selector that selects nothing.
+			name:       "credential_type on an aws secret_read spec",
+			config:     map[string]string{"mint_method": "secret_read", "secret_id": "prod/app", "credential_type": "api_key"},
+			sourceType: credential.SourceTypeAWS,
+			wantErr:    true,
+			errMsg:     "'credential_type' does not apply to mint_method=secret_read",
 		},
 	}
 


### PR DESCRIPTION
Stacked on #606. **This is the feature the whole stack exists for.**

Chaining has always been driver-agnostic — nothing in the manager or the reference validation asks what kind of source a referenced spec has — but in practice only one kind could be one, because `key_value` refused any source but `hvault` and no other factory ever inferred that type.

### Why a new mint method rather than another `credential_type`

`secret_read` reads a stored secret and vends the payload verbatim, under the key names it was stored with. That is the shape a chained consumer reads by name, and it is the opposite of what `secrets_manager` is for: that method exists to parse a payload into a declared shape, and this one exists not to. It reuses that method's fetch entirely, so it inherits the field projection and the claim templating from #606 without knowing about either.

### `key_value` validates per source now

Each source's locators are rejected on the other's specs, because the schema ignores keys it does not recognise — so a misplaced one would be accepted and then never read, leaving a spec that reads as configured for something it is not doing. The transit signer's passthrough bag is refused by prefix, its keys being named by the operator and so unlistable.

`secret_version` is the deliberate exception, left to the single validator that already rejects it everywhere it does not apply. Two owners of one rule are two messages that drift.

### The constraint worth knowing

A referenced spec must set `subject_token_source`, which forces the exchange path, which an aws source can only serve when it is keyless. So a chaining source needs an `oidc_federation` source, exactly as an hvault one does — while a static source still serves `secret_read` for a directly-bound spec. This is enforced at mint, not at write, because the store skips test-minting an exchange spec.

### Verification

Covered at three levels, because each was capable of passing while another was broken:

- the type's own validation (cross-product of source × mint method × foreign locators),
- the driver's fetch and dispatch (static and keyless happy paths, selection keys, leaseless contract),
- a chain driven end to end through two real drivers into a real consumer,
- and a store-level test writing the referenced spec and its consumer through the real validation chain — the only place those layers run in the order and combination a real write uses.

That last one exists because without it, reverting the type change would have left every other test in the PR passing. Verified it fails when the source-type gate is reverted.
