### PR TITLE
fix(cred): guard driver source config against concurrent rotation

### DIFF
--- a/credential/drivers/azure_driver.go
+++ b/credential/drivers/azure_driver.go
@@ -192,6 +192,17 @@ type AzureDriver struct {
 	credGeneration uint64
 	tokenMu        sync.Mutex
 
+	// configMu guards credSource.Config, which rotation replaces while mints are
+	// in flight. It is deliberately separate from tokenMu: token acquisition
+	// releases tokenMu for the duration of the HTTP call and reads the source
+	// credentials on the way, so tokenMu does not cover the config field at all.
+	//
+	// It is never held across acquiring another lock — sourceConfig takes it,
+	// reads one map header and releases — so the two locks cannot deadlock in
+	// either order, and a caller already holding tokenMu may read config freely.
+	// RWMutex because the readers are on the mint path.
+	configMu sync.RWMutex
+
 	// Object ID cache: appID -> objectID (immutable mapping in Azure AD)
 	objectIDCache map[string]string
 	objectIDMu    sync.Mutex
@@ -216,16 +227,39 @@ type AzureDriver struct {
 // Config accessors — single source of truth is credSource.Config.
 // These are cheap map lookups, not cached copies.
 
+// sourceConfig returns the current config map. Rotation swaps in a whole new map
+// rather than writing into the live one, so the result is a stable snapshot and
+// callers need not hold the lock while reading it.
+func (d *AzureDriver) sourceConfig() map[string]string {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return d.credSource.Config
+}
+
 func (d *AzureDriver) getTenantID() string {
-	return credential.GetString(d.credSource.Config, "tenant_id", "")
+	return credential.GetString(d.sourceConfig(), "tenant_id", "")
 }
 
 func (d *AzureDriver) getClientID() string {
-	return credential.GetString(d.credSource.Config, "client_id", "")
+	return credential.GetString(d.sourceConfig(), "client_id", "")
 }
 
 func (d *AzureDriver) getClientSecret() string {
-	return credential.GetString(d.credSource.Config, "client_secret", "")
+	return credential.GetString(d.sourceConfig(), "client_secret", "")
+}
+
+// sourceCreds returns the service principal's tenant, client id and secret from a
+// single snapshot.
+//
+// These three must never be read separately. A rotation landing between two of the
+// reads would pair a client id with a secret belonging to a different generation —
+// a credential that never existed — and the resulting failure looks like a bad
+// stored secret rather than a torn read.
+func (d *AzureDriver) sourceCreds() (tenantID, clientID, clientSecret string) {
+	config := d.sourceConfig()
+	return credential.GetString(config, "tenant_id", ""),
+		credential.GetString(config, "client_id", ""),
+		credential.GetString(config, "client_secret", "")
 }
 
 // cachedAzureToken holds an Azure AD access token with expiry and generation
@@ -368,7 +402,7 @@ func (d *AzureDriver) MintCredential(ctx context.Context, spec *credential.CredS
 	// A keyless source mints only through the exchange path, which carries the
 	// caller-scoped assertion. Fail closed here to avoid silently minting with
 	// no credential material.
-	if credential.GetString(d.credSource.Config, "auth_method", azureAuthMethodStatic) == azureAuthMethodOIDCFederation {
+	if credential.GetString(d.sourceConfig(), "auth_method", azureAuthMethodStatic) == azureAuthMethodOIDCFederation {
 		return nil, nil, 0, "", fmt.Errorf("azure: source uses auth_method=oidc_federation; the spec must set subject_token_source (warden_identity or agent_identity)")
 	}
 
@@ -393,7 +427,7 @@ func (d *AzureDriver) MintCredential(ctx context.Context, spec *credential.CredS
 // the app's federated credential must trust the origin IdP directly). There is no
 // caller-supplied, unverified subject token.
 func (d *AzureDriver) MintCredentialWithExchange(ctx context.Context, spec *credential.CredSpec, inputs *credential.ExchangeInputs) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	if credential.GetString(d.credSource.Config, "auth_method", azureAuthMethodStatic) != azureAuthMethodOIDCFederation {
+	if credential.GetString(d.sourceConfig(), "auth_method", azureAuthMethodStatic) != azureAuthMethodOIDCFederation {
 		return nil, nil, 0, "", fmt.Errorf("azure: workload identity federation requires auth_method=oidc_federation on the source")
 	}
 	if inputs == nil || inputs.SubjectToken == "" {
@@ -605,7 +639,11 @@ func (d *AzureDriver) PrepareRotation(ctx context.Context) (map[string]string, m
 	d.tokenMu.Lock()
 	defer d.tokenMu.Unlock()
 
-	oldSecretID := credential.GetString(d.credSource.Config, "secret_id", "")
+	// One snapshot for everything this rotation derives from the current config, so
+	// the secret it retires, the map it copies and the delay it returns all describe
+	// the same generation.
+	current := d.sourceConfig()
+	oldSecretID := credential.GetString(current, "secret_id", "")
 
 	// Get Graph API token
 	graphToken, err := d.getGraphTokenLocked(ctx)
@@ -625,8 +663,8 @@ func (d *AzureDriver) PrepareRotation(ctx context.Context) (map[string]string, m
 	d.removeOrphanedPasswordCredentials(ctx, graphToken, d.getClientID(), oldSecretID, newSecretID)
 
 	// Build new config
-	newConfig := make(map[string]string)
-	for k, v := range d.credSource.Config {
+	newConfig := make(map[string]string, len(current))
+	for k, v := range current {
 		newConfig[k] = v
 	}
 	newConfig["client_secret"] = newSecret
@@ -638,7 +676,7 @@ func (d *AzureDriver) PrepareRotation(ctx context.Context) (map[string]string, m
 
 	// Return activateAfter to let the rotation manager schedule activation
 	// after Azure AD eventual consistency has propagated the new credential.
-	activateAfter := credential.GetDuration(d.credSource.Config, "activation_delay", DefaultAzureActivationDelay)
+	activateAfter := credential.GetDuration(current, "activation_delay", DefaultAzureActivationDelay)
 
 	if d.logger != nil {
 		d.logger.Debug("prepared source credential rotation",
@@ -655,8 +693,11 @@ func (d *AzureDriver) CommitRotation(ctx context.Context, newConfig map[string]s
 	d.tokenMu.Lock()
 	defer d.tokenMu.Unlock()
 
-	// Update config (single source of truth for credentials)
+	// Update config (single source of truth for credentials). Under configMu, not
+	// tokenMu: the readers are mints that never take tokenMu at all.
+	d.configMu.Lock()
 	d.credSource.Config = newConfig
+	d.configMu.Unlock()
 
 	// Bump generation to invalidate all cached tokens; old-generation entries
 	// are ignored on lookup without needing to clear the map.
@@ -760,7 +801,7 @@ func (d *AzureDriver) PrepareSpecRotation(ctx context.Context, spec *credential.
 
 	// Return activateAfter to let the rotation manager schedule activation
 	// after Azure AD eventual consistency has propagated the new credential.
-	activateAfter := credential.GetDuration(d.credSource.Config, "activation_delay", DefaultAzureActivationDelay)
+	activateAfter := credential.GetDuration(d.sourceConfig(), "activation_delay", DefaultAzureActivationDelay)
 
 	if d.logger != nil {
 		d.logger.Debug("prepared spec credential rotation",
@@ -898,7 +939,8 @@ func (d *AzureDriver) getSourceToken(ctx context.Context, resourceURI string) (s
 	d.tokenMu.Unlock()
 
 	// Slow path: acquire token WITHOUT holding lock
-	token, expiresIn, err := d.acquireToken(ctx, d.getTenantID(), d.getClientID(), d.getClientSecret(), resourceURI)
+	tenantID, clientID, clientSecret := d.sourceCreds()
+	token, expiresIn, err := d.acquireToken(ctx, tenantID, clientID, clientSecret, resourceURI)
 	if err != nil {
 		return "", err
 	}
@@ -931,7 +973,8 @@ func (d *AzureDriver) getSourceTokenLocked(ctx context.Context, resourceURI stri
 		return cached.accessToken, nil
 	}
 
-	token, expiresIn, err := d.acquireToken(ctx, d.getTenantID(), d.getClientID(), d.getClientSecret(), resourceURI)
+	tenantID, clientID, clientSecret := d.sourceCreds()
+	token, expiresIn, err := d.acquireToken(ctx, tenantID, clientID, clientSecret, resourceURI)
 	if err != nil {
 		return "", err
 	}
@@ -961,7 +1004,7 @@ func (d *AzureDriver) getGraphTokenLocked(ctx context.Context) (string, error) {
 func (d *AzureDriver) hasGraphPermissions() bool {
 	// A keyless federation source has no client_secret, so the source-token probe
 	// below would be a doomed round-trip. It also has nothing to rotate.
-	if credential.GetString(d.credSource.Config, "auth_method", azureAuthMethodStatic) == azureAuthMethodOIDCFederation {
+	if credential.GetString(d.sourceConfig(), "auth_method", azureAuthMethodStatic) == azureAuthMethodOIDCFederation {
 		return false
 	}
 

--- a/credential/drivers/config_race_test.go
+++ b/credential/drivers/config_race_test.go
@@ -1,0 +1,237 @@
+package drivers
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests cover the driver side of source-config rotation: a rotation replaces
+// the config map while mints are still reading it. Run under -race — the detector
+// reports on the unguarded versions and is quiet on the guarded ones. Only the
+// generation-coherence test asserts a value; the rest exist for the detector.
+
+// TestAzureDriver_SourceCredsNeverMixesGenerations is the one case where locking each
+// read individually is not enough.
+//
+// Acquiring a token needs tenant, client id and secret together. Read one at a time,
+// a rotation landing between two of them pairs a client id with a secret from another
+// generation — a credential that never existed at the provider, whose failure reads
+// like a bad stored secret rather than a torn read. Each value here carries its
+// generation so a mixed triple is detectable.
+func TestAzureDriver_SourceCredsNeverMixesGenerations(t *testing.T) {
+	driver := newTestAzureDriver()
+	// Seed generation 0 so every value the readers see carries a generation; the
+	// helper's defaults do not, and would read as a mixed triple.
+	driver.credSource.Config = map[string]string{
+		"tenant_id":     "tenant-0",
+		"client_id":     "client-0",
+		"client_secret": "secret-0",
+	}
+
+	writerDone := make(chan struct{})
+	stop := make(chan struct{})
+	go func() {
+		defer close(writerDone)
+		for gen := 0; ; gen++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			cfg := map[string]string{
+				"tenant_id":     fmt.Sprintf("tenant-%d", gen),
+				"client_id":     fmt.Sprintf("client-%d", gen),
+				"client_secret": fmt.Sprintf("secret-%d", gen),
+			}
+			// The swap CommitRotation performs, without its network round trip.
+			driver.configMu.Lock()
+			driver.credSource.Config = cfg
+			driver.configMu.Unlock()
+		}
+	}()
+
+	var readers sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for j := 0; j < 20000; j++ {
+				tenantID, clientID, clientSecret := driver.sourceCreds()
+				tenantGen := strings.TrimPrefix(tenantID, "tenant-")
+				clientGen := strings.TrimPrefix(clientID, "client-")
+				secretGen := strings.TrimPrefix(clientSecret, "secret-")
+				if tenantGen != clientGen || clientGen != secretGen {
+					t.Errorf("torn credential read: tenant_id=%q client_id=%q client_secret=%q",
+						tenantID, clientID, clientSecret)
+					return
+				}
+			}
+		}()
+	}
+
+	readers.Wait()
+	close(stop)
+	<-writerDone
+}
+
+// TestGitLabDriver_CommitRotationIsRaceFreeWithMints drives the real CommitRotation,
+// whose config swap was the one write in this driver that took no lock at all, while
+// readers do what the mint path does.
+func TestGitLabDriver_CommitRotationIsRaceFreeWithMints(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":1,"name":"warden","active":true}`))
+	}))
+	defer server.Close()
+
+	driver := newTestGitLabDriver("initial-token")
+	driver.credSource.Config["gitlab_address"] = server.URL
+	driver.tokenCache = NewTokenCache()
+
+	stop := make(chan struct{})
+	var readers sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				// Exactly what doGitLabRequest reads on every proxied request.
+				_ = driver.getGitLabAddress()
+				_ = driver.getPAT()
+				_ = driver.getAuthMethod()
+				_ = driver.isChained()
+			}
+		}()
+	}
+
+	for gen := 0; gen < 50; gen++ {
+		newConfig := map[string]string{
+			"gitlab_address":        server.URL,
+			"auth_method":           "pat",
+			"personal_access_token": fmt.Sprintf("rotated-token-%d", gen),
+		}
+		require.NoError(t, driver.CommitRotation(t.Context(), newConfig))
+	}
+
+	close(stop)
+	readers.Wait()
+
+	require.Equal(t, "rotated-token-49", driver.getPAT(),
+		"the last committed token should be the one mints see")
+}
+
+// TestVaultDriver_ConfigReadsAreRaceFreeWithRotation covers the reads that ran bare
+// while CommitRotation replaced the config under authMu.
+//
+// The values on the unguarded paths happen to be identical across a rotation, so this
+// never produced a wrong credential — but an unsynchronized field write against
+// unsynchronized reads is a data race whatever the values are, and equal values are
+// not a guarantee the compiler or the memory model offers anything about.
+func TestVaultDriver_ConfigReadsAreRaceFreeWithRotation(t *testing.T) {
+	driver := &VaultDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeVault,
+			Config: map[string]string{
+				"auth_method":   "approle",
+				"vault_address": "https://vault.example.com",
+				"role_id":       "role-0",
+				"secret_id":     "secret-0",
+				"approle_mount": "approle",
+				"jwt_role":      "warden",
+			},
+		},
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+
+	stop := make(chan struct{})
+	var readers sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_ = driver.getAuthMethod()
+				_ = credential.GetString(driver.sourceConfig(), "vault_address", "")
+			}
+		}()
+	}
+
+	// The swap CommitRotation performs, without re-authenticating against a server.
+	for gen := 0; gen < 2000; gen++ {
+		newConfig := map[string]string{
+			"auth_method":   "approle",
+			"vault_address": "https://vault.example.com",
+			"role_id":       fmt.Sprintf("role-%d", gen),
+			"secret_id":     fmt.Sprintf("secret-%d", gen),
+			"approle_mount": "approle",
+			"jwt_role":      "warden",
+		}
+		driver.configMu.Lock()
+		driver.credSource.Config = newConfig
+		driver.configMu.Unlock()
+	}
+
+	close(stop)
+	readers.Wait()
+}
+
+// TestKubernetesDriver_HTTPClientSwapIsRaceFree covers the client pointer, which a
+// rotation replaces when the TLS settings change while requests are reading it.
+func TestKubernetesDriver_HTTPClientSwapIsRaceFree(t *testing.T) {
+	driver := &KubernetesDriver{
+		credSource: &credential.CredSource{
+			Type: credential.SourceTypeKubernetes,
+			Config: map[string]string{
+				"kubernetes_url": "https://k8s.example.com",
+				"token":          "initial",
+			},
+		},
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+
+	stop := make(chan struct{})
+	var readers sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				require.NotNil(t, driver.httpClientSnapshot())
+			}
+		}()
+	}
+
+	for gen := 0; gen < 2000; gen++ {
+		client := &http.Client{Timeout: time.Duration(gen%10+1) * time.Second}
+		driver.clientMu.Lock()
+		driver.httpClient = client
+		driver.clientMu.Unlock()
+	}
+
+	close(stop)
+	readers.Wait()
+}

--- a/credential/drivers/gitlab_driver.go
+++ b/credential/drivers/gitlab_driver.go
@@ -54,8 +54,15 @@ type GitLabDriver struct {
 	// HTTP client for GitLab API calls
 	httpClient *http.Client
 
-	// Mutex for protecting config updates during rotation
-	configMu sync.Mutex
+	// configMu guards credSource.Config, which rotation replaces while mints are
+	// in flight. It is an RWMutex because the readers are on the mint path: every
+	// request reads the address and token, and a plain Mutex would serialize
+	// minters behind each other for what is a map lookup.
+	//
+	// Writers replace the whole map rather than writing into it, so a reader that
+	// takes one snapshot can use it without holding the lock for the rest of the
+	// call — see sourceConfig.
+	configMu sync.RWMutex
 }
 
 // gitlabChainedAuth carries the per-mint values fetched via credential chaining.
@@ -251,22 +258,32 @@ func (f *GitLabDriverFactory) Create(config map[string]string, log *logger.Gated
 
 // Config accessors
 
+// sourceConfig returns the current config map. Rotation swaps in a whole new map
+// rather than writing into the live one, so the returned map is a stable snapshot
+// and callers need not hold the lock while reading it. Callers that need several
+// keys to agree must take one snapshot and read all of them from it.
+func (d *GitLabDriver) sourceConfig() map[string]string {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return d.credSource.Config
+}
+
 func (d *GitLabDriver) getGitLabAddress() string {
-	return strings.TrimRight(credential.GetString(d.credSource.Config, "gitlab_address", ""), "/")
+	return strings.TrimRight(credential.GetString(d.sourceConfig(), "gitlab_address", ""), "/")
 }
 
 func (d *GitLabDriver) getAuthMethod() string {
-	return credential.GetString(d.credSource.Config, "auth_method", "pat")
+	return credential.GetString(d.sourceConfig(), "auth_method", "pat")
 }
 
 func (d *GitLabDriver) getPAT() string {
-	return credential.GetString(d.credSource.Config, "personal_access_token", "")
+	return credential.GetString(d.sourceConfig(), "personal_access_token", "")
 }
 
 // isChained reports whether this source draws its token from another cred spec
 // rather than holding one inline.
 func (d *GitLabDriver) isChained() bool {
-	return credential.GetString(d.credSource.Config, credential.ConfigSecretSpec, "") != ""
+	return credential.GetString(d.sourceConfig(), credential.ConfigSecretSpec, "") != ""
 }
 
 // verifyAuth validates the source credentials by calling a simple GitLab API endpoint
@@ -737,9 +754,11 @@ func (d *GitLabDriver) preparePATRotation(ctx context.Context) (map[string]strin
 		return nil, nil, 0, fmt.Errorf("GitLab PAT rotation returned empty token")
 	}
 
-	// Build new config with the new token
-	newConfig := make(map[string]string, len(d.credSource.Config))
-	for k, v := range d.credSource.Config {
+	// Build new config with the new token, from one snapshot rather than the live
+	// field, so the copy cannot straddle a concurrent swap.
+	current := d.sourceConfig()
+	newConfig := make(map[string]string, len(current))
+	for k, v := range current {
 		newConfig[k] = v
 	}
 	newConfig["personal_access_token"] = rotateResult.Token
@@ -769,7 +788,7 @@ func (d *GitLabDriver) preparePATRotation(ctx context.Context) (map[string]strin
 // The renew-secret endpoint atomically replaces the old secret, so
 // activateAfter=0 is returned (fast path, no propagation delay needed).
 func (d *GitLabDriver) prepareOAuth2Rotation(ctx context.Context) (map[string]string, map[string]string, time.Duration, error) {
-	applicationID := credential.GetString(d.credSource.Config, "application_id", "")
+	applicationID := credential.GetString(d.sourceConfig(), "application_id", "")
 
 	// Rotate the application secret via admin API
 	path := fmt.Sprintf("/api/v4/applications/%s/renew-secret", url.PathEscape(applicationID))
@@ -789,9 +808,10 @@ func (d *GitLabDriver) prepareOAuth2Rotation(ctx context.Context) (map[string]st
 		return nil, nil, 0, fmt.Errorf("GitLab OAuth2 rotation returned empty secret")
 	}
 
-	// Build new config
-	newConfig := make(map[string]string, len(d.credSource.Config))
-	for k, v := range d.credSource.Config {
+	// Build new config, from one snapshot — see preparePATRotation.
+	current := d.sourceConfig()
+	newConfig := make(map[string]string, len(current))
+	for k, v := range current {
 		newConfig[k] = v
 	}
 	newConfig["application_secret"] = rotateResult.Secret
@@ -819,8 +839,11 @@ func (d *GitLabDriver) prepareOAuth2Rotation(ctx context.Context) (map[string]st
 
 // CommitRotation activates new credentials in the driver's internal state.
 func (d *GitLabDriver) CommitRotation(ctx context.Context, newConfig map[string]string) error {
-	// Update the config
+	// Update the config. Under configMu like the two swaps in PrepareRotation:
+	// mints still holding this instance read the map concurrently.
+	d.configMu.Lock()
 	d.credSource.Config = newConfig
+	d.configMu.Unlock()
 
 	// Invalidate OAuth2 token cache to force re-authentication
 	d.tokenCache.InvalidateGeneration()
@@ -979,8 +1002,12 @@ func isClientSecretRejection(err error) bool {
 // mixed in from a source that still had it would name a different application than
 // the secret belongs to.
 func (d *GitLabDriver) getOAuth2Token(ctx context.Context, chained *gitlabChainedAuth) (string, string, error) {
-	applicationID := credential.GetString(d.credSource.Config, "application_id", "")
-	applicationSecret := credential.GetString(d.credSource.Config, "application_secret", "")
+	// One snapshot for both halves, for the same reason the chained case supplies
+	// both: a rotation landing between two separate reads would pair an id with a
+	// secret minted for a different generation of the application.
+	config := d.sourceConfig()
+	applicationID := credential.GetString(config, "application_id", "")
+	applicationSecret := credential.GetString(config, "application_secret", "")
 	if chained != nil {
 		applicationID = chained.applicationID
 		applicationSecret = chained.secret

--- a/credential/drivers/kubernetes_driver.go
+++ b/credential/drivers/kubernetes_driver.go
@@ -55,10 +55,19 @@ var _ credential.ExchangeMinter = (*KubernetesDriver)(nil)
 type KubernetesDriver struct {
 	credSource *credential.CredSource
 	logger     *logger.GatedLogger
+
+	// httpClient is replaced wholesale when a rotation changes the TLS settings,
+	// so it is guarded rather than read directly — see httpClientSnapshot.
 	httpClient *http.Client
 
 	// authMu protects credSource.Config writes during rotation.
 	authMu sync.Mutex
+
+	// clientMu guards the httpClient field alone, and is deliberately not authMu:
+	// doK8sRequestWith is called by rotation paths that already hold authMu, so
+	// reading the client under authMu would deadlock. clientMu is only ever held
+	// long enough to read or replace one pointer, never across another lock.
+	clientMu sync.RWMutex
 }
 
 // KubernetesDriverFactory creates KubernetesDriver instances
@@ -407,9 +416,18 @@ func (d *KubernetesDriver) Type() string {
 	return credential.SourceTypeKubernetes
 }
 
+// httpClientSnapshot returns the current HTTP client. A rotation that changes the
+// TLS settings replaces the whole client, so a caller takes one reference and uses
+// it for the rest of the call rather than reading the field again.
+func (d *KubernetesDriver) httpClientSnapshot() *http.Client {
+	d.clientMu.RLock()
+	defer d.clientMu.RUnlock()
+	return d.httpClient
+}
+
 // Cleanup releases resources
 func (d *KubernetesDriver) Cleanup(_ context.Context) error {
-	d.httpClient.CloseIdleConnections()
+	d.httpClientSnapshot().CloseIdleConnections()
 	return nil
 }
 
@@ -573,7 +591,9 @@ func (d *KubernetesDriver) CommitRotation(ctx context.Context, newConfig map[str
 			d.authMu.Unlock()
 			return fmt.Errorf("failed to rebuild HTTP client after rotation: %w", err)
 		}
+		d.clientMu.Lock()
 		d.httpClient = httpClient
+		d.clientMu.Unlock()
 	}
 
 	if d.logger != nil {
@@ -660,7 +680,7 @@ func (d *KubernetesDriver) probeTLS(ctx context.Context) error {
 	// Transport is nil when neither is set (BuildHTTPClient returns a bare client
 	// then), which leaves a nil config and the system roots — the right default.
 	var tlsConfig *tls.Config
-	if transport, ok := d.httpClient.Transport.(*http.Transport); ok && transport != nil {
+	if transport, ok := d.httpClientSnapshot().Transport.(*http.Transport); ok && transport != nil {
 		tlsConfig = transport.TLSClientConfig
 	}
 
@@ -717,7 +737,7 @@ func (d *KubernetesDriver) doK8sRequestWith(ctx context.Context, k8sURL, token, 
 		headers["Content-Type"] = "application/json"
 	}
 
-	return httputil.ExecuteWithRetry(ctx, d.httpClient, httputil.HTTPRequest{
+	return httputil.ExecuteWithRetry(ctx, d.httpClientSnapshot(), httputil.HTTPRequest{
 		Method:  method,
 		URL:     k8sURL + path,
 		Body:    body,

--- a/credential/drivers/vault_driver.go
+++ b/credential/drivers/vault_driver.go
@@ -43,6 +43,13 @@ type VaultDriver struct {
 	httpClient    *http.Client // HTTP client for external API calls (e.g., IBM IAM token exchange)
 	tokenExpireAt time.Time    // Tracks when the current token expires
 	authMu        sync.Mutex   // Protects tokenExpireAt and authentication
+
+	// configMu guards the credSource.Config field, which rotation replaces. It is
+	// separate from authMu because loginViaApprole reads config while authMu is
+	// already held, so reading under authMu would deadlock. configMu is only ever
+	// held long enough to read or replace one map header, never across another
+	// lock, so the two cannot deadlock in either order.
+	configMu sync.RWMutex
 }
 
 // VaultDriverFactory creates VaultDriver instances
@@ -259,9 +266,17 @@ func (f *VaultDriverFactory) InferCredentialType(specConfig map[string]string) (
 	}
 }
 
+// sourceConfig returns the current config map. Rotation swaps in a whole new map
+// rather than writing into the live one, so the result is a stable snapshot.
+func (d *VaultDriver) sourceConfig() map[string]string {
+	d.configMu.RLock()
+	defer d.configMu.RUnlock()
+	return d.credSource.Config
+}
+
 // getAuthMethod returns the source's configured auth_method ("" for a pre-set token).
 func (d *VaultDriver) getAuthMethod() string {
-	return credential.GetString(d.credSource.Config, "auth_method", "")
+	return credential.GetString(d.sourceConfig(), "auth_method", "")
 }
 
 // authenticate performs Vault authentication only if needed (thread-safe)
@@ -301,9 +316,9 @@ func (d *VaultDriver) isTokenValid(ctx context.Context) bool {
 
 // loginViaApprole authenticates to Vault using AppRole
 func (d *VaultDriver) loginViaApprole(ctx context.Context) error {
-	roleID := credential.GetString(d.credSource.Config, "role_id", "")
-	secretID := credential.GetString(d.credSource.Config, "secret_id", "")
-	approleMount := credential.GetString(d.credSource.Config, "approle_mount", "")
+	roleID := credential.GetString(d.sourceConfig(), "role_id", "")
+	secretID := credential.GetString(d.sourceConfig(), "secret_id", "")
+	approleMount := credential.GetString(d.sourceConfig(), "approle_mount", "")
 
 	data := map[string]interface{}{
 		"role_id":   roleID,
@@ -513,7 +528,7 @@ func (d *VaultDriver) effectiveJWTRole(spec *credential.CredSpec) string {
 	if r := credential.GetString(spec.Config, "jwt_role", ""); r != "" {
 		return r
 	}
-	return credential.GetString(d.credSource.Config, "jwt_role", "")
+	return credential.GetString(d.sourceConfig(), "jwt_role", "")
 }
 
 // loginViaJWT builds a per-request, token-isolated Vault client and logs in at the
@@ -534,7 +549,7 @@ func (d *VaultDriver) loginViaJWT(ctx context.Context, spec *credential.CredSpec
 	if jwtRole == "" {
 		return nil, nil, fmt.Errorf("vault: jwt_role is required for auth_method=%s", vaultAuthMethodOIDCFederation)
 	}
-	jwtMount := credential.GetString(d.credSource.Config, "jwt_mount", defaultVaultJWTMount)
+	jwtMount := credential.GetString(d.sourceConfig(), "jwt_mount", defaultVaultJWTMount)
 
 	path := fmt.Sprintf("auth/%s/login", jwtMount)
 	secret, err := client.Logical().WriteWithContext(ctx, path, map[string]interface{}{
@@ -1137,13 +1152,13 @@ func (d *VaultDriver) Cleanup(ctx context.Context) error {
 // SupportsRotation returns true if this driver instance can rotate its credentials.
 // Currently only AppRole authentication supports rotation.
 func (d *VaultDriver) SupportsRotation() bool {
-	authMethod := credential.GetString(d.credSource.Config, "auth_method", "")
+	authMethod := credential.GetString(d.sourceConfig(), "auth_method", "")
 	if authMethod != "approle" {
 		return false
 	}
 
 	// AppRole rotation requires role_name to generate new secret_id
-	roleName := credential.GetString(d.credSource.Config, "role_name", "")
+	roleName := credential.GetString(d.sourceConfig(), "role_name", "")
 	return roleName != ""
 }
 
@@ -1154,14 +1169,14 @@ func (d *VaultDriver) PrepareRotation(ctx context.Context) (map[string]string, m
 	d.authMu.Lock()
 	defer d.authMu.Unlock()
 
-	authMethod := credential.GetString(d.credSource.Config, "auth_method", "")
+	authMethod := credential.GetString(d.sourceConfig(), "auth_method", "")
 	if authMethod != "approle" {
 		return nil, nil, 0, fmt.Errorf("rotation only supported for approle auth method, got: %s", authMethod)
 	}
 
-	approleMount := credential.GetString(d.credSource.Config, "approle_mount", "")
-	roleName := credential.GetString(d.credSource.Config, "role_name", "")
-	oldAccessor := credential.GetString(d.credSource.Config, "secret_id_accessor", "")
+	approleMount := credential.GetString(d.sourceConfig(), "approle_mount", "")
+	roleName := credential.GetString(d.sourceConfig(), "role_name", "")
+	oldAccessor := credential.GetString(d.sourceConfig(), "secret_id_accessor", "")
 
 	if roleName == "" {
 		return nil, nil, 0, fmt.Errorf("role_name is required for AppRole rotation")
@@ -1190,7 +1205,7 @@ func (d *VaultDriver) PrepareRotation(ctx context.Context) (map[string]string, m
 
 	// Build new config (both old and new are valid at this point)
 	newConfig := make(map[string]string)
-	for k, v := range d.credSource.Config {
+	for k, v := range d.sourceConfig() {
 		newConfig[k] = v
 	}
 	newConfig["secret_id"] = newSecretID
@@ -1216,16 +1231,19 @@ func (d *VaultDriver) PrepareRotation(ctx context.Context) (map[string]string, m
 
 // CommitRotation activates the new credentials in driver state.
 //
-// Thread-safety: authMu protects credSource.Config writes and loginViaApprole reads.
-// The rotated fields (secret_id, secret_id_accessor) are ONLY read inside loginViaApprole
-// which always runs under authMu. Other config fields (vault_address, database_mount, etc.)
-// are never modified by rotation, so concurrent reads by MintCredential are safe.
+// Thread-safety: authMu serializes this against authentication, and configMu guards
+// the config field itself. Both are needed. The rotated fields (secret_id,
+// secret_id_accessor) are only read inside loginViaApprole, which runs under authMu,
+// and the other fields hold the same value before and after a rotation — but equal
+// values do not make an unsynchronized field write safe. Readers elsewhere take
+// configMu, so the swap must too.
 func (d *VaultDriver) CommitRotation(ctx context.Context, newConfig map[string]string) error {
 	d.authMu.Lock()
 	defer d.authMu.Unlock()
 
-	// Update internal state (safe: rotated fields only read under authMu)
+	d.configMu.Lock()
 	d.credSource.Config = newConfig
+	d.configMu.Unlock()
 
 	// Re-authenticate with new credentials
 	if err := d.loginViaApprole(ctx); err != nil {


### PR DESCRIPTION
**Stack 2/9** — base `fix/cred-rotation-copy-on-write`.

Four drivers replaced their source config while mints were reading it. The writes were locked, or partly locked; the reads were not, so the lock synchronized nothing. The added tests reproduce the gitlab case exactly against the pre-fix code: a read at `gitlab_driver.go:255` racing the unlocked write at `:823`.

- **gitlab** — `CommitRotation` swapped the config with no lock at all, and the two eager swaps in `PrepareRotation` took `configMu` while every accessor read bare. `configMu` becomes an `RWMutex`: the readers are the mint path, and a plain `Mutex` would serialize minters behind a map lookup.
- **azure** — the swap took `tokenMu`, but token acquisition deliberately releases `tokenMu` for its HTTP call and read the credentials on the way. Config gets its own `RWMutex`, kept separate from `tokenMu` precisely because holding `tokenMu` is when config is read. Tenant, client id and secret are now read from one snapshot: read separately, a rotation between two of them pairs a client id with a secret from another generation, and the failure looks like a bad stored secret rather than a torn read.
- **vault** — the values on the unguarded paths are equal across a rotation, so this produced no wrong credential. Equal values do not make an unsynchronized field write safe.
- **kubernetes** — config was already fully guarded; the HTTP client swapped on a TLS change was not. It gets its own lock rather than `authMu`, which rotation already holds when the client is read.

Each driver keeps the write it already had. Making driver config immutable and rebuilding on change is the better end state but depends on the registry reliably rebuilding, so it lands later in the stack.