### PR TITLE
fix(cred): close credential drivers when a namespace is deleted

### DIFF
--- a/core/namespace_store.go
+++ b/core/namespace_store.go
@@ -993,6 +993,30 @@ func (ns *NamespaceStore) clearNamespaceResources(nsCtx context.Context, namespa
 		}
 	}
 
+	// Release the driver instances those sources left behind. Nothing did this
+	// before, so every driver in a deleted namespace — its HTTP clients, pooled
+	// connections and cached upstream tokens — stayed alive for the life of the
+	// process.
+	//
+	// After the clear, not before: with the sources gone a mint can no longer
+	// build a replacement, so closing last also sweeps up anything created while
+	// the clear was running. Failures are logged rather than returned, since the
+	// configs are already deleted and reporting an error for a completed deletion
+	// would be worse than a leaked client.
+	if ns.core.credentialManager != nil {
+		closed, err := ns.core.credentialManager.CloseAllDriversForNamespace(nsCtx)
+		if err != nil {
+			ns.core.logger.Warn("failed to close some credential drivers for deleted namespace",
+				logger.String("namespace_id", namespaceToDelete.ID),
+				logger.Err(err))
+		}
+		if closed > 0 {
+			ns.core.logger.Debug("closed credential drivers for deleted namespace",
+				logger.String("namespace_id", namespaceToDelete.ID),
+				logger.Int("count", closed))
+		}
+	}
+
 	// Clear policies of every type. Each type lives in its own storage view and
 	// the deletion job never clears the namespace prefix wholesale, so a type
 	// missing from this loop is orphaned in storage forever.

--- a/core/namespace_store_test.go
+++ b/core/namespace_store_test.go
@@ -976,3 +976,49 @@ func TestNamespaceStore_ClearNamespaceResources_NilManagers(t *testing.T) {
 	err := core.namespaceStore.clearNamespaceResources(nsCtx, childNs)
 	require.NoError(t, err)
 }
+
+// TestNamespaceStore_ClearNamespaceResourcesClosesDrivers asserts that deleting a
+// namespace releases the credential drivers its sources left behind.
+//
+// Nothing closed them before: CloseAllDriversForNamespace existed across three
+// layers with no production caller, so every driver in a deleted namespace kept its
+// HTTP clients, pooled connections and cached upstream tokens for the life of the
+// process.
+func TestNamespaceStore_ClearNamespaceResourcesClosesDrivers(t *testing.T) {
+	core := createTestCore(t)
+	defer core.tokenStore.Close()
+
+	driver := &mockRotatableDriver{supportsRotation: true}
+	require.NoError(t, core.credentialDriverRegistry.RegisterFactory(&mockDriverFactory{driver: driver}))
+
+	// Rebuild the manager so it resolves through the registry the mock is in.
+	credManager, err := credential.NewManager(
+		core.credentialTypeRegistry, core.credentialDriverRegistry, core.credConfigStore, core.logger)
+	require.NoError(t, err)
+	core.credentialManager = credManager
+
+	childNs := &namespace.Namespace{
+		ID:   "driver-cleanup-ns",
+		UUID: "driver-cleanup-ns-uuid",
+		Path: "driver-cleanup/",
+	}
+	nsCtx := namespace.ContextWithNamespace(context.Background(), childNs)
+
+	require.NoError(t, core.credConfigStore.CreateSource(nsCtx, &credential.CredSource{
+		Name: "mock-src",
+		Type: "mock",
+	}))
+
+	// Instantiate the driver, the way a mint would.
+	_, err = core.credentialManager.GetOrCreateDriver(nsCtx, "mock-src")
+	require.NoError(t, err)
+
+	// The factory hands back one shared instance, so the connection probe that
+	// source validation runs has already torn it down once. Measure the delta.
+	before := driver.GetDriverCleanupCount()
+
+	require.NoError(t, core.namespaceStore.clearNamespaceResources(nsCtx, childNs))
+
+	assert.Equal(t, before+1, driver.GetDriverCleanupCount(),
+		"deleting the namespace must close the drivers its sources created")
+}

--- a/core/rotation_test.go
+++ b/core/rotation_test.go
@@ -18,17 +18,18 @@ import (
 
 // mockRotatableDriver implements both SourceDriver and Rotatable (three-phase) for testing
 type mockRotatableDriver struct {
-	supportsRotation bool
-	prepareCount     int32
-	commitCount      int32
-	cleanupCount     int32
-	prepareError     error
-	commitError      error
-	cleanupError     error
-	preparedConfig   map[string]string
-	cleanupConfig    map[string]string
-	activateAfter    time.Duration // >0 triggers slow path
-	failUntilAttempt int32         // fail PrepareRotation until this many calls
+	supportsRotation   bool
+	prepareCount       int32
+	commitCount        int32
+	cleanupCount       int32
+	prepareError       error
+	commitError        error
+	cleanupError       error
+	preparedConfig     map[string]string
+	cleanupConfig      map[string]string
+	activateAfter      time.Duration // >0 triggers slow path
+	failUntilAttempt   int32         // fail PrepareRotation until this many calls
+	driverCleanupCount int32         // times Cleanup() ran on the driver instance
 }
 
 func (d *mockRotatableDriver) MintCredential(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
@@ -44,7 +45,14 @@ func (d *mockRotatableDriver) Type() string {
 }
 
 func (d *mockRotatableDriver) Cleanup(ctx context.Context) error {
+	atomic.AddInt32(&d.driverCleanupCount, 1)
 	return nil
+}
+
+// GetDriverCleanupCount reports how many times the driver instance itself was torn
+// down, as distinct from cleanupCount, which counts rotation's cleanup stage.
+func (d *mockRotatableDriver) GetDriverCleanupCount() int {
+	return int(atomic.LoadInt32(&d.driverCleanupCount))
 }
 
 func (d *mockRotatableDriver) SupportsRotation() bool {


### PR DESCRIPTION
**Stack 4/9** — base `fix/cred-store-write-locking`.

Deleting a namespace removed its specs and sources but left every driver those sources had created running. `CloseAllDriversForNamespace` existed across the manager, the coordinator and the registry with no caller outside tests, so the HTTP clients, pooled connections and cached upstream tokens of a deleted namespace stayed alive for the life of the process.

Closing happens after the configs are cleared, not before: with the sources gone a mint can no longer build a replacement, so closing last also sweeps up any driver created while the clear was running. Failures are logged rather than returned — the configs are already deleted, and reporting an error for a completed deletion would be worse than a leaked client.

The added test asserts the driver's `Cleanup` runs, and fails on the pre-fix code.
