### PR TITLE
refactor(cred): read source config once per operation, not once per key

### DIFF
--- a/credential/drivers/config_race_test.go
+++ b/credential/drivers/config_race_test.go
@@ -6,10 +6,12 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -234,4 +236,83 @@ func TestKubernetesDriver_HTTPClientSwapIsRaceFree(t *testing.T) {
 
 	close(stop)
 	readers.Wait()
+}
+
+// TestGitLabDriver_RequestUsesOneConfigGeneration asserts that a single request
+// reads the address and the token from one snapshot.
+//
+// doGitLabRequest used to call getGitLabAddress, getAuthMethod and getPAT
+// separately, taking three snapshots. Production rotation only ever replaces the
+// token, so the mismatch stayed invisible — but that is a property of what rotation
+// happens to touch today, not of the code. Both keys carry a generation here so the
+// pairing is observable at all: each server accepts only its own token, and a
+// request built from two generations arrives somewhere holding the wrong one.
+func TestGitLabDriver_RequestUsesOneConfigGeneration(t *testing.T) {
+	var mismatches int64
+
+	newServer := func(wantToken string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("PRIVATE-TOKEN") != wantToken {
+				atomic.AddInt64(&mismatches, 1)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"id":1,"active":true}`))
+		}))
+	}
+
+	serverA := newServer("token-a")
+	defer serverA.Close()
+	serverB := newServer("token-b")
+	defer serverB.Close()
+
+	driver := newTestGitLabDriver("token-a")
+	driver.credSource.Config = credential.NewConfig(map[string]string{
+		"gitlab_address":        serverA.URL,
+		"auth_method":           "pat",
+		"personal_access_token": "token-a",
+	})
+	driver.tokenCache = NewTokenCache()
+
+	stop := make(chan struct{})
+	var writer sync.WaitGroup
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		generations := []credential.Config{
+			credential.NewConfig(map[string]string{
+				"gitlab_address": serverA.URL, "auth_method": "pat", "personal_access_token": "token-a",
+			}),
+			credential.NewConfig(map[string]string{
+				"gitlab_address": serverB.URL, "auth_method": "pat", "personal_access_token": "token-b",
+			}),
+		}
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			driver.configMu.Lock()
+			driver.credSource.Config = generations[i%2]
+			driver.configMu.Unlock()
+		}
+	}()
+
+	var callers sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		callers.Add(1)
+		go func() {
+			defer callers.Done()
+			for j := 0; j < 300; j++ {
+				_, _, _ = driver.doGitLabRequest(t.Context(), http.MethodGet, "/api/v4/x", nil, nil)
+			}
+		}()
+	}
+	callers.Wait()
+	close(stop)
+	writer.Wait()
+
+	assert.Zero(t, atomic.LoadInt64(&mismatches),
+		"every request must send the token belonging to the address it was sent to")
 }

--- a/credential/drivers/gitlab_driver.go
+++ b/credential/drivers/gitlab_driver.go
@@ -262,22 +262,41 @@ func (f *GitLabDriverFactory) Create(config credential.Config, log *logger.Gated
 // rather than writing into the live one, so the returned map is a stable snapshot
 // and callers need not hold the lock while reading it. Callers that need several
 // keys to agree must take one snapshot and read all of them from it.
+// An operation that reads more than one key must take one snapshot and read every
+// value from it. Calling this per key is correct for a single value and wrong for
+// a set: a rotation between two calls yields values from two generations.
 func (d *GitLabDriver) sourceConfig() credential.Config {
 	d.configMu.RLock()
 	defer d.configMu.RUnlock()
 	return d.credSource.Config
 }
 
+// The gitlab* functions read one already-taken snapshot. An operation needing more
+// than one value takes a snapshot once and calls these, so every value it uses comes
+// from the same generation; the getX methods below are the convenience form for the
+// single-value case.
+func gitlabAddress(config credential.Config) string {
+	return strings.TrimRight(credential.GetString(config, "gitlab_address", ""), "/")
+}
+
+func gitlabAuthMethod(config credential.Config) string {
+	return credential.GetString(config, "auth_method", "pat")
+}
+
+func gitlabPAT(config credential.Config) string {
+	return credential.GetString(config, "personal_access_token", "")
+}
+
 func (d *GitLabDriver) getGitLabAddress() string {
-	return strings.TrimRight(credential.GetString(d.sourceConfig(), "gitlab_address", ""), "/")
+	return gitlabAddress(d.sourceConfig())
 }
 
 func (d *GitLabDriver) getAuthMethod() string {
-	return credential.GetString(d.sourceConfig(), "auth_method", "pat")
+	return gitlabAuthMethod(d.sourceConfig())
 }
 
 func (d *GitLabDriver) getPAT() string {
-	return credential.GetString(d.sourceConfig(), "personal_access_token", "")
+	return gitlabPAT(d.sourceConfig())
 }
 
 // isChained reports whether this source draws its token from another cred spec
@@ -888,7 +907,14 @@ func (d *GitLabDriver) CleanupRotation(_ context.Context, cleanupConfig map[stri
 // reports failures as an opaque message; a caller that must distinguish an
 // authentication rejection from any other error has no other way to see it.
 func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string, body []byte, chained *gitlabChainedAuth) ([]byte, int, error) {
-	apiURL := d.getGitLabAddress() + path
+	// One snapshot for the whole request. Reading the address, the auth method and
+	// the token separately would let a rotation landing mid-request pair values from
+	// two generations — harmless only for as long as rotation keeps touching exactly
+	// one key, which is not a property worth depending on. It is also the request
+	// path, so this is two fewer lock acquisitions per proxied call.
+	config := d.sourceConfig()
+
+	apiURL := gitlabAddress(config) + path
 
 	// Prepare headers
 	headers := make(map[string]string)
@@ -898,12 +924,12 @@ func (d *GitLabDriver) doGitLabRequest(ctx context.Context, method, path string,
 
 	// Set authentication based on auth method
 	var bearerKey string
-	switch d.getAuthMethod() {
+	switch gitlabAuthMethod(config) {
 	case "pat":
 		if chained != nil {
 			headers["PRIVATE-TOKEN"] = chained.secret
 		} else {
-			headers["PRIVATE-TOKEN"] = d.getPAT()
+			headers["PRIVATE-TOKEN"] = gitlabPAT(config)
 		}
 	case "oauth2":
 		token, key, err := d.getOAuth2Token(ctx, chained)

--- a/credential/drivers/vault_driver.go
+++ b/credential/drivers/vault_driver.go
@@ -268,6 +268,9 @@ func (f *VaultDriverFactory) InferCredentialType(specConfig credential.Config) (
 
 // sourceConfig returns the current config map. Rotation swaps in a whole new map
 // rather than writing into the live one, so the result is a stable snapshot.
+// An operation that reads more than one key must take one snapshot and read every
+// value from it. Calling this per key is correct for a single value and wrong for
+// a set: a rotation between two calls yields values from two generations.
 func (d *VaultDriver) sourceConfig() credential.Config {
 	d.configMu.RLock()
 	defer d.configMu.RUnlock()
@@ -316,9 +319,18 @@ func (d *VaultDriver) isTokenValid(ctx context.Context) bool {
 
 // loginViaApprole authenticates to Vault using AppRole
 func (d *VaultDriver) loginViaApprole(ctx context.Context) error {
-	roleID := credential.GetString(d.sourceConfig(), "role_id", "")
-	secretID := credential.GetString(d.sourceConfig(), "secret_id", "")
-	approleMount := credential.GetString(d.sourceConfig(), "approle_mount", "")
+	// One snapshot: secret_id is what rotation replaces, so reading it separately
+	// from role_id would let a login pair a role with a secret issued for a
+	// different generation of it.
+	//
+	// That cannot happen today — every caller holds authMu, and the only writer
+	// holds it too — but that is an argument spanning three functions, and it stops
+	// holding the moment someone adds a caller that does not take authMu. The
+	// snapshot makes the guarantee local.
+	config := d.sourceConfig()
+	roleID := credential.GetString(config, "role_id", "")
+	secretID := credential.GetString(config, "secret_id", "")
+	approleMount := credential.GetString(config, "approle_mount", "")
 
 	data := map[string]interface{}{
 		"role_id":   roleID,
@@ -1152,14 +1164,13 @@ func (d *VaultDriver) Cleanup(ctx context.Context) error {
 // SupportsRotation returns true if this driver instance can rotate its credentials.
 // Currently only AppRole authentication supports rotation.
 func (d *VaultDriver) SupportsRotation() bool {
-	authMethod := credential.GetString(d.sourceConfig(), "auth_method", "")
-	if authMethod != "approle" {
+	config := d.sourceConfig()
+	if credential.GetString(config, "auth_method", "") != "approle" {
 		return false
 	}
 
 	// AppRole rotation requires role_name to generate new secret_id
-	roleName := credential.GetString(d.sourceConfig(), "role_name", "")
-	return roleName != ""
+	return credential.GetString(config, "role_name", "") != ""
 }
 
 // PrepareRotation generates a new AppRole secret_id WITHOUT destroying the old one.
@@ -1169,14 +1180,19 @@ func (d *VaultDriver) PrepareRotation(ctx context.Context) (map[string]string, m
 	d.authMu.Lock()
 	defer d.authMu.Unlock()
 
-	authMethod := credential.GetString(d.sourceConfig(), "auth_method", "")
+	// One snapshot for everything this rotation derives from the current config, so
+	// the role it generates against and the accessor it retires describe the same
+	// generation.
+	config := d.sourceConfig()
+
+	authMethod := credential.GetString(config, "auth_method", "")
 	if authMethod != "approle" {
 		return nil, nil, 0, fmt.Errorf("rotation only supported for approle auth method, got: %s", authMethod)
 	}
 
-	approleMount := credential.GetString(d.sourceConfig(), "approle_mount", "")
-	roleName := credential.GetString(d.sourceConfig(), "role_name", "")
-	oldAccessor := credential.GetString(d.sourceConfig(), "secret_id_accessor", "")
+	approleMount := credential.GetString(config, "approle_mount", "")
+	roleName := credential.GetString(config, "role_name", "")
+	oldAccessor := credential.GetString(config, "secret_id_accessor", "")
 
 	if roleName == "" {
 		return nil, nil, 0, fmt.Errorf("role_name is required for AppRole rotation")
@@ -1203,9 +1219,10 @@ func (d *VaultDriver) PrepareRotation(ctx context.Context) (map[string]string, m
 		return nil, nil, 0, fmt.Errorf("secret_id_accessor not found in response")
 	}
 
-	// Build new config (both old and new are valid at this point)
-	newConfig := make(map[string]string)
-	for k, v := range d.sourceConfig().All() {
+	// Build new config (both old and new are valid at this point), from the same
+	// snapshot the checks above used rather than re-reading the live field.
+	newConfig := make(map[string]string, config.Len())
+	for k, v := range config.All() {
 		newConfig[k] = v
 	}
 	newConfig["secret_id"] = newSecretID


### PR DESCRIPTION
**Stack 7/9** — base `refactor/cred-config-value-type`.

Locking each read individually makes every value correct on its own and says nothing about a set of them. An operation reading several keys took several snapshots, so a rotation landing between two of them paired values from different generations.

The added test makes that concrete for gitlab: with both the address and the token carrying a generation, and each stub server accepting only its own token, the pre-fix code sends **88–99 wrongly-paired requests per run out of 1200**. Zero after.

- `doGitLabRequest` took three snapshots — address, auth method, token — and now takes one. This is the proxied request path, so it is also two fewer lock acquisitions per call. The `gitlab*` helpers read an already-taken snapshot; the `getX` methods remain the single-value convenience form.
- `loginViaApprole` read `role_id` and `secret_id` separately, and `secret_id` is exactly what rotation replaces. It was safe, but only by an argument spanning three functions that stops holding the moment a caller appears that does not take `authMu`. The snapshot makes it local.
- vault `SupportsRotation` and `PrepareRotation` likewise read once.

**AWS needed no change**, contrary to what the plan for this work assumed: its per-key `sourceConfig` calls each read a single key, which is coherent by construction. The pattern looked wrong; the call sites are not.

`sourceConfig` now documents the rule rather than leaving it to be re-derived: per key is right for one value and wrong for a set.
