### PR TITLE
fix(cred): refuse to install a driver built from superseded source config

### DIFF
--- a/credential/driver_coordinator.go
+++ b/credential/driver_coordinator.go
@@ -2,6 +2,7 @@ package credential
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/stephnangue/warden/internal/namespace"
@@ -51,32 +52,58 @@ func NewDriverCoordinator(
 //
 // Returns the driver instance or an error
 func (c *DriverCoordinator) GetOrCreateDriver(ctx context.Context, sourceName string) (SourceDriver, error) {
-	// First try to get existing driver
+	// A cached instance is the common case and costs one map read.
 	if driver, ok := c.driverRegistry.GetDriver(ctx, sourceName); ok {
 		return driver, nil
 	}
 
-	// Driver doesn't exist, fetch source config and create it
-	credSource, err := c.configStore.GetSource(ctx, sourceName)
-	if err != nil {
-		return nil, fmt.Errorf("source '%s' not found: %w", sourceName, err)
+	// Building an instance reads the source and then installs, and the two cannot
+	// be done under one lock — the read goes through the config store, the install
+	// through the registry. A source update landing in between used to leave the
+	// driver built from the config read before it, permanently: nothing re-checks a
+	// registry hit, so that instance was served until the next update or a restart.
+	//
+	// So the generation is read first, and the install refused if it moved while
+	// the source was being read. Config updates are rare, and each retry starts by
+	// re-checking the registry, so this settles immediately in practice; the bound
+	// exists only so a pathological update storm cannot spin here.
+	const maxAttempts = 3
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if driver, ok := c.driverRegistry.GetDriver(ctx, sourceName); ok {
+			return driver, nil
+		}
+
+		generation, err := c.driverRegistry.Generation(ctx, sourceName)
+		if err != nil {
+			return nil, err
+		}
+
+		credSource, err := c.configStore.GetSource(ctx, sourceName)
+		if err != nil {
+			return nil, fmt.Errorf("source '%s' not found: %w", sourceName, err)
+		}
+
+		driver, created, err := c.driverRegistry.CreateDriver(ctx, sourceName, credSource, generation)
+		if errors.Is(err, ErrDriverConfigChanged) {
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to create driver for source '%s': %w", sourceName, err)
+		}
+
+		// Only log when a new driver was actually created (not when returning existing)
+		if created {
+			ns, _ := namespace.FromContext(ctx)
+			c.logger.Debug("credential source driver created",
+				logger.String("namespace", ns.ID),
+				logger.String("source_name", sourceName),
+				logger.String("source_type", credSource.Type))
+		}
+
+		return driver, nil
 	}
 
-	driver, created, err := c.driverRegistry.CreateDriver(ctx, sourceName, credSource)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create driver for source '%s': %w", sourceName, err)
-	}
-
-	// Only log when a new driver was actually created (not when returning existing)
-	if created {
-		ns, _ := namespace.FromContext(ctx)
-		c.logger.Debug("credential source driver created",
-			logger.String("namespace", ns.ID),
-			logger.String("source_name", sourceName),
-			logger.String("source_type", credSource.Type))
-	}
-
-	return driver, nil
+	return nil, fmt.Errorf("failed to create driver for source '%s': config kept changing after %d attempts", sourceName, maxAttempts)
 }
 
 // CloseDriver closes and removes a driver instance by source name.

--- a/credential/driver_coordinator_test.go
+++ b/credential/driver_coordinator_test.go
@@ -1,0 +1,184 @@
+package credential
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/internal/namespace"
+	"github.com/stephnangue/warden/logger"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingDriver reports the config it was built from, so a test can tell which
+// generation of a source an installed driver came from.
+type recordingDriver struct {
+	config map[string]string
+}
+
+func (d *recordingDriver) MintCredential(context.Context, *CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	return nil, nil, 0, "", nil
+}
+func (d *recordingDriver) Revoke(context.Context, string) error { return nil }
+func (d *recordingDriver) Type() string                        { return "recording" }
+func (d *recordingDriver) Cleanup(context.Context) error       { return nil }
+
+type recordingFactory struct {
+	mu    sync.Mutex
+	built []string // the "version" config value each Create saw, in order
+}
+
+func (f *recordingFactory) Type() string                           { return "recording" }
+func (f *recordingFactory) ValidateConfig(map[string]string) error { return nil }
+func (f *recordingFactory) SensitiveConfigFields() []string        { return nil }
+func (f *recordingFactory) InferCredentialType(map[string]string) (string, error) {
+	return "", nil
+}
+func (f *recordingFactory) Create(config map[string]string, _ *logger.GatedLogger) (SourceDriver, error) {
+	f.mu.Lock()
+	f.built = append(f.built, config["version"])
+	f.mu.Unlock()
+	return &recordingDriver{config: config}, nil
+}
+
+// TestGetOrCreateDriver_RefusesToInstallDriverBuiltFromStaleConfig covers the window
+// between reading a source and installing the driver built from it.
+//
+// The read goes through the config store and the install through the registry, so no
+// single lock spans them. A source update landing in between used to leave the
+// registry holding a driver built from the config read before the update — and
+// permanently, because a registry hit is a plain map lookup that re-checks nothing.
+// Every later mint on that source used the superseded credentials until the next
+// config change or a restart.
+//
+// The hook here lands exactly that update, once, in exactly that window.
+func TestGetOrCreateDriver_RefusesToInstallDriverBuiltFromStaleConfig(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	registry := NewDriverRegistry(log)
+	factory := &recordingFactory{}
+	require.NoError(t, registry.RegisterFactory(factory))
+
+	store := newMockConfigStore()
+	store.sources["src"] = &CredSource{
+		Name:   "src",
+		Type:   "recording",
+		Config: map[string]string{"version": "v1"},
+	}
+
+	coordinator := NewDriverCoordinator(registry, store, log)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	// Fire once: the caller has just read v1 and has not installed yet. Publish v2
+	// and invalidate, which is what a source update does.
+	var once sync.Once
+	store.getSourceHook = func() {
+		once.Do(func() {
+			store.mu.Lock()
+			store.sources["src"] = &CredSource{
+				Name:   "src",
+				Type:   "recording",
+				Config: map[string]string{"version": "v2"},
+			}
+			store.mu.Unlock()
+
+			require.NoError(t, registry.CloseDriver(ctx, "src"))
+		})
+	}
+
+	driver, err := coordinator.GetOrCreateDriver(ctx, "src")
+	require.NoError(t, err)
+
+	installed, ok := driver.(*recordingDriver)
+	require.True(t, ok)
+	assert.Equal(t, "v2", installed.config["version"],
+		"the installed driver must come from the config that is current, not the one read before the update")
+
+	// And the instance the registry serves from here on is that same one.
+	cached, ok := registry.GetDriver(ctx, "src")
+	require.True(t, ok)
+	assert.Same(t, driver, cached)
+
+	factory.mu.Lock()
+	built := append([]string(nil), factory.built...)
+	factory.mu.Unlock()
+	assert.Equal(t, []string{"v2"}, built,
+		"the stale generation is caught before the driver is built, so no wasted construction — "+
+			"which matters because several factories authenticate inside Create")
+}
+
+// TestGetOrCreateDriver_ReturnsCachedInstanceWithoutRebuilding asserts the hot path
+// is unchanged: a cached instance is returned without consulting the config store.
+func TestGetOrCreateDriver_ReturnsCachedInstanceWithoutRebuilding(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	registry := NewDriverRegistry(log)
+	factory := &recordingFactory{}
+	require.NoError(t, registry.RegisterFactory(factory))
+
+	store := newMockConfigStore()
+	store.sources["src"] = &CredSource{
+		Name:   "src",
+		Type:   "recording",
+		Config: map[string]string{"version": "v1"},
+	}
+
+	coordinator := NewDriverCoordinator(registry, store, log)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	first, err := coordinator.GetOrCreateDriver(ctx, "src")
+	require.NoError(t, err)
+
+	// Any further read of the source would trip this.
+	store.getSourceHook = func() {
+		t.Error("a cached driver must not re-read the source")
+	}
+
+	second, err := coordinator.GetOrCreateDriver(ctx, "src")
+	require.NoError(t, err)
+	assert.Same(t, first, second)
+
+	factory.mu.Lock()
+	defer factory.mu.Unlock()
+	assert.Len(t, factory.built, 1, "the driver must be built exactly once")
+}
+
+// TestGetOrCreateDriver_ConcurrentCallersShareOneInstance guards the ordinary
+// contended case: many mints missing the cache at once must not leave the registry
+// churning or handing back different instances.
+func TestGetOrCreateDriver_ConcurrentCallersShareOneInstance(t *testing.T) {
+	log, _ := logger.NewGatedLogger(logger.DefaultConfig(), logger.GatedWriterConfig{})
+	registry := NewDriverRegistry(log)
+	require.NoError(t, registry.RegisterFactory(&recordingFactory{}))
+
+	store := newMockConfigStore()
+	store.sources["src"] = &CredSource{
+		Name:   "src",
+		Type:   "recording",
+		Config: map[string]string{"version": "v1"},
+	}
+
+	coordinator := NewDriverCoordinator(registry, store, log)
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+
+	const callers = 16
+	drivers := make([]SourceDriver, callers)
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			d, err := coordinator.GetOrCreateDriver(ctx, "src")
+			if err != nil {
+				t.Errorf("caller %d: %v", idx, err)
+				return
+			}
+			drivers[idx] = d
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 1; i < callers; i++ {
+		assert.Same(t, drivers[0], drivers[i], "all callers must share one instance")
+	}
+}

--- a/credential/driver_registry.go
+++ b/credential/driver_registry.go
@@ -15,14 +15,28 @@ type DriverRegistry struct {
 	factories map[string]SourceDriverFactory // type -> factory
 	instances map[string]SourceDriver        // {namespace}:{source_name} -> driver instance
 	log       *logger.GatedLogger
+
+	// generations counts how many times each source key has been invalidated.
+	//
+	// A driver is built outside this lock, from a source read outside it, so the
+	// config it was built from can go stale before the instance is installed —
+	// and because a registry hit is a plain map lookup, a stale instance
+	// installed once is served until the next config change or a restart.
+	//
+	// Callers therefore read the generation before reading the source and hand it
+	// back at install time; an install whose generation has moved is refused and
+	// the caller re-reads. Checking at install rather than on lookup keeps the
+	// hot path a single map read, and keeps driver teardown off the mint path.
+	generations map[string]uint64
 }
 
 // NewDriverRegistry creates a new driver registry
 func NewDriverRegistry(log *logger.GatedLogger) *DriverRegistry {
 	return &DriverRegistry{
-		factories: make(map[string]SourceDriverFactory),
-		instances: make(map[string]SourceDriver),
-		log:       log,
+		factories:   make(map[string]SourceDriverFactory),
+		instances:   make(map[string]SourceDriver),
+		generations: make(map[string]uint64),
+		log:         log,
 	}
 }
 
@@ -52,12 +66,32 @@ func (r *DriverRegistry) qualifiedKey(ctx context.Context, sourceName string) (s
 	return fmt.Sprintf("%s:%s", ns.ID, sourceName), nil
 }
 
+// Generation returns the current invalidation count for a source key. Read it
+// before reading the source, and pass it to CreateDriver: that is what lets
+// CreateDriver tell whether the config the driver was built from is still current.
+func (r *DriverRegistry) Generation(ctx context.Context, sourceName string) (uint64, error) {
+	qualifiedName, err := r.qualifiedKey(ctx, sourceName)
+	if err != nil {
+		return 0, err
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.generations[qualifiedName], nil
+}
+
 // CreateDriver creates a driver instance for the given source
 // The driver is stored with a namespace-qualified key to prevent collisions
 // between sources with the same name in different namespaces.
 // Returns the driver and a boolean indicating if a new driver was created (true)
 // or an existing driver was returned (false).
-func (r *DriverRegistry) CreateDriver(ctx context.Context, sourceName string, source *CredSource) (SourceDriver, bool, error) {
+//
+// observedGeneration is the value Generation returned before the source was read.
+// If the key has been invalidated since, the source this driver was built from is
+// no longer current and the install is refused with ErrDriverConfigChanged rather
+// than pinning stale config in the registry.
+func (r *DriverRegistry) CreateDriver(ctx context.Context, sourceName string, source *CredSource, observedGeneration uint64) (SourceDriver, bool, error) {
 	qualifiedName, err := r.qualifiedKey(ctx, sourceName)
 	if err != nil {
 		return nil, false, err
@@ -69,6 +103,10 @@ func (r *DriverRegistry) CreateDriver(ctx context.Context, sourceName string, so
 	// Check if instance already exists
 	if driver, exists := r.instances[qualifiedName]; exists {
 		return driver, false, nil
+	}
+
+	if r.generations[qualifiedName] != observedGeneration {
+		return nil, false, ErrDriverConfigChanged
 	}
 
 	// Get factory for source type
@@ -150,6 +188,11 @@ func (r *DriverRegistry) CloseDriver(ctx context.Context, sourceName string) err
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Bump the generation whether or not an instance is present. An invalidation
+	// with nothing cached still matters: a mint that has already read the old
+	// source config and not yet installed its driver must be refused.
+	r.generations[qualifiedName]++
+
 	driver, exists := r.instances[qualifiedName]
 	if !exists {
 		// Driver doesn't exist - nothing to clean up
@@ -204,6 +247,7 @@ func (r *DriverRegistry) CloseAllForNamespace(ctx context.Context) (int, error) 
 	var lastErr error
 
 	for _, key := range toClose {
+		r.generations[key]++
 		driver := r.instances[key]
 		if err := driver.Cleanup(ctx); err != nil {
 			r.log.Warn("driver cleanup failed during namespace cleanup",

--- a/credential/errors.go
+++ b/credential/errors.go
@@ -24,6 +24,11 @@ var (
 	// ErrDriverCreationFailed is returned when driver creation failed
 	ErrDriverCreationFailed = errors.New("driver creation failed")
 
+	// ErrDriverConfigChanged is returned when a driver was built from a source
+	// config that stopped being current before the instance could be installed.
+	// The caller re-reads the source and tries again; it is not surfaced to users.
+	ErrDriverConfigChanged = errors.New("source config changed while building driver")
+
 	// ErrCredentialNotFound is returned when a credential is not found in storage
 	ErrCredentialNotFound = errors.New("credential not found")
 

--- a/credential/manager_test.go
+++ b/credential/manager_test.go
@@ -38,6 +38,10 @@ type mockConfigStore struct {
 	sources   map[string]*CredSource
 	persisted []*CredSpec // specs captured by PersistRotatedSpec, in order
 	persistFn func(spec *CredSpec) error
+
+	// getSourceHook, when set, runs after GetSource has read a source and before
+	// it returns. See GetSource.
+	getSourceHook func()
 }
 
 func newMockConfigStore() *mockConfigStore {
@@ -71,10 +75,18 @@ func (m *mockConfigStore) ReloadSpec(ctx context.Context, name string) (*CredSpe
 
 func (m *mockConfigStore) GetSource(ctx context.Context, name string) (*CredSource, error) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
 	source, ok := m.sources[name]
+	hook := m.getSourceHook
+	m.mu.Unlock()
+
 	if !ok {
 		return nil, errors.New("source not found")
+	}
+	// Runs after the source has been read and before it reaches the caller, so a
+	// test can land a config update in exactly the window a caller sits in between
+	// reading a source and installing the driver built from it.
+	if hook != nil {
+		hook()
 	}
 	return source, nil
 }


### PR DESCRIPTION
**Stack 5/9** — base `fix/cred-namespace-driver-close`.

`GetOrCreateDriver` reads the source through the config store and installs the driver through the registry, so no single lock spans the two. A source update landing in between left the registry holding a driver built from the config read before it — and permanently, because a registry hit is a plain map lookup that re-checks nothing. Every later mint used the superseded credentials until the next config change or a restart.

Moving the driver teardown after the persist (PR 3) narrows that window but cannot close it. The added test drives the interleaving deterministically: on the pre-fix code the registry pins the **v1** driver after a v2 update.

The registry now counts invalidations per source key. A caller reads the count before reading the source and hands it back at install time; an install whose count has moved is refused, and the caller re-reads. Bounded at three attempts, which a config-update storm cannot exceed in practice since each retry starts by re-checking the registry.

Checking at install rather than on lookup was deliberate: the hot path stays a single map read, nothing is evicted while a mint is holding it, and no driver `Cleanup` — which can do network I/O — ever runs on the issuance path. The check also lands before the factory runs, so the superseded driver is never built at all; that matters because several factories authenticate inside `Create`.

The generation is bumped whether or not an instance is cached. An invalidation with nothing cached still has to be seen: that is exactly the case where a mint has read the old config and not yet installed.
