### PR TITLE
refactor(cred): resolve a spec and its source once per issuance

### DIFF
--- a/credential/chaining_test.go
+++ b/credential/chaining_test.go
@@ -1184,3 +1184,38 @@ func TestChaining_CacheIsolatesPerRole(t *testing.T) {
 	assert.Equal(t, int32(2), env.exchangeDriver.mintCalls.Load(),
 		"one role across two sessions must still share its cached secret")
 }
+
+// TestChaining_ResolvesEachSourceOnce asserts that a chained issuance reads each
+// source it needs exactly once.
+//
+// Every helper that wanted a source-level value used to ask the store again: the
+// chaining reference, then the cache TTL, then the secret field. Three reads of the
+// consuming source per issuance. That was not just repeated work — the store's cache
+// has no TTL, discards the return of its Set, and may reject or evict at any moment,
+// so those reads could return different objects with no rotation running, and a spec
+// could be routed as chained against one generation of its source while its cache
+// policy and secret field came from another.
+func TestChaining_ResolvesEachSourceOnce(t *testing.T) {
+	env := newChainingEnv(t)
+	defer env.manager.Stop()
+
+	env.store.AddSpec(&CredSpec{
+		Name: "consumer", Type: TypeVaultToken, Source: "consumersource",
+		Config: NewConfig(map[string]string{ConfigSecretSpec: "secret-spec"}),
+	})
+
+	ctx := createNamespaceContext()
+	env.store.resetSourceReads()
+
+	cred, err := env.manager.IssueCredential(ctx, chainCaller("tok"), "consumer", nil)
+	require.NoError(t, err)
+	require.NotNil(t, cred)
+
+	// One for the consuming pair, one for the referenced pair — the two the issuance
+	// genuinely needs — plus the read each driver build pairs with a generation so it
+	// can refuse to install a driver built from config that went stale mid-build.
+	assert.LessOrEqual(t, env.store.sourceReadCount("consumersource"), 2,
+		"the consuming source must be resolved once for the request, not once per helper")
+	assert.LessOrEqual(t, env.store.sourceReadCount("secretsource"), 2,
+		"the referenced spec's source must be resolved once for the request")
+}

--- a/credential/manager.go
+++ b/credential/manager.go
@@ -363,16 +363,18 @@ func (m *Manager) IssueCredential(ctx context.Context, caller Caller, specName s
 // on a real cache miss (or, for a chained secret-spec, on the non-caching path so
 // the fetched secret is never cached).
 func (m *Manager) issueCredential(ctx context.Context, caller Caller, specName string, inputs *ExchangeInputs) (*Credential, error) {
-	// Step 1: Resolve credential spec using SpecResolver
-	spec, err := m.specResolver.ResolveSpec(ctx, specName)
+	// Step 1: Resolve the spec and the source it binds to, once. Everything below
+	// reads that one pair rather than asking the store again per helper.
+	bound, err := m.resolveBound(ctx, specName)
 	if err != nil {
 		return nil, err
 	}
+	spec := bound.spec
 
 	// Credential chaining: when the spec (or its source) references another cred
 	// spec as its secret source, mint that referenced spec as the same caller and
 	// mint this credential from the fetched material. Spec-level reference wins.
-	secretRef, err := m.secretSpecRef(ctx, spec)
+	secretRef, err := bound.secretSpecRef()
 	if err != nil {
 		return nil, err
 	}
@@ -382,9 +384,9 @@ func (m *Manager) issueCredential(ctx context.Context, caller Caller, specName s
 		// client-auth secret — route to the exchange-aware chaining path. Otherwise the
 		// plain chaining path (mint directly from the fetched material) applies.
 		if inputs != nil {
-			return m.issueChainedExchange(ctx, caller, spec, secretRef, inputs)
+			return m.issueChainedExchange(ctx, caller, bound, secretRef, inputs)
 		}
-		return m.issueChained(ctx, caller, spec, secretRef)
+		return m.issueChained(ctx, caller, bound, secretRef)
 	}
 
 	// Step 2: Get or create source driver using DriverCoordinator
@@ -419,20 +421,47 @@ func (m *Manager) mintAndParse(ctx context.Context, spec *CredSpec, driver Sourc
 	return cred, nil
 }
 
+// boundSpec is a spec together with the source it binds to, resolved once at the top
+// of an issuance and threaded down.
+//
+// Resolving per helper was not merely redundant work. The config store's cache has
+// no TTL, discards the return of its Set, and may reject or evict an entry at any
+// time, so two reads of one source name within a single request could hand back two
+// different objects with no rotation running at all. Everything downstream now reads
+// one pair.
+//
+// sourceErr is carried rather than returned at resolve time. A spec that names its
+// own secret_spec never needed its source, so failing the issuance early would break
+// specs that work today.
+type boundSpec struct {
+	spec      *CredSpec
+	source    *CredSource
+	sourceErr error
+}
+
+// resolveBound reads the spec and its source once.
+func (m *Manager) resolveBound(ctx context.Context, specName string) (boundSpec, error) {
+	spec, err := m.specResolver.ResolveSpec(ctx, specName)
+	if err != nil {
+		return boundSpec{}, err
+	}
+	source, srcErr := m.configStore.GetSource(ctx, spec.Source)
+	return boundSpec{spec: spec, source: source, sourceErr: srcErr}, nil
+}
+
 // secretSpecRef returns the referenced secret-spec name for credential chaining:
 // spec-level (ConfigSecretSpec on the spec) wins over source-level (on the source).
-// Returns "" when the spec is not chained. A source-read failure is returned rather
+// Returns "" when the spec is not chained. A source-read failure is reported rather
 // than swallowed, so a transient error can't silently route a chained spec down the
 // direct (non-chained) mint path.
-func (m *Manager) secretSpecRef(ctx context.Context, spec *CredSpec) (string, error) {
-	if ref := spec.Config.Get(ConfigSecretSpec); ref != "" {
+func (b boundSpec) secretSpecRef() (string, error) {
+	if ref := b.spec.Config.Get(ConfigSecretSpec); ref != "" {
 		return ref, nil
 	}
-	src, err := m.configStore.GetSource(ctx, spec.Source)
-	if err != nil {
-		return "", fmt.Errorf("failed to resolve source %q for credential chaining: %w", spec.Source, err)
+	if b.sourceErr != nil {
+		return "", fmt.Errorf("failed to resolve source %q for credential chaining: %w", b.spec.Source, b.sourceErr)
 	}
-	return src.Config.Get(ConfigSecretSpec), nil
+	return b.source.Config.Get(ConfigSecretSpec), nil
 }
 
 // issueChained mints a consuming credential whose secret comes from a referenced
@@ -440,13 +469,14 @@ func (m *Manager) secretSpecRef(ctx context.Context, spec *CredSpec) (string, er
 // the secret material, and hands it to the consuming driver. By default the fetched
 // secret is not cached (re-minted on every consuming-credential miss); a consumer may
 // opt into source-scoped caching via secret_cache_ttl (see resolveChainedSecretData).
-func (m *Manager) issueChained(ctx context.Context, caller Caller, spec *CredSpec, secretRef string) (*Credential, error) {
+func (m *Manager) issueChained(ctx context.Context, caller Caller, bound boundSpec, secretRef string) (*Credential, error) {
+	spec := bound.spec
 	ctx, inputsB, err := m.chainPreamble(ctx, caller, spec, secretRef)
 	if err != nil {
 		return nil, err
 	}
 
-	return m.resolveAndMintChained(ctx, caller, spec, secretRef, inputsB,
+	return m.resolveAndMintChained(ctx, caller, bound, secretRef, inputsB,
 		func(ctx context.Context, spec *CredSpec, material SecretMaterial) (*Credential, error) {
 			driver, err := m.driverCoordinator.GetOrCreateDriver(ctx, spec.Source)
 			if err != nil {
@@ -461,13 +491,14 @@ func (m *Manager) issueChained(ctx context.Context, caller Caller, spec *CredSpe
 // (cached per secret_cache_ttl) and performs the exchange using the consuming spec's own
 // exchange inputs plus the fetched material. Reuses resolveAndMintChained, so caching,
 // per-agent/per-user isolation, and evict-and-retry are inherited from the generic path.
-func (m *Manager) issueChainedExchange(ctx context.Context, caller Caller, spec *CredSpec, secretRef string, inputs *ExchangeInputs) (*Credential, error) {
+func (m *Manager) issueChainedExchange(ctx context.Context, caller Caller, bound boundSpec, secretRef string, inputs *ExchangeInputs) (*Credential, error) {
+	spec := bound.spec
 	ctx, inputsB, err := m.chainPreamble(ctx, caller, spec, secretRef)
 	if err != nil {
 		return nil, err
 	}
 
-	return m.resolveAndMintChained(ctx, caller, spec, secretRef, inputsB,
+	return m.resolveAndMintChained(ctx, caller, bound, secretRef, inputsB,
 		func(ctx context.Context, spec *CredSpec, material SecretMaterial) (*Credential, error) {
 			driver, err := m.driverCoordinator.GetOrCreateDriver(ctx, spec.Source)
 			if err != nil {
@@ -516,16 +547,17 @@ func (m *Manager) chainPreamble(ctx context.Context, caller Caller, spec *CredSp
 func (m *Manager) resolveAndMintChained(
 	ctx context.Context,
 	caller Caller,
-	spec *CredSpec,
+	bound boundSpec,
 	secretRef string,
 	inputsB *ExchangeInputs,
 	mintFn func(ctx context.Context, spec *CredSpec, material SecretMaterial) (*Credential, error),
 ) (*Credential, error) {
-	data, typ, fromCache, key, err := m.resolveChainedSecretData(ctx, caller, spec, secretRef, inputsB)
+	spec := bound.spec
+	data, typ, fromCache, key, err := m.resolveChainedSecretData(ctx, caller, bound, secretRef, inputsB)
 	if err != nil {
 		return nil, err
 	}
-	material := m.buildSecretMaterial(ctx, spec, data, typ)
+	material := m.buildSecretMaterial(bound, data, typ)
 
 	cred, err := mintFn(ctx, spec, material)
 	if err != nil && fromCache && (errors.Is(err, ErrChainedSecretRejected) || errors.Is(err, ErrRefreshTokenRejected) || errors.Is(err, ErrChainedSecretIncomplete)) {
@@ -533,11 +565,11 @@ func (m *Manager) resolveAndMintChained(
 		// something the driver needs — evict it and retry once with a fresh fetch, in
 		// case it was rotated or completed at the source after we cached it.
 		m.invalidateChainedSecret(key)
-		data, typ, _, _, rerr := m.resolveChainedSecretData(ctx, caller, spec, secretRef, inputsB)
+		data, typ, _, _, rerr := m.resolveChainedSecretData(ctx, caller, bound, secretRef, inputsB)
 		if rerr != nil {
 			return nil, rerr
 		}
-		return mintFn(ctx, spec, m.buildSecretMaterial(ctx, spec, data, typ))
+		return mintFn(ctx, spec, m.buildSecretMaterial(bound, data, typ))
 	}
 	return cred, err
 }
@@ -545,8 +577,8 @@ func (m *Manager) resolveAndMintChained(
 // buildSecretMaterial resolves the secret_field for the consuming spec and wraps the
 // fetched data as SecretMaterial. The field is resolved per-consumer (not cached),
 // using a synthetic Credential so resolveSecretField's type-based fallback still works.
-func (m *Manager) buildSecretMaterial(ctx context.Context, spec *CredSpec, data map[string]string, typ string) SecretMaterial {
-	field := m.resolveSecretField(ctx, spec, &Credential{Data: data, Type: typ})
+func (m *Manager) buildSecretMaterial(bound boundSpec, data map[string]string, typ string) SecretMaterial {
+	field := m.resolveSecretField(bound, &Credential{Data: data, Type: typ})
 	return SecretMaterial{Data: data, Field: field}
 }
 
@@ -616,8 +648,8 @@ func (m *Manager) fetchChainedSecret(ctx context.Context, caller Caller, secretR
 // retry. A ttl <= 0, or a context without a namespace, disables caching and fetches
 // directly — the behaviour-preserving default. An entry never outlives the referenced
 // credential: a lifetime reported by the fetch caps the configured ttl.
-func (m *Manager) resolveChainedSecretData(ctx context.Context, caller Caller, spec *CredSpec, secretRef string, inputsB *ExchangeInputs) (data map[string]string, typ string, fromCache bool, key string, err error) {
-	ttl := m.secretCacheTTL(ctx, spec)
+func (m *Manager) resolveChainedSecretData(ctx context.Context, caller Caller, bound boundSpec, secretRef string, inputsB *ExchangeInputs) (data map[string]string, typ string, fromCache bool, key string, err error) {
+	ttl := bound.secretCacheTTL()
 	if ttl <= 0 {
 		return m.fetchUncached(ctx, caller, secretRef, inputsB)
 	}
@@ -707,15 +739,15 @@ func (m *Manager) fetchUncached(ctx context.Context, caller Caller, secretRef st
 // one secret's rotation profile, so inheriting it across a different reference
 // caches one payload under a policy picked for another, silently opting the spec
 // into caching it never asked for.
-func (m *Manager) secretCacheTTL(ctx context.Context, spec *CredSpec) time.Duration {
-	if _, ok := spec.Config.Lookup(ConfigSecretCacheTTL); ok {
-		return GetDuration(spec.Config, ConfigSecretCacheTTL, 0)
+func (b boundSpec) secretCacheTTL() time.Duration {
+	if _, ok := b.spec.Config.Lookup(ConfigSecretCacheTTL); ok {
+		return GetDuration(b.spec.Config, ConfigSecretCacheTTL, 0)
 	}
-	if src, err := m.configStore.GetSource(ctx, spec.Source); err == nil && src != nil {
-		if !sourceModifiersApply(spec, src) {
+	if b.sourceErr == nil && b.source != nil {
+		if !sourceModifiersApply(b.spec, b.source) {
 			return 0
 		}
-		return GetDuration(src.Config, ConfigSecretCacheTTL, 0)
+		return GetDuration(b.source.Config, ConfigSecretCacheTTL, 0)
 	}
 	return 0
 }
@@ -982,12 +1014,12 @@ func copyStringMap(in map[string]string) map[string]string {
 // A spec refining the field for a source-level reference is the coherent case and
 // still works: both concern the same payload. See sourceModifiersApply for the one
 // case that does not.
-func (m *Manager) resolveSecretField(ctx context.Context, spec *CredSpec, credB *Credential) string {
-	if f := spec.Config.Get(ConfigSecretField); f != "" {
+func (m *Manager) resolveSecretField(bound boundSpec, credB *Credential) string {
+	if f := bound.spec.Config.Get(ConfigSecretField); f != "" {
 		return f
 	}
-	if src, err := m.configStore.GetSource(ctx, spec.Source); err == nil && src != nil && sourceModifiersApply(spec, src) {
-		if f := src.Config.Get(ConfigSecretField); f != "" {
+	if bound.sourceErr == nil && bound.source != nil && sourceModifiersApply(bound.spec, bound.source) {
+		if f := bound.source.Config.Get(ConfigSecretField); f != "" {
 			return f
 		}
 	}

--- a/credential/manager_test.go
+++ b/credential/manager_test.go
@@ -42,14 +42,33 @@ type mockConfigStore struct {
 	// getSourceHook, when set, runs after GetSource has read a source and before
 	// it returns. See GetSource.
 	getSourceHook func()
+
+	// sourceReads counts GetSource calls per name, so a test can assert an issuance
+	// resolves each source exactly once.
+	sourceReads map[string]int
 }
 
 func newMockConfigStore() *mockConfigStore {
 	return &mockConfigStore{
-		cache:   make(map[string]*CredSpec),
-		storage: make(map[string]*CredSpec),
-		sources: make(map[string]*CredSource),
+		cache:       make(map[string]*CredSpec),
+		storage:     make(map[string]*CredSpec),
+		sources:     make(map[string]*CredSource),
+		sourceReads: make(map[string]int),
 	}
+}
+
+// sourceReadCount reports how many times a source name was resolved.
+func (m *mockConfigStore) sourceReadCount(name string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.sourceReads[name]
+}
+
+// resetSourceReads zeroes the counters so a test can measure one issuance.
+func (m *mockConfigStore) resetSourceReads() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sourceReads = make(map[string]int)
 }
 
 func (m *mockConfigStore) GetSpec(ctx context.Context, name string) (*CredSpec, error) {
@@ -77,6 +96,10 @@ func (m *mockConfigStore) GetSource(ctx context.Context, name string) (*CredSour
 	m.mu.Lock()
 	source, ok := m.sources[name]
 	hook := m.getSourceHook
+	if m.sourceReads == nil {
+		m.sourceReads = make(map[string]int)
+	}
+	m.sourceReads[name]++
 	m.mu.Unlock()
 
 	if !ok {
@@ -1600,4 +1623,42 @@ func TestClaimsFingerprint_NoConcatenationCollisions(t *testing.T) {
 		claimsFingerprint(map[string]string{"a": "b", "c": "d"}),
 		claimsFingerprint(map[string]string{"a": "bcd"}))
 	assert.NotContains(t, claimsFingerprint(map[string]string{"sub": "SECRETVALUE"}), "SECRETVALUE")
+}
+
+// TestManager_IssuanceResolvesEachSourceOnce pins the read count of a plain
+// issuance.
+//
+// Unlike the chained case — see TestChaining_ResolvesEachSourceOnce, which is where
+// the repeated reads actually were — a plain issuance always resolved its source
+// once, so this test does not reproduce a past defect. It guards against a future
+// one: the helpers that want a source-level value now take the pair they are given,
+// and the count must not start growing again as more of them appear.
+func TestManager_IssuanceResolvesEachSourceOnce(t *testing.T) {
+	manager, configStore, _ := createTestManager(t)
+	defer manager.Stop()
+
+	configStore.AddSource(&CredSource{Name: "src", Type: SourceTypeLocal, Config: NewConfig(map[string]string{})})
+	configStore.AddSpec(&CredSpec{Name: "spec", Type: TypeVaultToken, Source: "src", Config: NewConfig(map[string]string{})})
+
+	ctx := createNamespaceContext()
+	configStore.resetSourceReads()
+
+	_, err := manager.IssueCredential(ctx, Caller{TokenID: "tok", TokenTTL: time.Hour}, "spec", nil)
+	require.NoError(t, err)
+
+	// Two, and both are load-bearing: the request's own snapshot, and the read the
+	// driver coordinator pairs with a generation so it can refuse to install a driver
+	// built from config that went stale mid-build. Handing the coordinator the
+	// request's already-read source would collapse this to one and undo that check.
+	// What this asserts is that the number does not grow with the number of helpers
+	// that want a source-level value.
+	assert.Equal(t, 2, configStore.sourceReadCount("src"),
+		"a plain issuance resolves its source once for the request and once to build the driver")
+
+	// The driver is cached now, so a second issuance takes only the request snapshot.
+	configStore.resetSourceReads()
+	_, err = manager.IssueCredential(ctx, Caller{TokenID: "tok2", TokenTTL: time.Hour}, "spec", nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, configStore.sourceReadCount("src"),
+		"with the driver already built, an issuance resolves its source exactly once")
 }


### PR DESCRIPTION
**Stack 8/9** — base `refactor/cred-driver-config-snapshot`.

Every helper that wanted a source-level value asked the store again: the chaining reference, then the cache TTL, then the secret field. A chained issuance read its consuming source three times, which the added test measures directly — **three before, one after**, plus the one each driver build takes.

The repetition was the smaller problem. The store's cache has no TTL, discards the return of its `Set`, and may reject or evict an entry at any time, so those reads could hand back different objects with no rotation running at all: a spec routed as chained against one generation of its source, then given a cache policy and a secret field from another.

An issuance now resolves the pair once and threads it. **Two pairs, not one** — the consuming spec with its source, and the referenced secret-spec with its own, which is a different source that no top-level resolve can stand in for.

The source read is kept tolerant rather than failing the issuance early. A spec naming its own `secret_spec` never needed its source, so resolving eagerly and returning the error would break specs that work today; `boundSpec` carries the error instead and each helper decides, exactly as before.

### Deliberately not done

Handing the driver coordinator the source the request already read. That would collapse the remaining two reads to one and undo the generation check from PR 5 that lets the coordinator refuse a driver built from config that went stale mid-build. The second read is part of that protocol, not redundancy.

### Review note

`TestManager_IssuanceResolvesEachSourceOnce` does **not** reproduce a past defect — a plain issuance always resolved its source once. It guards against a future one, and its comment says so. The chained test is the one that discriminates.
