### PR TITLE
fix(gcp): harden the credential driver and expose endpoint overrides

### DIFF
--- a/credential/drivers/assertion_claims_test.go
+++ b/credential/drivers/assertion_claims_test.go
@@ -196,7 +196,7 @@ func TestDeriveAssertionResource(t *testing.T) {
 		{
 			name:       "gcp impersonation names the target service account",
 			sourceType: credential.SourceTypeGCP,
-			sourceCfg:  map[string]string{"workload_identity_provider": testAudGCPProvider},
+			sourceCfg:  map[string]string{"auth_method": "oidc_federation", "workload_identity_provider": testAudGCPProvider},
 			specCfg:    map[string]string{"mint_method": "impersonated_access_token", "target_service_account": "sa@p.iam.gserviceaccount.com"},
 			want:       "gcp-iam:sa@p.iam.gserviceaccount.com",
 			wantOK:     true,
@@ -204,7 +204,7 @@ func TestDeriveAssertionResource(t *testing.T) {
 		{
 			name:       "gcp federated names the provider from source config",
 			sourceType: credential.SourceTypeGCP,
-			sourceCfg:  map[string]string{"workload_identity_provider": testAudGCPProvider},
+			sourceCfg:  map[string]string{"auth_method": "oidc_federation", "workload_identity_provider": testAudGCPProvider},
 			specCfg:    map[string]string{"mint_method": "access_token"},
 			want:       "gcp-wif:" + testAudGCPProvider,
 			wantOK:     true,

--- a/credential/drivers/aws_driver.go
+++ b/credential/drivers/aws_driver.go
@@ -176,12 +176,12 @@ func (f *AWSDriverFactory) ValidateConfig(config credential.Config) error {
 			Example("sts.amazonaws.com"),
 
 		credential.StringField("sts_endpoint").
-			Custom(validateAWSEndpoint).
+			Custom(validateEndpointURL).
 			Describe("Override where STS calls are sent, including the credential probe run when this source is written (default: the SDK's regional endpoint). Does not apply to the IAM, Redshift or RDS clients").
 			Example("https://sts.us-east-1.amazonaws.com"),
 
 		credential.StringField("secretsmanager_endpoint").
-			Custom(validateAWSEndpoint).
+			Custom(validateEndpointURL).
 			Describe("Override where Secrets Manager calls are sent (default: the SDK's regional endpoint)").
 			Example("https://secretsmanager.us-east-1.amazonaws.com"),
 
@@ -225,10 +225,11 @@ func (f *AWSDriverFactory) ValidateConfig(config credential.Config) error {
 	return nil
 }
 
-// validateAWSEndpoint checks an endpoint override is a URL the SDK can actually
+// validateEndpointURL checks an endpoint override is a URL a client can actually
 // send to. A keyless source runs no probe when it is written, so without this a
-// typo surfaces only on the first request that needs it.
-func validateAWSEndpoint(v string) error {
+// typo surfaces only on the first request that needs it. Shared with the other
+// drivers that expose endpoint overrides — nothing about it is AWS-specific.
+func validateEndpointURL(v string) error {
 	u, err := url.Parse(v)
 	if err != nil {
 		return fmt.Errorf("endpoint is not a valid URL: %w", err)

--- a/credential/drivers/gcp_driver.go
+++ b/credential/drivers/gcp_driver.go
@@ -7,10 +7,13 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
+	"unicode"
 
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
 	"github.com/stephnangue/warden/credential"
@@ -35,17 +38,48 @@ const (
 	gcpAuthMethodOIDCFederation = "oidc_federation"
 )
 
-// Default GCP API hosts. The driver's stsHost/iamCredentialsHost fields default to
-// these; tests override the fields to point token exchange and impersonation at a
-// local server.
+// Default GCP API hosts. The driver's host fields default to these. The STS and IAM
+// Credentials hosts are additionally settable from source config, so a deployment
+// behind a private-service-connect endpoint — and the e2e suite, which runs the whole
+// federated fetch against a local listener — can redirect them.
 const (
 	defaultGCPSTSHost            = "https://sts.googleapis.com"
 	defaultGCPIAMCredentialsHost = "https://iamcredentials.googleapis.com"
+	defaultGCPIAMHost            = "https://iam.googleapis.com"
 )
 
-// gcpFederatedTokenFallbackTTL is used when the STS token-exchange response omits
-// the optional expires_in, so the lease is never zero/negative.
-const gcpFederatedTokenFallbackTTL = 1 * time.Hour
+// OAuth2 scopes this driver requests. cloud-platform authorizes the token mints and
+// the impersonation call; the narrower iam scope authorizes only the key-management
+// calls rotation makes against iam.googleapis.com.
+const (
+	gcpCloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+	gcpIAMScope           = "https://www.googleapis.com/auth/iam"
+)
+
+// gcpSTSTokenFallbackTTL is used when the STS token-exchange response omits the
+// optional expires_in, so the lease is never zero/negative. It applies only to that
+// response: an impersonated token carries a requested lifetime, and falling back to a
+// constant there would hand out a lease outliving the token (see impersonationTTL).
+const gcpSTSTokenFallbackTTL = 1 * time.Hour
+
+// gcpMaxImpersonationLifetime is the ceiling generateAccessToken accepts. The API's
+// own default maximum is 3600s; 43200s requires the target service account to sit in
+// an org policy carrying the credential-lifetime-extension constraint. Validating
+// against the higher bound leaves that policy's decision to GCP while still catching
+// a lifetime that no configuration could ever satisfy.
+const gcpMaxImpersonationLifetime = 43200 * time.Second
+
+// gcpAPIMaxAttempts is how many times a GCP API call is tried before giving up. The
+// calls this driver makes are all safe to re-issue, and GCP answers 429 on the
+// service-account key quota and 5xx under load — a single attempt turned any of those
+// into a failed mint or a half-finished rotation.
+const gcpAPIMaxAttempts = 3
+
+// gcpRotationVerifyTimeout bounds the wait for a freshly created service-account key
+// to become usable. A new key is not immediately recognised across Google's replicas,
+// so the first mints against it can fail with an invalid-signature error that is
+// purely propagation delay; treating that as a bad key would delete a good one.
+const gcpRotationVerifyTimeout = 60 * time.Second
 
 // Compile-time interface assertions
 var _ credential.SourceDriver = (*GCPDriver)(nil)
@@ -85,19 +119,20 @@ type GCPDriver struct {
 	// HTTP client for GCP API calls
 	httpClient *http.Client
 
-	// authMu guards credSource.Config and sourceVerified against the rewrite in
-	// CommitRotation. It is held only across those field accesses and never across a
-	// token mint, so a slow acquisition cannot block a config reader.
+	// authMu guards credSource.Config against the rewrite in CommitRotation. It is
+	// held only across those field accesses and never across a token mint, so a slow
+	// acquisition cannot block a config reader.
 	authMu sync.Mutex
 
-	// Flag to track if source credentials have been verified
-	// Protected by authMu
-	sourceVerified bool
-
-	// API hosts, defaulting to the public GCP endpoints. Overridden in tests to
-	// point STS token exchange and SA impersonation at a local server.
+	// API hosts, defaulting to the public GCP endpoints. stsHost and
+	// iamCredentialsHost are settable from source config; iamHost is not, because the
+	// only calls it serves create and delete real service-account keys, which an
+	// override cannot redirect anywhere useful. It stays a field so the rotation tests
+	// can reach a local listener — before it existed those two calls hardcoded their
+	// URL inline and were untestable, which is why they carried no coverage at all.
 	stsHost            string
 	iamCredentialsHost string
+	iamHost            string
 }
 
 // Config accessors — single source of truth is credSource.Config. Each takes authMu,
@@ -139,9 +174,34 @@ func (d *GCPDriver) parseServiceAccountKey() (*serviceAccountKey, error) {
 	if saKeyJSON == "" {
 		return nil, fmt.Errorf("service_account_key is empty")
 	}
+	return parseServiceAccountKeyJSON([]byte(saKeyJSON))
+}
+
+// parseServiceAccountKeyJSON decodes a service-account key and checks every field
+// this driver goes on to use: the type it dispatches on, the identity it addresses
+// the key by when rotating, and the private key that signs the token grant.
+//
+// "Unmarshals without error" is not a check — `null` and `{}` both satisfy it, and a
+// key that passes only that bar reaches storage as the source's credential and breaks
+// it. The type is pinned here as well as at the token grant so a credential document
+// naming a file or URL to fetch is refused at the boundary it arrives on.
+func parseServiceAccountKeyJSON(raw []byte) (*serviceAccountKey, error) {
 	var saKey serviceAccountKey
-	if err := json.Unmarshal([]byte(saKeyJSON), &saKey); err != nil {
-		return nil, fmt.Errorf("invalid service_account_key JSON: %w", err)
+	if err := json.Unmarshal(raw, &saKey); err != nil {
+		return nil, fmt.Errorf("must be valid JSON: %w", err)
+	}
+	if saKey.Type != "service_account" {
+		return nil, fmt.Errorf("'type' must be \"service_account\", got %q: other credential types name an external file or URL to read, which this driver never fetches", saKey.Type)
+	}
+	for _, f := range []struct{ name, value string }{
+		{"project_id", saKey.ProjectID},
+		{"client_email", saKey.ClientEmail},
+		{"private_key", saKey.PrivateKey},
+		{"private_key_id", saKey.PrivateKeyID},
+	} {
+		if f.value == "" {
+			return nil, fmt.Errorf("missing '%s' field in JSON", f.name)
+		}
 	}
 	return &saKey, nil
 }
@@ -164,18 +224,8 @@ func (f *GCPDriverFactory) ValidateConfig(config credential.Config) error {
 
 		credential.StringField("service_account_key").
 			Custom(func(value string) error {
-				// Validate that service_account_key is valid JSON with required fields
-				var saKey serviceAccountKey
-				if err := json.Unmarshal([]byte(value), &saKey); err != nil {
-					return fmt.Errorf("must be valid JSON: %w", err)
-				}
-				if saKey.ClientEmail == "" {
-					return fmt.Errorf("missing 'client_email' field in JSON")
-				}
-				if saKey.PrivateKey == "" {
-					return fmt.Errorf("missing 'private_key' field in JSON")
-				}
-				return nil
+				_, err := parseServiceAccountKeyJSON([]byte(value))
+				return err
 			}).
 			Describe("GCP service account key in JSON format (required for auth_method=static)").
 			Example("{\"type\":\"service_account\",\"project_id\":\"...\",\"private_key\":\"...\"}"),
@@ -183,6 +233,20 @@ func (f *GCPDriverFactory) ValidateConfig(config credential.Config) error {
 		credential.StringField("workload_identity_provider").
 			Describe("Full WIF provider resource name (required for auth_method=oidc_federation)").
 			Example("//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/warden-oidc"),
+
+		credential.StringField("sts_endpoint").
+			Custom(validateEndpointURL).
+			Describe("Override where the STS token exchange is sent (default: the public GCP endpoint). Only applies to auth_method=oidc_federation").
+			Example("https://sts.googleapis.com"),
+
+		credential.StringField("iamcredentials_endpoint").
+			Custom(validateEndpointURL).
+			Describe("Override where service-account impersonation calls are sent (default: the public GCP endpoint). Does not apply to the IAM key-management calls rotation makes").
+			Example("https://iamcredentials.googleapis.com"),
+
+		credential.DurationField("activation_delay").
+			Describe("How long to wait after creating a rotated service-account key before activating it, covering IAM propagation").
+			Example("2m"),
 
 		credential.StringField("ca_data").
 			Custom(ValidateCAData).
@@ -208,6 +272,12 @@ func (f *GCPDriverFactory) ValidateConfig(config credential.Config) error {
 		if credential.GetString(config, "workload_identity_provider", "") != "" {
 			return fmt.Errorf("workload_identity_provider is only valid for auth_method=oidc_federation")
 		}
+		// Same reasoning for the STS override. Static auth never reaches STS — it
+		// exchanges the key's own token_uri — so this would be accepted and never
+		// read, leaving a source that looks redirected while talking to Google.
+		if credential.GetString(config, "sts_endpoint", "") != "" {
+			return fmt.Errorf("sts_endpoint is only valid for auth_method=oidc_federation: static auth exchanges the service account key's own token_uri and never calls STS")
+		}
 	case gcpAuthMethodOIDCFederation:
 		// A federation source holds no static key. Reject leftover static config so a
 		// misconfiguration cannot silently mix modes.
@@ -225,6 +295,23 @@ func (f *GCPDriverFactory) ValidateConfig(config credential.Config) error {
 	return nil
 }
 
+// ValidateRotationConfig refuses a rotation period on a source whose impersonation
+// calls are redirected. Rotation acts on the real account through IAM, which
+// deliberately has no override, so a source pointed at a stand-in would verify
+// against it while trying to rotate keys that only exist somewhere else.
+//
+// sts_endpoint is absent from this check on purpose: it is valid only under
+// oidc_federation, and a federated source is already refused a rotation_period
+// before any driver sees it. Naming it here would be a rule that can never fire.
+func (f *GCPDriverFactory) ValidateRotationConfig(config credential.Config) error {
+	if credential.GetString(config, "iamcredentials_endpoint", "") == "" {
+		return nil
+	}
+	return fmt.Errorf("rotation_period cannot be set on a source that overrides " +
+		"iamcredentials_endpoint: rotation manages service account keys in the real " +
+		"project, which that override does not redirect")
+}
+
 // SensitiveConfigFields returns the list of config keys that should be masked in output
 func (f *GCPDriverFactory) SensitiveConfigFields() []string {
 	return []string{"service_account_key", "ca_data"}
@@ -235,7 +322,12 @@ func (f *GCPDriverFactory) InferCredentialType(specConfig credential.Config) (st
 	mintMethod := specConfig.Get("mint_method")
 	switch mintMethod {
 	case "cloud_sql_iam_token":
-		return credential.TypeDBAuthToken, nil
+		// Named by the db_auth_token schema and validated there, but no mint path
+		// implements it. Refusing here turns a spec that writes cleanly and then
+		// fails on every request into one that fails at the point the mistake is
+		// made. The same refusal lives in the db_auth_token validator, which is the
+		// path taken when the operator states `type` instead of leaving it inferred.
+		return "", fmt.Errorf("mint_method %q is not implemented for the gcp driver", mintMethod)
 	case "", "access_token", "impersonated_access_token":
 		return credential.TypeGCPAccessToken, nil
 	default:
@@ -250,10 +342,13 @@ func (f *GCPDriverFactory) Create(config credential.Config, log *logger.GatedLog
 			Type:   credential.SourceTypeGCP,
 			Config: config,
 		},
-		logger:             log.WithSubsystem(credential.SourceTypeGCP),
-		tokenCache:         NewTokenCache(),
-		stsHost:            defaultGCPSTSHost,
-		iamCredentialsHost: defaultGCPIAMCredentialsHost,
+		logger:     log.WithSubsystem(credential.SourceTypeGCP),
+		tokenCache: NewTokenCache(),
+		stsHost: strings.TrimRight(
+			credential.GetString(config, "sts_endpoint", defaultGCPSTSHost), "/"),
+		iamCredentialsHost: strings.TrimRight(
+			credential.GetString(config, "iamcredentials_endpoint", defaultGCPIAMCredentialsHost), "/"),
+		iamHost: defaultGCPIAMHost,
 	}
 
 	httpClient, err := BuildHTTPClient(config, 30*time.Second)
@@ -273,10 +368,9 @@ func (f *GCPDriverFactory) Create(config credential.Config, log *logger.GatedLog
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if _, _, err := driver.acquireToken(ctx, []string{"https://www.googleapis.com/auth/cloud-platform"}); err != nil {
+	if _, _, err := driver.acquireToken(ctx, []string{gcpCloudPlatformScope}); err != nil {
 		return nil, fmt.Errorf("GCP authentication failed: %w", err)
 	}
-	driver.sourceVerified = true
 
 	return driver, nil
 }
@@ -344,19 +438,48 @@ func gcpImpersonatedMetadata(saKey *serviceAccountKey, targetSA, scopes, lifetim
 	return meta
 }
 
-// mintAccessToken exchanges the source SA key for an OAuth2 access token
+// mintAccessToken exchanges the source SA key for an OAuth2 access token.
+//
+// The credential this vends is the source service account's own token, shared by
+// every caller asking for the same scopes. That makes the spec's scopes the only
+// thing narrowing it, so they are required rather than defaulted: the former default
+// was cloud-platform, which on a rotation-enabled source carries authority over the
+// source's own keys — a leaked lease could mint a replacement for Warden's identity
+// and outlive any revocation.
 func (d *GCPDriver) mintAccessToken(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
-	scopesStr := credential.GetString(spec.Config, "scopes", "https://www.googleapis.com/auth/cloud-platform")
+	scopesStr := credential.GetString(spec.Config, "scopes", "")
 	scopes := splitScopes(scopesStr)
+	if len(scopes) == 0 {
+		return nil, nil, 0, "", fmt.Errorf("gcp: 'scopes' is required for mint_method=access_token: this vends the source service account's own token, and without explicit scopes it would carry the source's full authority")
+	}
 
 	token, expiry, err := d.getSourceToken(ctx, scopes)
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("failed to acquire GCP access token: %w", err)
 	}
 
-	saKey, _ := d.parseServiceAccountKey()
+	saKey, err := d.parseServiceAccountKey()
+	if err != nil && d.logger != nil {
+		// The key just minted a token, so this is near-unreachable; log rather than
+		// fail, but do not discard it — the cost is audit metadata losing the subject.
+		d.logger.Warn("could not parse source service account key for mint metadata",
+			logger.String("spec", spec.Name), logger.String("error", err.Error()))
+	}
 
+	// A cached token is handed out with the life it has left, not the life it had.
+	// Zero or negative means the grant carried no usable expiry: caching that yields a
+	// credential already expired on arrival, which re-mints on every single request.
 	ttl := time.Until(expiry)
+	if ttl <= 0 {
+		return nil, nil, 0, "", fmt.Errorf("gcp: access token carries no usable expiry (expires at %s)", expiry.UTC().Format(time.RFC3339))
+	}
+	// MinTTL is deliberately not enforced: the token's real validity is fixed by
+	// Google and a short remainder cannot be extended, so capping is the only bound
+	// available. The same asymmetry is documented on the federated path.
+	if spec.MaxTTL > 0 && ttl > spec.MaxTTL {
+		ttl = spec.MaxTTL
+	}
+
 	rawData := map[string]interface{}{
 		"access_token": token,
 	}
@@ -383,12 +506,23 @@ func (d *GCPDriver) mintImpersonatedAccessToken(ctx context.Context, spec *crede
 		return nil, nil, 0, "", fmt.Errorf("target_service_account is required for impersonated_access_token mint method")
 	}
 
-	scopesStr := credential.GetString(spec.Config, "scopes", "https://www.googleapis.com/auth/cloud-platform")
+	scopesStr := credential.GetString(spec.Config, "scopes", gcpCloudPlatformScope)
 	scopes := splitScopes(scopesStr)
+	if len(scopes) == 0 {
+		return nil, nil, 0, "", fmt.Errorf("gcp: 'scopes' resolved to nothing for mint_method=impersonated_access_token")
+	}
 	lifetime := credential.GetString(spec.Config, "lifetime", "3600s")
+	// Checked here as well as on the federated path: the impersonated token's life is
+	// what the caller asked for, so a value outside the spec's bounds must fail rather
+	// than be issued and then capped to something the operator did not choose.
+	requested, err := validateGCPLifetime(spec, lifetime)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
 
-	// Get source token with IAM scope for impersonation
-	sourceToken, _, err := d.getSourceToken(ctx, []string{"https://www.googleapis.com/auth/iam"})
+	// The impersonation call authorizes on cloud-platform, the same scope the
+	// federated path presents for the identical call.
+	sourceToken, _, err := d.getSourceToken(ctx, []string{gcpCloudPlatformScope})
 	if err != nil {
 		return nil, nil, 0, "", fmt.Errorf("failed to get source token for impersonation: %w", err)
 	}
@@ -398,9 +532,13 @@ func (d *GCPDriver) mintImpersonatedAccessToken(ctx context.Context, spec *crede
 		return nil, nil, 0, "", err
 	}
 
-	ttl := ttlFromExpireTime(expireTime, gcpFederatedTokenFallbackTTL)
+	ttl := impersonationTTL(expireTime, requested, spec)
 
-	saKey, _ := d.parseServiceAccountKey()
+	saKey, err := d.parseServiceAccountKey()
+	if err != nil && d.logger != nil {
+		d.logger.Warn("could not parse source service account key for mint metadata",
+			logger.String("spec", spec.Name), logger.String("error", err.Error()))
+	}
 
 	rawData := map[string]interface{}{
 		"access_token": accessToken,
@@ -445,7 +583,7 @@ func (d *GCPDriver) generateAccessToken(ctx context.Context, bearerToken, target
 		bearerToken: bearerToken,
 		okStatuses:  []int{http.StatusOK},
 		operation:   "generateAccessToken",
-	}, 1)
+	})
 	if err != nil {
 		return "", "", err
 	}
@@ -487,7 +625,7 @@ const gcpTokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchan
 // gcpFederationScope is the scope requested from STS for the federated token on the
 // impersonation path: the token only needs to call generateAccessToken, and the
 // real per-credential scopes are applied there. Matches x/oauth2 externalaccount.
-const gcpFederationScope = "https://www.googleapis.com/auth/cloud-platform"
+const gcpFederationScope = gcpCloudPlatformScope
 
 // MintCredentialWithExchange mints a GCP credential over Workload Identity
 // Federation by exchanging the caller's verified identity assertion at GCP STS for
@@ -513,11 +651,15 @@ func (d *GCPDriver) MintCredentialWithExchange(ctx context.Context, spec *creden
 			return nil, nil, 0, "", fmt.Errorf("gcp: target_service_account is required for impersonated_access_token")
 		}
 		lifetime := credential.GetString(spec.Config, "lifetime", "3600s")
-		if err := validateGCPLifetime(spec, lifetime); err != nil {
+		requested, err := validateGCPLifetime(spec, lifetime)
+		if err != nil {
 			return nil, nil, 0, "", err
 		}
 		scopesStr := credential.GetString(spec.Config, "scopes", gcpFederationScope)
 		scopes := splitScopes(scopesStr)
+		if len(scopes) == 0 {
+			return nil, nil, 0, "", fmt.Errorf("gcp: 'scopes' resolved to nothing for mint_method=impersonated_access_token")
+		}
 
 		// Exchange the assertion for a federated token scoped to call the IAM
 		// Credentials API, then impersonate the target SA with it.
@@ -529,7 +671,7 @@ func (d *GCPDriver) MintCredentialWithExchange(ctx context.Context, spec *creden
 		if err != nil {
 			return nil, nil, 0, "", err
 		}
-		ttl := ttlFromExpireTime(expireTime, gcpFederatedTokenFallbackTTL)
+		ttl := impersonationTTL(expireTime, requested, spec)
 
 		rawData := map[string]interface{}{"access_token": accessToken}
 		metadata := map[string]interface{}{
@@ -565,11 +707,17 @@ func (d *GCPDriver) MintCredentialWithExchange(ctx context.Context, spec *creden
 		if spec.MaxTTL > 0 && ttl > spec.MaxTTL {
 			ttl = spec.MaxTTL
 		}
+		// The subject is the principal the token was federated for, not the provider
+		// it was federated through — the provider is one value for the whole source,
+		// so recording it here made every caller look identical in the audit trail.
+		// It is still reported separately as `provider`.
 		rawData := map[string]interface{}{"access_token": fedToken}
 		metadata := map[string]interface{}{
-			"subject":  d.getWorkloadIdentityProvider(),
 			"scopes":   scopesStr,
 			"provider": d.getWorkloadIdentityProvider(),
+		}
+		if sub := inputs.AgentClaims["sub"]; sub != "" {
+			metadata["subject"] = sub
 		}
 		if d.logger != nil {
 			d.logger.Debug("minted federated GCP access token",
@@ -609,7 +757,7 @@ func (d *GCPDriver) exchangeWIFToken(ctx context.Context, subjectToken, subjectT
 		contentType: "application/x-www-form-urlencoded",
 		okStatuses:  []int{http.StatusOK},
 		operation:   "stsTokenExchange",
-	}, 1)
+	})
 	if err != nil {
 		return "", 0, err
 	}
@@ -628,25 +776,56 @@ func (d *GCPDriver) exchangeWIFToken(ctx context.Context, subjectToken, subjectT
 
 	ttl := time.Duration(tokenResp.ExpiresIn) * time.Second
 	if ttl <= 0 {
-		ttl = gcpFederatedTokenFallbackTTL
+		ttl = gcpSTSTokenFallbackTTL
 	}
 	return tokenResp.AccessToken, ttl, nil
 }
 
+// gcpLifetimePattern matches the only spelling the IAM Credentials API accepts for
+// its lifetime field: a decimal number of seconds with an "s" suffix, the protobuf
+// Duration JSON encoding. The spec's value is forwarded to that field verbatim, so
+// anything Go's duration parser would also accept — "1h", "30m" — has to be refused
+// here or it validates locally and is rejected by the API on every mint.
+var gcpLifetimePattern = regexp.MustCompile(`^[0-9]+(\.[0-9]+)?s$`)
+
 // validateGCPLifetime parses a GCP lifetime string (e.g. "1800s") and checks it
-// against the spec's TTL bounds, mirroring the AWS federated session-TTL guard.
-func validateGCPLifetime(spec *credential.CredSpec, lifetime string) error {
+// against both the API's ceiling and the spec's TTL bounds, returning the parsed
+// duration so callers can bound a lease by what was actually requested.
+func validateGCPLifetime(spec *credential.CredSpec, lifetime string) (time.Duration, error) {
+	if !gcpLifetimePattern.MatchString(lifetime) {
+		return 0, fmt.Errorf("gcp: invalid lifetime %q: must be a number of seconds with an 's' suffix, e.g. \"1800s\"", lifetime)
+	}
 	dur, err := time.ParseDuration(lifetime)
 	if err != nil {
-		return fmt.Errorf("gcp: invalid lifetime %q: %w", lifetime, err)
+		return 0, fmt.Errorf("gcp: invalid lifetime %q: %w", lifetime, err)
+	}
+	if dur <= 0 {
+		return 0, fmt.Errorf("gcp: lifetime %q must be positive", lifetime)
+	}
+	if dur > gcpMaxImpersonationLifetime {
+		return 0, fmt.Errorf("gcp: lifetime %s exceeds the maximum the IAM Credentials API accepts (%s)", dur, gcpMaxImpersonationLifetime)
 	}
 	if spec.MinTTL > 0 && dur < spec.MinTTL {
-		return fmt.Errorf("gcp: lifetime %s is below the spec minimum %s", dur, spec.MinTTL)
+		return 0, fmt.Errorf("gcp: lifetime %s is below the spec minimum %s", dur, spec.MinTTL)
 	}
 	if spec.MaxTTL > 0 && dur > spec.MaxTTL {
-		return fmt.Errorf("gcp: lifetime %s exceeds the spec maximum %s", dur, spec.MaxTTL)
+		return 0, fmt.Errorf("gcp: lifetime %s exceeds the spec maximum %s", dur, spec.MaxTTL)
 	}
-	return nil
+	return dur, nil
+}
+
+// impersonationTTL resolves the lease life of an impersonated token. The API's
+// expireTime is authoritative when present; when it is absent or unparseable the
+// requested lifetime is the honest fallback, because that is what the token was
+// asked to live for. A fixed constant here would hand out a lease outliving the
+// token — a spec asking for 600s would be served a dead token from cache for the
+// remaining 50 minutes of a one-hour lease.
+func impersonationTTL(expireTime string, requested time.Duration, spec *credential.CredSpec) time.Duration {
+	ttl := ttlFromExpireTime(expireTime, requested)
+	if spec.MaxTTL > 0 && ttl > spec.MaxTTL {
+		ttl = spec.MaxTTL
+	}
+	return ttl
 }
 
 // gcpAssertionResource reports the canonical downstream resource a GCP federation
@@ -654,10 +833,16 @@ func validateGCPLifetime(spec *credential.CredSpec, lifetime string) error {
 // config only, no network or driver state. The provider prefix is human-readable
 // sugar on an opaque value — never parse it back.
 func gcpAssertionResource(sourceCfg, specCfg credential.Config) (string, bool) {
+	// The claim describes what an assertion is presented to, and only a federated
+	// source presents one. Without this a static source would derive a resource for a
+	// mint the exchange path refuses outright, naming a target nothing ever reaches.
+	// gcpAssertionAudience gates on the same condition.
+	if credential.GetString(sourceCfg, "auth_method", gcpAuthMethodStatic) != gcpAuthMethodOIDCFederation {
+		return "", false
+	}
+
 	// Default mirrors the federated mint_method dispatch in MintCredentialWithExchange
 	// (empty → access_token) so the named resource matches what the exchange reaches.
-	// A static source has no workload_identity_provider, so access_token still yields
-	// no resource there.
 	switch credential.GetString(specCfg, "mint_method", "access_token") {
 	case "impersonated_access_token":
 		if sa := credential.GetString(specCfg, "target_service_account", ""); sa != "" {
@@ -686,8 +871,14 @@ func (d *GCPDriver) Type() string {
 	return credential.SourceTypeGCP
 }
 
-// Cleanup releases resources
+// Cleanup releases resources. A driver is torn down on every source config change
+// and on every rotation, so idle keep-alive connections to the GCP endpoints would
+// otherwise accumulate one set per teardown. The token cache needs no clearing — the
+// instance is unreachable once this returns.
 func (d *GCPDriver) Cleanup(ctx context.Context) error {
+	if d.httpClient != nil {
+		d.httpClient.CloseIdleConnections()
+	}
 	return nil
 }
 
@@ -703,8 +894,15 @@ func (d *GCPDriver) SupportsRotation() bool {
 	return d.getAuthMethod() == gcpAuthMethodStatic
 }
 
-// PrepareRotation creates a new SA key for the source service account.
-// Returns activateAfter to allow time for GCP IAM propagation.
+// PrepareRotation creates a new SA key for the source service account, proves it
+// works, and returns activateAfter to allow time for GCP IAM propagation.
+//
+// The verification is not optional. The rotation manager persists the returned config
+// before it ever calls CommitRotation, so a key that turns out to be unusable is
+// already the source's stored credential by the time anything notices — and the
+// created key is never reclaimed, which matters because a service account may hold
+// only ten. Left alone, a handful of failed rotations exhausts the quota and no
+// future rotation can succeed. So: verify here, and delete what we made if it fails.
 func (d *GCPDriver) PrepareRotation(ctx context.Context) (map[string]string, map[string]string, time.Duration, error) {
 	saKey, err := d.parseServiceAccountKey()
 	if err != nil {
@@ -712,9 +910,10 @@ func (d *GCPDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 	}
 
 	oldKeyID := saKey.PrivateKeyID
+	oldKeyJSON := d.getServiceAccountKey()
 
 	// Get IAM token using current credentials
-	iamToken, _, err := d.acquireToken(ctx, []string{"https://www.googleapis.com/auth/iam"})
+	iamToken, _, err := d.acquireToken(ctx, []string{gcpIAMScope})
 	if err != nil {
 		return nil, nil, 0, fmt.Errorf("failed to get IAM token: %w", err)
 	}
@@ -725,14 +924,23 @@ func (d *GCPDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 		return nil, nil, 0, err
 	}
 
+	if err := d.verifyNewKey(ctx, newKeyJSON); err != nil {
+		d.discardUnusableKey(ctx, iamToken, saKey, newKeyJSON)
+		return nil, nil, 0, fmt.Errorf("newly created SA key never became usable: %w", err)
+	}
+
 	// Build new config
 	newConfig := d.configSnapshot()
 	newConfig["service_account_key"] = newKeyJSON
 
+	// The old key travels with the cleanup handle so the deletion can authenticate as
+	// the key it is deleting. See CleanupRotation for why that matters. This rides the
+	// same barrier-encrypted storage the new key already does.
 	cleanupConfig := map[string]string{
-		"old_key_id":            oldKeyID,
-		"service_account_email": saKey.ClientEmail,
-		"project_id":            saKey.ProjectID,
+		"old_key_id":              oldKeyID,
+		"service_account_email":   saKey.ClientEmail,
+		"project_id":              saKey.ProjectID,
+		"old_service_account_key": oldKeyJSON,
 	}
 
 	// Rotation does not touch activation_delay, so the snapshot carries the live value.
@@ -748,8 +956,63 @@ func (d *GCPDriver) PrepareRotation(ctx context.Context) (map[string]string, map
 	return newConfig, cleanupConfig, activateAfter, nil
 }
 
+// verifyNewKey waits for a freshly created key to mint a token. A new key is not
+// recognised across Google's replicas the instant it is created, so the first
+// attempts can fail with a signature error that is nothing but propagation delay —
+// a single probe would routinely condemn a perfectly good key. Retries with a flat
+// one-second gap until the key works or the window closes.
+func (d *GCPDriver) verifyNewKey(ctx context.Context, keyJSON string) error {
+	deadline := time.Now().Add(gcpRotationVerifyTimeout)
+
+	var lastErr error
+	for {
+		if _, _, lastErr = d.tokenFromKeyJSON(ctx, keyJSON, []string{gcpCloudPlatformScope}); lastErr == nil {
+			return nil
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return lastErr
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(1 * time.Second):
+		}
+	}
+}
+
+// discardUnusableKey deletes a key that was created but never became usable, so a
+// failed rotation does not permanently consume one of the ten slots a service
+// account has. Best-effort by nature: the rotation has already failed and this only
+// decides whether it also leaks. Runs on a detached context so a caller that gave up
+// mid-rotation does not cancel the cleanup of what it just created.
+func (d *GCPDriver) discardUnusableKey(ctx context.Context, iamToken string, saKey *serviceAccountKey, newKeyJSON string) {
+	newKey, err := parseServiceAccountKeyJSON([]byte(newKeyJSON))
+	if err != nil || newKey.PrivateKeyID == "" {
+		return
+	}
+
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+
+	if err := d.deleteServiceAccountKey(cleanupCtx, iamToken, saKey.ProjectID, saKey.ClientEmail, newKey.PrivateKeyID); err != nil && d.logger != nil {
+		d.logger.Warn("could not delete the unusable SA key just created; it still counts against the per-account key quota",
+			logger.String("key_id", truncateID(newKey.PrivateKeyID, 8)),
+			logger.String("error", err.Error()))
+	}
+}
+
 // CommitRotation activates new credentials in the driver
 func (d *GCPDriver) CommitRotation(ctx context.Context, newConfig map[string]string) error {
+	// Prove the key works before publishing it, not after. Swapping first and checking
+	// second leaves a driver holding a credential it has just discovered is broken,
+	// with nothing to roll back to; failing here leaves the working key in place.
+	if _, _, err := d.tokenFromKeyJSON(ctx, newConfig["service_account_key"], []string{gcpCloudPlatformScope}); err != nil {
+		return fmt.Errorf("failed to authenticate with new SA key: %w", err)
+	}
+
 	// Publish the new key and retire every token the old one minted, as one step. The
 	// generation bump follows the config write under the same lock, so a mint already
 	// in flight against the retired key cannot file its result under the new
@@ -757,18 +1020,6 @@ func (d *GCPDriver) CommitRotation(ctx context.Context, newConfig map[string]str
 	d.authMu.Lock()
 	d.credSource.Config = credential.NewConfig(newConfig)
 	d.tokenCache.InvalidateGeneration()
-	d.sourceVerified = false
-	d.authMu.Unlock()
-
-	// Verify new credentials work. Deliberately not under authMu: acquireToken reads
-	// the config through the accessors, which take the lock themselves.
-	_, _, err := d.acquireToken(ctx, []string{"https://www.googleapis.com/auth/cloud-platform"})
-	if err != nil {
-		return fmt.Errorf("failed to authenticate with new SA key: %w", err)
-	}
-
-	d.authMu.Lock()
-	d.sourceVerified = true
 	d.authMu.Unlock()
 
 	if d.logger != nil {
@@ -788,8 +1039,19 @@ func (d *GCPDriver) CleanupRotation(ctx context.Context, cleanupConfig map[strin
 	saEmail := cleanupConfig["service_account_email"]
 	projectID := cleanupConfig["project_id"]
 
-	// Get IAM token
-	iamToken, _, err := d.getSourceToken(ctx, []string{"https://www.googleapis.com/auth/iam"})
+	// Authenticate as the key being deleted, when the handle carries it. By this point
+	// the new key has only just been published, and it is the one whose public half may
+	// not yet be recognised everywhere — the very propagation lag PrepareRotation waits
+	// out. The retired key has no such problem: it has existed long enough to be known
+	// to every replica, right up until it is removed. An older handle predating this
+	// field falls back to the live credential, which is the previous behaviour.
+	var iamToken string
+	var err error
+	if oldKeyJSON := cleanupConfig["old_service_account_key"]; oldKeyJSON != "" {
+		iamToken, _, err = d.tokenFromKeyJSON(ctx, oldKeyJSON, []string{gcpIAMScope})
+	} else {
+		iamToken, _, err = d.getSourceToken(ctx, []string{gcpIAMScope})
+	}
 	if err != nil {
 		return fmt.Errorf("failed to get IAM token: %w", err)
 	}
@@ -816,7 +1078,16 @@ func (d *GCPDriver) CleanupRotation(ctx context.Context, cleanupConfig map[strin
 func (d *GCPDriver) getSourceToken(ctx context.Context, scopes []string) (string, time.Time, error) {
 	scopeKey := strings.Join(scopes, ",")
 
-	for {
+	// Losing the generation race means a rotation landed mid-mint, which is rare and
+	// self-clearing. Losing it repeatedly means something is wrong, and this sits on
+	// the request path — so bound the retries rather than spin against a rotation loop.
+	const maxGenerationRetries = 3
+
+	for attempt := 0; attempt < maxGenerationRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return "", time.Time{}, err
+		}
+
 		// Read the generation before the SA key, so a rotation landing while the mint
 		// is in flight is always visible as a change by the time we store.
 		gen := d.tokenCache.GetGeneration()
@@ -838,6 +1109,8 @@ func (d *GCPDriver) getSourceToken(ctx context.Context, scopes []string) (string
 			return token, expiry, nil
 		}
 	}
+
+	return "", time.Time{}, fmt.Errorf("gcp: source key rotated repeatedly while minting; giving up after %d attempts", maxGenerationRetries)
 }
 
 // acquireToken gets a fresh OAuth2 token using the SA key.
@@ -846,8 +1119,26 @@ func (d *GCPDriver) acquireToken(ctx context.Context, scopes []string) (string, 
 	if saKeyJSON == "" {
 		return "", time.Time{}, fmt.Errorf("service_account_key is empty")
 	}
+	return d.tokenFromKeyJSON(ctx, saKeyJSON, scopes)
+}
 
-	creds, err := google.CredentialsFromJSON(ctx, []byte(saKeyJSON), scopes...)
+// tokenFromKeyJSON mints a token from an explicit key, bypassing both the config and
+// the cache. Rotation needs that: it must prove a newly created key works before
+// publishing it, and must delete the retired key while still authenticating as it.
+//
+// The credential type is pinned rather than inferred. The untyped constructor
+// dispatches on the JSON's own "type" field, so a key declaring external_account or
+// impersonated_service_account would turn this into a fetch of whatever file or URL
+// that document names — reading host files and calling arbitrary endpoints as this
+// process, from nothing but source config. Only a service-account key is ever valid
+// here, so say so.
+//
+// oauthClientCtx carries the driver's HTTP client: without it the token exchange
+// silently runs on http.DefaultClient, ignoring ca_data, tls_skip_verify and the
+// client timeout that the operator configured for exactly these calls.
+func (d *GCPDriver) tokenFromKeyJSON(ctx context.Context, keyJSON string, scopes []string) (string, time.Time, error) {
+	creds, err := google.CredentialsFromJSONWithType(
+		d.oauthClientCtx(ctx), []byte(keyJSON), google.ServiceAccount, scopes...)
 	if err != nil {
 		return "", time.Time{}, fmt.Errorf("failed to create GCP credentials: %w", err)
 	}
@@ -858,6 +1149,15 @@ func (d *GCPDriver) acquireToken(ctx context.Context, scopes []string) (string, 
 	}
 
 	return token.AccessToken, token.Expiry, nil
+}
+
+// oauthClientCtx returns ctx carrying the driver's HTTP client, which is what
+// x/oauth2 looks for when it builds its transport.
+func (d *GCPDriver) oauthClientCtx(ctx context.Context) context.Context {
+	if d.httpClient == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, oauth2.HTTPClient, d.httpClient)
 }
 
 // ============================================================================
@@ -876,7 +1176,7 @@ type gcpAPIRequest struct {
 }
 
 // doGCPRequest executes an HTTP request to a GCP API endpoint
-func (d *GCPDriver) doGCPRequest(ctx context.Context, apiReq gcpAPIRequest, maxAttempts int) ([]byte, error) {
+func (d *GCPDriver) doGCPRequest(ctx context.Context, apiReq gcpAPIRequest) ([]byte, error) {
 	// Prepare headers
 	headers := make(map[string]string)
 	if apiReq.contentType != "" {
@@ -886,11 +1186,16 @@ func (d *GCPDriver) doGCPRequest(ctx context.Context, apiReq gcpAPIRequest, maxA
 		headers["Authorization"] = "Bearer " + apiReq.bearerToken
 	}
 
-	// Configure retry behavior (no automatic retries by default)
+	// GCP answers 429 on quota (service-account key creation is capped per project
+	// per minute) and 5xx under load on both STS and IAM Credentials. Every call this
+	// driver makes through here is safe to re-issue: the token mints are idempotent in
+	// effect, and a re-issued key creation is recovered by the rollback in
+	// PrepareRotation. Retrying none of them, as this did, turned one transient answer
+	// into a failed mint or a half-finished rotation.
 	retryConfig := httputil.HTTPRetryConfig{
-		MaxAttempts:       maxAttempts,
+		MaxAttempts:       gcpAPIMaxAttempts,
 		MaxBodySize:       gcpMaxResponseBodySize,
-		RetryableStatuses: []int{}, // GCP doesn't retry by default
+		RetryableStatuses: []int{429, 500, 502, 503, 504},
 		BaseBackoff:       1 * time.Second,
 		JitterPercent:     20,
 	}
@@ -912,8 +1217,14 @@ func (d *GCPDriver) doGCPRequest(ctx context.Context, apiReq gcpAPIRequest, maxA
 
 // createServiceAccountKey creates a new key for the given service account
 func (d *GCPDriver) createServiceAccountKey(ctx context.Context, iamToken, saEmail, projectID string) (string, error) {
-	apiURL := fmt.Sprintf("https://iam.googleapis.com/v1/projects/%s/serviceAccounts/%s/keys",
-		url.PathEscape(projectID), url.PathEscape(saEmail))
+	// Empty values here would build a path with a hole in it — /v1/projects//... —
+	// which the API answers with a 400 or 404 that says nothing about the real cause.
+	if projectID == "" || saEmail == "" {
+		return "", fmt.Errorf("cannot create SA key: service account key is missing project_id or client_email")
+	}
+
+	apiURL := fmt.Sprintf("%s/v1/projects/%s/serviceAccounts/%s/keys",
+		d.iamHost, url.PathEscape(projectID), url.PathEscape(saEmail))
 
 	reqBody, _ := json.Marshal(map[string]interface{}{
 		"privateKeyType": "TYPE_GOOGLE_CREDENTIALS_FILE",
@@ -928,7 +1239,7 @@ func (d *GCPDriver) createServiceAccountKey(ctx context.Context, iamToken, saEma
 		bearerToken: iamToken,
 		okStatuses:  []int{http.StatusOK},
 		operation:   "createServiceAccountKey",
-	}, 1)
+	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create SA key: %w", err)
 	}
@@ -941,22 +1252,21 @@ func (d *GCPDriver) createServiceAccountKey(ctx context.Context, iamToken, saEma
 		return "", fmt.Errorf("failed to decode create key response: %w", err)
 	}
 
-	// Decode base64 to get the actual JSON key file content
-	import_encoding := keyResp.PrivateKeyData
-	if import_encoding == "" {
+	if keyResp.PrivateKeyData == "" {
 		return "", fmt.Errorf("create key response missing privateKeyData")
 	}
 
-	// The privateKeyData is base64-encoded; decode it
-	keyJSON, err := base64Decode(import_encoding)
+	keyJSON, err := base64Decode(keyResp.PrivateKeyData)
 	if err != nil {
 		return "", fmt.Errorf("failed to decode privateKeyData: %w", err)
 	}
 
-	// Validate the new key is valid JSON
-	var newKey serviceAccountKey
-	if err := json.Unmarshal(keyJSON, &newKey); err != nil {
-		return "", fmt.Errorf("new SA key is not valid JSON: %w", err)
+	// Checked against every field the driver will use, not merely "is it JSON".
+	// Whatever comes back here becomes the source's stored credential, and a
+	// truncated or empty document that passed a laxer check would be persisted and
+	// leave the source unable to authenticate at all.
+	if _, err := parseServiceAccountKeyJSON(keyJSON); err != nil {
+		return "", fmt.Errorf("newly created SA key is unusable: %w", err)
 	}
 
 	return string(keyJSON), nil
@@ -964,8 +1274,12 @@ func (d *GCPDriver) createServiceAccountKey(ctx context.Context, iamToken, saEma
 
 // deleteServiceAccountKey deletes a specific key from a service account
 func (d *GCPDriver) deleteServiceAccountKey(ctx context.Context, iamToken, projectID, saEmail, keyID string) error {
-	apiURL := fmt.Sprintf("https://iam.googleapis.com/v1/projects/%s/serviceAccounts/%s/keys/%s",
-		url.PathEscape(projectID), url.PathEscape(saEmail), url.PathEscape(keyID))
+	if projectID == "" || saEmail == "" || keyID == "" {
+		return fmt.Errorf("cannot delete SA key: missing project, service account or key id")
+	}
+
+	apiURL := fmt.Sprintf("%s/v1/projects/%s/serviceAccounts/%s/keys/%s",
+		d.iamHost, url.PathEscape(projectID), url.PathEscape(saEmail), url.PathEscape(keyID))
 
 	_, err := d.doGCPRequest(ctx, gcpAPIRequest{
 		method:      "DELETE",
@@ -973,7 +1287,7 @@ func (d *GCPDriver) deleteServiceAccountKey(ctx context.Context, iamToken, proje
 		bearerToken: iamToken,
 		okStatuses:  []int{http.StatusOK, http.StatusNoContent},
 		operation:   "deleteServiceAccountKey",
-	}, 1)
+	})
 	return err
 }
 
@@ -981,16 +1295,34 @@ func (d *GCPDriver) deleteServiceAccountKey(ctx context.Context, iamToken, proje
 // Helpers
 // ============================================================================
 
-// splitScopes splits a comma-separated scopes string into a slice
+// splitScopes splits a scopes string into a slice, accepting either separator an
+// operator is likely to reach for: commas, or the spaces Google's own documentation
+// uses. Empty elements are dropped rather than passed through — a trailing comma or
+// an explicitly empty value would otherwise become a blank scope, which the token
+// grant rejects, and which reads as "no scopes set" everywhere it is logged.
 func splitScopes(scopesStr string) []string {
-	scopes := strings.Split(scopesStr, ",")
-	for i := range scopes {
-		scopes[i] = strings.TrimSpace(scopes[i])
-	}
-	return scopes
+	return strings.FieldsFunc(scopesStr, func(r rune) bool {
+		return r == ',' || unicode.IsSpace(r)
+	})
 }
 
-// base64Decode decodes a standard base64-encoded string
+// base64Decode decodes base64 in any of the four encodings proto3 JSON permits for a
+// bytes field. Standard padded encoding is what Google emits today; accepting the
+// URL-safe and unpadded forms costs three fallbacks and removes a decode failure that
+// would look like a corrupt key.
 func base64Decode(encoded string) ([]byte, error) {
-	return base64.StdEncoding.DecodeString(encoded)
+	encodings := []*base64.Encoding{
+		base64.StdEncoding,
+		base64.URLEncoding,
+		base64.RawStdEncoding,
+		base64.RawURLEncoding,
+	}
+	var err error
+	for _, enc := range encodings {
+		var decoded []byte
+		if decoded, err = enc.DecodeString(encoded); err == nil {
+			return decoded, nil
+		}
+	}
+	return nil, err
 }

--- a/credential/drivers/gcp_driver_test.go
+++ b/credential/drivers/gcp_driver_test.go
@@ -116,7 +116,7 @@ func TestGCPDriverFactory_ValidateConfig(t *testing.T) {
 
 	t.Run("missing client_email", func(t *testing.T) {
 		err := f.ValidateConfig(credential.NewConfig(map[string]string{
-			"service_account_key": `{"private_key": "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n"}`,
+			"service_account_key": `{"type":"service_account","project_id":"p","private_key_id":"kid","private_key": "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n"}`,
 		}))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "client_email")
@@ -124,10 +124,46 @@ func TestGCPDriverFactory_ValidateConfig(t *testing.T) {
 
 	t.Run("missing private_key", func(t *testing.T) {
 		err := f.ValidateConfig(credential.NewConfig(map[string]string{
-			"service_account_key": `{"client_email": "test@project.iam.gserviceaccount.com"}`,
+			"service_account_key": `{"type":"service_account","project_id":"p","private_key_id":"kid","client_email": "test@project.iam.gserviceaccount.com"}`,
 		}))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "private_key")
+	})
+
+	// The library this driver hands the key to dispatches on the document's own
+	// "type": an external_account names a file or URL for it to go and read, which
+	// would turn writing a credential source into reading host files and calling
+	// arbitrary endpoints as this process. Only a service account is ever valid here.
+	t.Run("non-service-account credential type rejected", func(t *testing.T) {
+		for _, typ := range []string{"external_account", "impersonated_service_account", "authorized_user", ""} {
+			err := f.ValidateConfig(credential.NewConfig(map[string]string{
+				"service_account_key": `{"type":"` + typ + `","project_id":"p","private_key_id":"kid","client_email":"x@y.iam.gserviceaccount.com","private_key":"k","token_url":"https://attacker.example","credential_source":{"file":"/etc/passwd"}}`,
+			}))
+			require.Errorf(t, err, "type=%q must be refused", typ)
+			assert.Contains(t, err.Error(), "service_account")
+		}
+	})
+
+	// Rotation addresses the key by project and key id, so a document missing either
+	// cannot be rotated and would build a request path with a hole in it.
+	t.Run("missing rotation identity fields", func(t *testing.T) {
+		for field, keyJSON := range map[string]string{
+			"project_id":     `{"type":"service_account","private_key_id":"kid","client_email":"x@y.iam.gserviceaccount.com","private_key":"k"}`,
+			"private_key_id": `{"type":"service_account","project_id":"p","client_email":"x@y.iam.gserviceaccount.com","private_key":"k"}`,
+		} {
+			err := f.ValidateConfig(credential.NewConfig(map[string]string{"service_account_key": keyJSON}))
+			require.Errorf(t, err, "missing %s must be refused", field)
+			assert.Contains(t, err.Error(), field)
+		}
+	})
+
+	// "Unmarshals without error" is not a check: these are the documents that passed
+	// the old one and would have been stored as the source's credential.
+	t.Run("degenerate JSON rejected", func(t *testing.T) {
+		for _, keyJSON := range []string{`null`, `{}`} {
+			err := f.ValidateConfig(credential.NewConfig(map[string]string{"service_account_key": keyJSON}))
+			require.Errorf(t, err, "%s must be refused", keyJSON)
+		}
 	})
 
 	t.Run("valid config", func(t *testing.T) {
@@ -277,24 +313,16 @@ func TestGCPDriver_ParseServiceAccountKey(t *testing.T) {
 	})
 }
 
-func TestSplitScopes(t *testing.T) {
-	t.Run("single scope", func(t *testing.T) {
-		scopes := splitScopes("https://www.googleapis.com/auth/cloud-platform")
-		assert.Equal(t, []string{"https://www.googleapis.com/auth/cloud-platform"}, scopes)
-	})
-
-	t.Run("multiple scopes", func(t *testing.T) {
-		scopes := splitScopes("https://www.googleapis.com/auth/compute, https://www.googleapis.com/auth/devstorage.read_only")
-		assert.Equal(t, []string{
-			"https://www.googleapis.com/auth/compute",
-			"https://www.googleapis.com/auth/devstorage.read_only",
-		}, scopes)
-	})
-}
-
 // newTestGCPSAKey builds a usable service-account key whose token_uri points at a local
 // server, so the oauth2 library performs a real signed JWT exchange against it.
 func newTestGCPSAKey(t *testing.T, tokenURI, clientEmail string) string {
+	t.Helper()
+	return newTestGCPSAKeyWithID(t, tokenURI, clientEmail, "test-key-id")
+}
+
+// newTestGCPSAKeyWithID builds a key with a chosen private_key_id, which rotation
+// addresses keys by — the retired key is named by the id carried on the old one.
+func newTestGCPSAKeyWithID(t *testing.T, tokenURI, clientEmail, keyID string) string {
 	t.Helper()
 
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -304,11 +332,12 @@ func newTestGCPSAKey(t *testing.T, tokenURI, clientEmail string) string {
 	require.NoError(t, err)
 
 	saKey := map[string]string{
-		"type":         "service_account",
-		"project_id":   "test-project",
-		"private_key":  string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})),
-		"client_email": clientEmail,
-		"token_uri":    tokenURI,
+		"type":           "service_account",
+		"project_id":     "test-project",
+		"private_key_id": keyID,
+		"private_key":    string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})),
+		"client_email":   clientEmail,
+		"token_uri":      tokenURI,
 	}
 	encoded, err := json.Marshal(saKey)
 	require.NoError(t, err)
@@ -401,9 +430,8 @@ func TestGCPDriver_ConcurrentRotationAndMintIsRaceFree(t *testing.T) {
 
 	wg.Wait()
 
-	// Whatever the interleaving, the driver ends on the rotated key and reports verified.
+	// Whatever the interleaving, the driver ends on the rotated key.
 	assert.Equal(t, rotatedKey, d.getServiceAccountKey())
-	assert.True(t, d.sourceVerified)
 }
 
 // gcpAssertionIssuer reads the client_email out of the signed JWT the oauth2 library

--- a/credential/drivers/gcp_federation_test.go
+++ b/credential/drivers/gcp_federation_test.go
@@ -46,7 +46,7 @@ func TestGCPDriverFactory_ValidateConfig_Federation(t *testing.T) {
 		err := f.ValidateConfig(credential.NewConfig(map[string]string{
 			"auth_method":                "oidc_federation",
 			"workload_identity_provider": testWIFProvider,
-			"service_account_key":        `{"client_email":"x@y.iam.gserviceaccount.com","private_key":"k"}`,
+			"service_account_key":        `{"type":"service_account","project_id":"p","private_key_id":"kid","client_email":"x@y.iam.gserviceaccount.com","private_key":"k"}`,
 		}))
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "must not be set")
@@ -78,7 +78,7 @@ func TestGCPDriverFactory_ValidateConfig_Federation(t *testing.T) {
 	t.Run("workload_identity_provider rejected on static", func(t *testing.T) {
 		err := f.ValidateConfig(credential.NewConfig(map[string]string{
 			"auth_method":                "static",
-			"service_account_key":        `{"client_email":"x@y.iam.gserviceaccount.com","private_key":"k"}`,
+			"service_account_key":        `{"type":"service_account","project_id":"p","private_key_id":"kid","client_email":"x@y.iam.gserviceaccount.com","private_key":"k"}`,
 			"workload_identity_provider": testWIFProvider,
 		}))
 		require.Error(t, err)
@@ -95,9 +95,13 @@ func TestGCPDriverFactory_InferCredentialType_Federation(t *testing.T) {
 		assert.Equal(t, credential.TypeGCPAccessToken, got, "mint_method=%q", mm)
 	}
 
-	got, err := f.InferCredentialType(credential.NewConfig(map[string]string{"mint_method": "cloud_sql_iam_token"}))
-	require.NoError(t, err)
-	assert.Equal(t, credential.TypeDBAuthToken, got)
+	// cloud_sql_iam_token infers a type but has no mint path, so a spec naming it
+	// used to write cleanly and fail on every request. Refused here instead — the
+	// db_auth_token validator refuses it too, for the operator who states `type`
+	// rather than leaving it inferred.
+	_, err := f.InferCredentialType(credential.NewConfig(map[string]string{"mint_method": "cloud_sql_iam_token"}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not implemented")
 
 	_, err = f.InferCredentialType(credential.NewConfig(map[string]string{"mint_method": "bogus"}))
 	require.Error(t, err)
@@ -187,7 +191,7 @@ func TestGCPDriver_ExchangeWIFToken(t *testing.T) {
 		d := newFederationDriver(testWIFProvider, sts.URL, "")
 		_, ttl, err := d.exchangeWIFToken(context.TODO(), "jwt", "", "scope")
 		require.NoError(t, err)
-		assert.Equal(t, gcpFederatedTokenFallbackTTL, ttl)
+		assert.Equal(t, gcpSTSTokenFallbackTTL, ttl)
 	})
 
 	t.Run("comma-separated scope normalized to space list", func(t *testing.T) {
@@ -342,9 +346,14 @@ func TestGCPDriver_MintCredentialWithExchange_UnsupportedMethod(t *testing.T) {
 }
 
 func TestGCPAssertionResource(t *testing.T) {
+	federatedSource := map[string]string{
+		"auth_method":                gcpAuthMethodOIDCFederation,
+		"workload_identity_provider": testWIFProvider,
+	}
+
 	t.Run("impersonation from spec", func(t *testing.T) {
 		res, ok := gcpAssertionResource(
-			credential.NewConfig(map[string]string{"workload_identity_provider": testWIFProvider}),
+			credential.NewConfig(federatedSource),
 			credential.NewConfig(map[string]string{"mint_method": "impersonated_access_token", "target_service_account": "bq@proj.iam.gserviceaccount.com"}),
 		)
 		assert.True(t, ok)
@@ -353,7 +362,7 @@ func TestGCPAssertionResource(t *testing.T) {
 
 	t.Run("federated from source", func(t *testing.T) {
 		res, ok := gcpAssertionResource(
-			credential.NewConfig(map[string]string{"workload_identity_provider": testWIFProvider}),
+			credential.NewConfig(federatedSource),
 			credential.NewConfig(map[string]string{"mint_method": "access_token"}),
 		)
 		assert.True(t, ok)
@@ -362,7 +371,7 @@ func TestGCPAssertionResource(t *testing.T) {
 
 	t.Run("routed via DeriveAssertionResource", func(t *testing.T) {
 		res, ok := DeriveAssertionResource(credential.SourceTypeGCP,
-			credential.NewConfig(map[string]string{"workload_identity_provider": testWIFProvider}),
+			credential.NewConfig(federatedSource),
 			credential.NewConfig(map[string]string{"mint_method": "access_token"}),
 		)
 		assert.True(t, ok)
@@ -371,6 +380,18 @@ func TestGCPAssertionResource(t *testing.T) {
 
 	t.Run("no resource when unset", func(t *testing.T) {
 		_, ok := gcpAssertionResource(credential.NewConfig(map[string]string{}), credential.NewConfig(map[string]string{"mint_method": "access_token"}))
+		assert.False(t, ok)
+	})
+
+	// A static source presents no assertion, so naming a resource for one describes a
+	// mint the exchange path refuses outright. The audience derivation gates on the
+	// same condition; this one did not, and would answer for a source that never
+	// federates anything.
+	t.Run("no resource on a static source", func(t *testing.T) {
+		_, ok := gcpAssertionResource(
+			credential.NewConfig(map[string]string{"service_account_key": "{}"}),
+			credential.NewConfig(map[string]string{"mint_method": "impersonated_access_token", "target_service_account": "bq@proj.iam.gserviceaccount.com"}),
+		)
 		assert.False(t, ok)
 	})
 }

--- a/credential/drivers/gcp_hardening_test.go
+++ b/credential/drivers/gcp_hardening_test.go
@@ -1,0 +1,685 @@
+package drivers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The GCP driver carried a set of defects that survived because the paths holding
+// them had no coverage at all: the two static mint methods were never driven end to
+// end, and the two service-account key calls rotation makes had none whatsoever. The
+// rows here pin each fix at the level the bug lived at.
+
+func TestSplitScopes(t *testing.T) {
+	// A blank scope reaches the token grant as a scope and is rejected there, while
+	// reading as "no scopes" in every log on the way. A space-separated list is the
+	// form Google's own documentation uses, and silently became one bogus scope.
+	for _, tc := range []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"empty yields nothing", "", []string{}},
+		{"only separators yields nothing", " , , ", []string{}},
+		{"trailing comma dropped", "a,b,", []string{"a", "b"}},
+		{"surrounding space trimmed", " a , b ", []string{"a", "b"}},
+		{"space separated", "a b", []string{"a", "b"}},
+		{"mixed separators", "a, b c", []string{"a", "b", "c"}},
+		{"single", gcpCloudPlatformScope, []string{gcpCloudPlatformScope}},
+		{"comma separated pair", "https://www.googleapis.com/auth/compute, https://www.googleapis.com/auth/devstorage.read_only",
+			[]string{"https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/devstorage.read_only"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, splitScopes(tc.in))
+		})
+	}
+}
+
+func TestBase64Decode_AcceptsEveryProto3Encoding(t *testing.T) {
+	payload := []byte(`{"type":"service_account"}?~`)
+
+	for name, encoded := range map[string]string{
+		"standard":     base64.StdEncoding.EncodeToString(payload),
+		"url safe":     base64.URLEncoding.EncodeToString(payload),
+		"raw standard": base64.RawStdEncoding.EncodeToString(payload),
+		"raw url safe": base64.RawURLEncoding.EncodeToString(payload),
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := base64Decode(encoded)
+			require.NoError(t, err)
+			assert.Equal(t, payload, got)
+		})
+	}
+
+	t.Run("still reports a real failure", func(t *testing.T) {
+		_, err := base64Decode("!!!not base64!!!")
+		require.Error(t, err)
+	})
+}
+
+// The lifetime string is forwarded verbatim to a protobuf Duration field, which
+// accepts only seconds. Go's duration parser accepts a great deal more, so a value
+// like "1h" used to validate locally and then be rejected by the API on every mint.
+func TestValidateGCPLifetime(t *testing.T) {
+	spec := &credential.CredSpec{Name: "s"}
+
+	t.Run("accepts the seconds form", func(t *testing.T) {
+		got, err := validateGCPLifetime(spec, "1800s")
+		require.NoError(t, err)
+		assert.Equal(t, 30*time.Minute, got)
+	})
+
+	for _, bad := range []string{"1h", "30m", "0s", "-10s", "", "3600", "1.5h"} {
+		t.Run("rejects "+bad, func(t *testing.T) {
+			_, err := validateGCPLifetime(spec, bad)
+			require.Errorf(t, err, "lifetime %q must be refused", bad)
+		})
+	}
+
+	t.Run("rejects beyond the API ceiling", func(t *testing.T) {
+		_, err := validateGCPLifetime(spec, "50000s")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "maximum")
+	})
+
+	t.Run("honours the spec bounds", func(t *testing.T) {
+		bounded := &credential.CredSpec{Name: "s", MinTTL: 10 * time.Minute, MaxTTL: 20 * time.Minute}
+		_, err := validateGCPLifetime(bounded, "60s")
+		require.Error(t, err)
+		_, err = validateGCPLifetime(bounded, "3600s")
+		require.Error(t, err)
+		_, err = validateGCPLifetime(bounded, "900s")
+		require.NoError(t, err)
+	})
+}
+
+// A fixed fallback here handed out a lease outliving the token: a spec asking for
+// 600s was served a dead token from cache for the remaining 50 minutes of an hour.
+func TestImpersonationTTL(t *testing.T) {
+	spec := &credential.CredSpec{Name: "s"}
+
+	t.Run("expireTime wins when present", func(t *testing.T) {
+		exp := time.Now().Add(25 * time.Minute).UTC().Format(time.RFC3339)
+		got := impersonationTTL(exp, 10*time.Minute, spec)
+		assert.InDelta(t, (25 * time.Minute).Seconds(), got.Seconds(), 5)
+	})
+
+	t.Run("falls back to what was requested, not a constant", func(t *testing.T) {
+		assert.Equal(t, 10*time.Minute, impersonationTTL("", 10*time.Minute, spec))
+		assert.Equal(t, 10*time.Minute, impersonationTTL("not-a-timestamp", 10*time.Minute, spec))
+	})
+
+	t.Run("capped by MaxTTL", func(t *testing.T) {
+		bounded := &credential.CredSpec{Name: "s", MaxTTL: 5 * time.Minute}
+		assert.Equal(t, 5*time.Minute, impersonationTTL("", 10*time.Minute, bounded))
+	})
+}
+
+func TestGCPDriverFactory_EndpointOverrides(t *testing.T) {
+	f := &GCPDriverFactory{}
+
+	t.Run("rejected on a static source", func(t *testing.T) {
+		err := f.ValidateConfig(credential.NewConfig(map[string]string{
+			"auth_method":         "static",
+			"service_account_key": `{"type":"service_account","project_id":"p","private_key_id":"kid","client_email":"x@y.iam.gserviceaccount.com","private_key":"k"}`,
+			"sts_endpoint":        "https://sts.example",
+		}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "only valid for auth_method=oidc_federation")
+	})
+
+	t.Run("accepted on a federation source", func(t *testing.T) {
+		err := f.ValidateConfig(credential.NewConfig(map[string]string{
+			"auth_method":                "oidc_federation",
+			"workload_identity_provider": testWIFProvider,
+			"sts_endpoint":               "http://127.0.0.1:1234",
+			"iamcredentials_endpoint":    "http://127.0.0.1:1234",
+		}))
+		require.NoError(t, err)
+	})
+
+	t.Run("malformed endpoint refused", func(t *testing.T) {
+		err := f.ValidateConfig(credential.NewConfig(map[string]string{
+			"auth_method":                "oidc_federation",
+			"workload_identity_provider": testWIFProvider,
+			"sts_endpoint":               "not-a-url",
+		}))
+		require.Error(t, err)
+	})
+
+	// Rotation acts on the real project through IAM, which has no override, so a
+	// source whose impersonation is redirected cannot also be rotated.
+	t.Run("rotation refused alongside an impersonation override", func(t *testing.T) {
+		err := f.ValidateRotationConfig(credential.NewConfig(map[string]string{
+			"iamcredentials_endpoint": "http://127.0.0.1:1234",
+		}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rotation_period")
+
+		require.NoError(t, f.ValidateRotationConfig(credential.NewConfig(map[string]string{})))
+	})
+}
+
+// newStaticGCPDriver builds a static-auth driver whose token grant and IAM calls both
+// reach the given server.
+func newStaticGCPDriver(t *testing.T, srvURL, keyJSON string) *GCPDriver {
+	t.Helper()
+	return &GCPDriver{
+		credSource: &credential.CredSource{
+			Type:   credential.SourceTypeGCP,
+			Config: credential.NewConfig(map[string]string{"service_account_key": keyJSON}),
+		},
+		tokenCache:         NewTokenCache(),
+		httpClient:         &http.Client{Timeout: 5 * time.Second},
+		stsHost:            srvURL,
+		iamCredentialsHost: srvURL,
+		iamHost:            srvURL,
+	}
+}
+
+// tokenGrantServer answers the OAuth2 JWT-bearer grant the static path makes, with a
+// caller-chosen expires_in so the lease arithmetic can be driven.
+func tokenGrantServer(t *testing.T, expiresIn int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body := map[string]interface{}{"access_token": "static-token", "token_type": "Bearer"}
+		if expiresIn > 0 {
+			body["expires_in"] = expiresIn
+		}
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestGCPDriver_MintAccessToken_Static(t *testing.T) {
+	// The credential vended here is the source service account's own token, shared by
+	// everyone asking for the same scopes. Defaulting it to cloud-platform handed out
+	// the source's full authority — including, on a rotation-enabled source, the
+	// ability to mint a replacement key for Warden's own identity.
+	t.Run("scopes are required", func(t *testing.T) {
+		srv := tokenGrantServer(t, 3600)
+		d := newStaticGCPDriver(t, srv.URL, newTestGCPSAKey(t, srv.URL+"/token", "sa@test-project.iam.gserviceaccount.com"))
+
+		_, _, _, _, err := d.mintAccessToken(context.TODO(),
+			&credential.CredSpec{Name: "s", Config: credential.NewConfig(map[string]string{})})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "scopes")
+	})
+
+	t.Run("lease capped by MaxTTL", func(t *testing.T) {
+		srv := tokenGrantServer(t, 3600)
+		d := newStaticGCPDriver(t, srv.URL, newTestGCPSAKey(t, srv.URL+"/token", "sa@test-project.iam.gserviceaccount.com"))
+
+		_, _, ttl, _, err := d.mintAccessToken(context.TODO(), &credential.CredSpec{
+			Name:   "s",
+			MaxTTL: 5 * time.Minute,
+			Config: credential.NewConfig(map[string]string{"scopes": "https://www.googleapis.com/auth/devstorage.read_only"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 5*time.Minute, ttl, "an hour-long token must not outlive the spec's ceiling")
+	})
+
+	t.Run("unbounded spec keeps the token's own life", func(t *testing.T) {
+		srv := tokenGrantServer(t, 3600)
+		d := newStaticGCPDriver(t, srv.URL, newTestGCPSAKey(t, srv.URL+"/token", "sa@test-project.iam.gserviceaccount.com"))
+
+		_, _, ttl, leaseID, err := d.mintAccessToken(context.TODO(), &credential.CredSpec{
+			Name:   "s",
+			Config: credential.NewConfig(map[string]string{"scopes": "https://www.googleapis.com/auth/devstorage.read_only"}),
+		})
+		require.NoError(t, err)
+		assert.InDelta(t, time.Hour.Seconds(), ttl.Seconds(), 30)
+		assert.Empty(t, leaseID, "an access token expires naturally and carries no lease")
+	})
+
+	// Without expires_in the library leaves Expiry at the zero time, so the lease was
+	// hugely negative. The manager then cached a credential already expired on
+	// arrival, and every single request re-minted.
+	t.Run("a grant with no expiry is refused, not cached", func(t *testing.T) {
+		srv := tokenGrantServer(t, 0)
+		d := newStaticGCPDriver(t, srv.URL, newTestGCPSAKey(t, srv.URL+"/token", "sa@test-project.iam.gserviceaccount.com"))
+
+		_, _, _, _, err := d.mintAccessToken(context.TODO(), &credential.CredSpec{
+			Name:   "s",
+			Config: credential.NewConfig(map[string]string{"scopes": "https://www.googleapis.com/auth/devstorage.read_only"}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expiry")
+	})
+}
+
+// gcpAssertionScope reads the scope claim out of the signed JWT the oauth2 library
+// sends for a service-account grant, so a test server can tell what a token was
+// actually asked to authorize.
+func gcpAssertionScope(t *testing.T, r *http.Request) string {
+	t.Helper()
+	require.NoError(t, r.ParseForm())
+
+	parts := strings.Split(r.FormValue("assertion"), ".")
+	if len(parts) != 3 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+
+	var claims struct {
+		Scope string `json:"scope"`
+	}
+	require.NoError(t, json.Unmarshal(payload, &claims))
+	return claims.Scope
+}
+
+// impersonationServer answers both the token grant and generateAccessToken, recording
+// the scopes the impersonation call was authorized with.
+type impersonationServer struct {
+	*httptest.Server
+	authScopes atomic.Value // string: the scope of the source token grant
+	expireTime string
+}
+
+func newImpersonationServer(t *testing.T, expireTime string) *impersonationServer {
+	t.Helper()
+	s := &impersonationServer{expireTime: expireTime}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.Contains(r.URL.Path, ":generateAccessToken") {
+			body := map[string]string{"accessToken": "impersonated-token"}
+			if s.expireTime != "" {
+				body["expireTime"] = s.expireTime
+			}
+			_ = json.NewEncoder(w).Encode(body)
+			return
+		}
+
+		// The JWT-bearer grant carries the requested scope inside the signed
+		// assertion, not as a form field.
+		s.authScopes.Store(gcpAssertionScope(t, r))
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "source-token", "token_type": "Bearer", "expires_in": 3600,
+		})
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func TestGCPDriver_MintImpersonatedAccessToken_Static(t *testing.T) {
+	specCfg := func(extra map[string]string) credential.Config {
+		cfg := map[string]string{
+			"mint_method":            "impersonated_access_token",
+			"target_service_account": "bq@test-project.iam.gserviceaccount.com",
+		}
+		for k, v := range extra {
+			cfg[k] = v
+		}
+		return credential.NewConfig(cfg)
+	}
+
+	t.Run("rejects a lifetime the API would reject", func(t *testing.T) {
+		srv := newImpersonationServer(t, "")
+		d := newStaticGCPDriver(t, srv.URL, newTestGCPSAKey(t, srv.URL+"/token", "sa@test-project.iam.gserviceaccount.com"))
+
+		_, _, _, _, err := d.mintImpersonatedAccessToken(context.TODO(),
+			&credential.CredSpec{Name: "s", Config: specCfg(map[string]string{"lifetime": "1h"})})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "lifetime")
+	})
+
+	t.Run("rejects a lifetime outside the spec bounds", func(t *testing.T) {
+		srv := newImpersonationServer(t, "")
+		d := newStaticGCPDriver(t, srv.URL, newTestGCPSAKey(t, srv.URL+"/token", "sa@test-project.iam.gserviceaccount.com"))
+
+		_, _, _, _, err := d.mintImpersonatedAccessToken(context.TODO(), &credential.CredSpec{
+			Name: "s", MaxTTL: 5 * time.Minute, Config: specCfg(map[string]string{"lifetime": "3600s"}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "maximum")
+	})
+
+	// The federated path authorizes the identical generateAccessToken call with
+	// cloud-platform; the static one asked for a different scope entirely.
+	t.Run("authorizes with cloud-platform", func(t *testing.T) {
+		srv := newImpersonationServer(t, time.Now().Add(time.Hour).UTC().Format(time.RFC3339))
+		d := newStaticGCPDriver(t, srv.URL, newTestGCPSAKey(t, srv.URL+"/token", "sa@test-project.iam.gserviceaccount.com"))
+
+		_, _, _, _, err := d.mintImpersonatedAccessToken(context.TODO(),
+			&credential.CredSpec{Name: "s", Config: specCfg(nil)})
+		require.NoError(t, err)
+		assert.Equal(t, gcpCloudPlatformScope, srv.authScopes.Load())
+	})
+
+	// No expireTime in the response used to mean a flat one-hour lease regardless of
+	// what was asked for, so a 600s token was served from cache long after it died.
+	t.Run("lease follows the requested lifetime when expireTime is absent", func(t *testing.T) {
+		srv := newImpersonationServer(t, "")
+		d := newStaticGCPDriver(t, srv.URL, newTestGCPSAKey(t, srv.URL+"/token", "sa@test-project.iam.gserviceaccount.com"))
+
+		_, _, ttl, _, err := d.mintImpersonatedAccessToken(context.TODO(),
+			&credential.CredSpec{Name: "s", Config: specCfg(map[string]string{"lifetime": "600s"})})
+		require.NoError(t, err)
+		assert.Equal(t, 10*time.Minute, ttl)
+	})
+}
+
+func TestGCPDriver_Cleanup_ClosesIdleConnections(t *testing.T) {
+	d := &GCPDriver{httpClient: &http.Client{}}
+	require.NoError(t, d.Cleanup(context.TODO()))
+
+	// A driver built without a client (as several tests do) must not panic.
+	bare := &GCPDriver{}
+	require.NoError(t, bare.Cleanup(context.TODO()))
+}
+
+func TestGCPDriver_GetSourceToken_HonoursCancellation(t *testing.T) {
+	srv := tokenGrantServer(t, 3600)
+	d := newStaticGCPDriver(t, srv.URL, newTestGCPSAKey(t, srv.URL+"/token", "sa@test-project.iam.gserviceaccount.com"))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, _, err := d.getSourceToken(ctx, []string{gcpCloudPlatformScope})
+	require.Error(t, err, "a cancelled request must not spin on the generation race")
+}
+
+// doGCPRequest retried nothing at all: its retryable-status list was empty and every
+// caller asked for a single attempt. GCP answers 429 on the service-account key quota
+// and 5xx under load, so one transient answer failed a mint outright.
+func TestGCPDriver_RetriesTransientStatuses(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"FED","expires_in":1800,"token_type":"Bearer"}`))
+	}))
+	defer srv.Close()
+
+	d := newFederationDriver(testWIFProvider, srv.URL, "")
+	tok, _, err := d.exchangeWIFToken(context.TODO(), "jwt", "", gcpCloudPlatformScope)
+	require.NoError(t, err)
+	assert.Equal(t, "FED", tok)
+	assert.EqualValues(t, 2, atomic.LoadInt32(&calls), "the 429 must have been retried")
+
+	t.Run("a client error is not retried", func(t *testing.T) {
+		var bad int32
+		badSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&bad, 1)
+			w.WriteHeader(http.StatusBadRequest)
+		}))
+		defer badSrv.Close()
+
+		bd := newFederationDriver(testWIFProvider, badSrv.URL, "")
+		_, _, err := bd.exchangeWIFToken(context.TODO(), "jwt", "", gcpCloudPlatformScope)
+		require.Error(t, err)
+		assert.EqualValues(t, 1, atomic.LoadInt32(&bad))
+	})
+}
+
+// rotationServer stands in for the IAM key-management API and the token grant. These
+// two calls had no coverage whatsoever, which is why they hardcoded their host.
+type rotationServer struct {
+	*httptest.Server
+
+	newKeyUsable atomic.Bool
+	created      atomic.Int32
+	deleted      atomic.Value // string: the last key id deleted
+	deleteIssuer atomic.Value // string: client_email of the key that authorized the delete
+	newKeyJSON   string
+}
+
+func newRotationServer(t *testing.T, newKeyEmail string) *rotationServer {
+	t.Helper()
+	s := &rotationServer{}
+	s.newKeyUsable.Store(true)
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		issuer := gcpAssertionIssuer(t, r)
+		// The new key is refused until the test says it has propagated, which is what
+		// PrepareRotation's verification waits out.
+		if issuer == newKeyEmail && !s.newKeyUsable.Load() {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"error":"invalid_grant","error_description":"Invalid JWT Signature."}`))
+			return
+		}
+		s.deleteIssuer.Store(issuer)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "iam-token-" + issuer, "token_type": "Bearer", "expires_in": 3600,
+		})
+	})
+
+	mux.HandleFunc("/v1/projects/", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			s.created.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"privateKeyData": base64.StdEncoding.EncodeToString([]byte(s.newKeyJSON)),
+			})
+		case http.MethodDelete:
+			parts := strings.Split(r.URL.Path, "/keys/")
+			s.deleted.Store(parts[len(parts)-1])
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	})
+
+	s.Server = httptest.NewServer(mux)
+	t.Cleanup(s.Close)
+	return s
+}
+
+func TestGCPDriver_PrepareRotation(t *testing.T) {
+	const (
+		oldEmail = "old@test-project.iam.gserviceaccount.com"
+		newEmail = "new@test-project.iam.gserviceaccount.com"
+	)
+
+	t.Run("carries the retired key on the cleanup handle", func(t *testing.T) {
+		srv := newRotationServer(t, newEmail)
+		oldKey := newTestGCPSAKeyWithID(t, srv.URL+"/token", oldEmail, "old-key-id")
+		srv.newKeyJSON = newTestGCPSAKeyWithID(t, srv.URL+"/token", newEmail, "new-key-id")
+
+		d := newStaticGCPDriver(t, srv.URL, oldKey)
+		newConfig, cleanupConfig, _, err := d.PrepareRotation(context.TODO())
+		require.NoError(t, err)
+
+		assert.Equal(t, srv.newKeyJSON, newConfig["service_account_key"])
+		assert.Equal(t, "old-key-id", cleanupConfig["old_key_id"])
+		assert.Equal(t, oldKey, cleanupConfig["old_service_account_key"],
+			"cleanup must be able to authenticate as the key it deletes")
+	})
+
+	// The rotation manager persists the returned config before CommitRotation ever
+	// runs, so a key that never works is already the source's stored credential by
+	// the time anything notices — and the created key counts against a quota of ten.
+	t.Run("deletes a key that never becomes usable", func(t *testing.T) {
+		srv := newRotationServer(t, newEmail)
+		srv.newKeyUsable.Store(false)
+		srv.newKeyJSON = newTestGCPSAKeyWithID(t, srv.URL+"/token", newEmail, "new-key-id")
+
+		d := newStaticGCPDriver(t, srv.URL, newTestGCPSAKeyWithID(t, srv.URL+"/token", oldEmail, "old-key-id"))
+
+		// Shorten the window so the test does not sit through the real one.
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		_, _, _, err := d.PrepareRotation(ctx)
+		require.Error(t, err)
+		assert.EqualValues(t, 1, srv.created.Load())
+		assert.Equal(t, "new-key-id", srv.deleted.Load(),
+			"the unusable key must be reclaimed, or repeated failures exhaust the ten-key quota")
+	})
+
+	t.Run("a key that becomes usable after a delay is kept", func(t *testing.T) {
+		srv := newRotationServer(t, newEmail)
+		srv.newKeyUsable.Store(false)
+		srv.newKeyJSON = newTestGCPSAKeyWithID(t, srv.URL+"/token", newEmail, "new-key-id")
+
+		d := newStaticGCPDriver(t, srv.URL, newTestGCPSAKeyWithID(t, srv.URL+"/token", oldEmail, "old-key-id"))
+
+		go func() {
+			time.Sleep(1500 * time.Millisecond)
+			srv.newKeyUsable.Store(true)
+		}()
+
+		newConfig, _, _, err := d.PrepareRotation(context.TODO())
+		require.NoError(t, err, "propagation delay must not be mistaken for a bad key")
+		assert.Equal(t, srv.newKeyJSON, newConfig["service_account_key"])
+		assert.Empty(t, srv.deleted.Load(), "a key that came good must not be deleted")
+	})
+}
+
+func TestGCPDriver_CommitRotation_ProbesBeforePublishing(t *testing.T) {
+	srv := tokenGrantServer(t, 3600)
+	goodKey := newTestGCPSAKey(t, srv.URL+"/token", "sa@test-project.iam.gserviceaccount.com")
+	d := newStaticGCPDriver(t, srv.URL, goodKey)
+
+	// A key whose grant endpoint answers nothing usable.
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer dead.Close()
+	badKey := newTestGCPSAKey(t, dead.URL+"/token", "broken@test-project.iam.gserviceaccount.com")
+
+	err := d.CommitRotation(context.TODO(), map[string]string{"service_account_key": badKey})
+	require.Error(t, err)
+	assert.Equal(t, goodKey, d.getServiceAccountKey(),
+		"a failed commit must leave the working key in place, not publish the broken one")
+}
+
+func TestGCPDriver_CleanupRotation_AuthenticatesAsTheRetiredKey(t *testing.T) {
+	const (
+		oldEmail = "old@test-project.iam.gserviceaccount.com"
+		newEmail = "new@test-project.iam.gserviceaccount.com"
+	)
+
+	srv := newRotationServer(t, newEmail)
+	oldKey := newTestGCPSAKeyWithID(t, srv.URL+"/token", oldEmail, "old-key-id")
+
+	// The driver already holds the new key, as it would after a commit.
+	d := newStaticGCPDriver(t, srv.URL, newTestGCPSAKeyWithID(t, srv.URL+"/token", newEmail, "new-key-id"))
+
+	require.NoError(t, d.CleanupRotation(context.TODO(), map[string]string{
+		"old_key_id":              "old-key-id",
+		"service_account_email":   oldEmail,
+		"project_id":              "test-project",
+		"old_service_account_key": oldKey,
+	}))
+
+	assert.Equal(t, "old-key-id", srv.deleted.Load())
+	// The newly published key is the one whose public half may not have propagated;
+	// the retired key has been known to every replica for as long as it existed.
+	assert.Equal(t, oldEmail, srv.deleteIssuer.Load(),
+		"the deletion must authenticate as the key being deleted")
+}
+
+func TestGCPDriver_CleanupRotation_FallsBackForOlderHandles(t *testing.T) {
+	const newEmail = "new@test-project.iam.gserviceaccount.com"
+
+	srv := newRotationServer(t, newEmail)
+	d := newStaticGCPDriver(t, srv.URL, newTestGCPSAKeyWithID(t, srv.URL+"/token", newEmail, "new-key-id"))
+
+	// A handle written before the retired key travelled with it.
+	require.NoError(t, d.CleanupRotation(context.TODO(), map[string]string{
+		"old_key_id":            "old-key-id",
+		"service_account_email": "old@test-project.iam.gserviceaccount.com",
+		"project_id":            "test-project",
+	}))
+
+	assert.Equal(t, "old-key-id", srv.deleted.Load())
+	assert.Equal(t, newEmail, srv.deleteIssuer.Load(), "falls back to the live credential")
+}
+
+func TestGCPDriver_CreateServiceAccountKey_RejectsUnusableMaterial(t *testing.T) {
+	for name, payload := range map[string]string{
+		"null":      `null`,
+		"empty":     `{}`,
+		"truncated": `{"type":"service_account","project_id":"p"}`,
+		"wrong type": `{"type":"external_account","project_id":"p","private_key_id":"k",` +
+			`"client_email":"x@y.iam.gserviceaccount.com","private_key":"k"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]string{
+					"privateKeyData": base64.StdEncoding.EncodeToString([]byte(payload)),
+				})
+			}))
+			defer srv.Close()
+
+			d := &GCPDriver{httpClient: &http.Client{Timeout: 5 * time.Second}, iamHost: srv.URL}
+			_, err := d.createServiceAccountKey(context.TODO(), "tok", "sa@p.iam.gserviceaccount.com", "p")
+			require.Error(t, err, "%s would otherwise be stored as the source credential", name)
+		})
+	}
+
+	t.Run("a key missing its project cannot be addressed", func(t *testing.T) {
+		d := &GCPDriver{httpClient: &http.Client{}, iamHost: "http://127.0.0.1:1"}
+		_, err := d.createServiceAccountKey(context.TODO(), "tok", "sa@p.iam.gserviceaccount.com", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project_id")
+	})
+}
+
+// The driver's HTTP client carries ca_data, tls_skip_verify and the request timeout.
+// The OAuth2 token grant used to run on http.DefaultClient instead, so all three were
+// silently ignored on every static-auth mint.
+func TestGCPDriver_TokenGrantUsesTheConfiguredClient(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "tok", "token_type": "Bearer", "expires_in": 3600,
+		})
+	}))
+	defer srv.Close()
+
+	keyJSON := newTestGCPSAKey(t, srv.URL+"/token", "sa@test-project.iam.gserviceaccount.com")
+
+	t.Run("a client trusting the server succeeds", func(t *testing.T) {
+		d := newStaticGCPDriver(t, srv.URL, keyJSON)
+		d.httpClient = srv.Client() // carries the test CA, as ca_data would
+		_, _, err := d.acquireToken(context.TODO(), []string{gcpCloudPlatformScope})
+		require.NoError(t, err)
+	})
+
+	t.Run("a client that does not trust it fails", func(t *testing.T) {
+		d := newStaticGCPDriver(t, srv.URL, keyJSON)
+		d.httpClient = &http.Client{Timeout: 5 * time.Second}
+		_, _, err := d.acquireToken(context.TODO(), []string{gcpCloudPlatformScope})
+		require.Error(t, err, "the driver's client must be the one making the grant")
+		assert.Contains(t, strings.ToLower(err.Error()), "certificate")
+	})
+}
+
+// The library dispatches on the document's own "type", so an external_account names a
+// file or URL for it to fetch. Refused at the grant as well as at config validation:
+// a key can reach here from storage written before the validator tightened.
+func TestGCPDriver_TokenGrantRefusesForeignCredentialTypes(t *testing.T) {
+	d := &GCPDriver{httpClient: &http.Client{Timeout: 5 * time.Second}}
+
+	external := fmt.Sprintf(`{"type":"external_account","audience":"//x","subject_token_type":"urn:ietf:params:oauth:token-type:jwt","token_url":"%s","credential_source":{"file":"/etc/passwd"}}`, "http://127.0.0.1:1/token")
+
+	_, _, err := d.tokenFromKeyJSON(context.TODO(), external, []string{gcpCloudPlatformScope})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "/etc/passwd", "the document must be refused before anything it names is read")
+}

--- a/credential/types/db_auth_token.go
+++ b/credential/types/db_auth_token.go
@@ -75,14 +75,17 @@ func NewDBAuthTokenCredType() *DBAuthTokenCredType {
 // ConfigSchema returns the declarative schema for database auth token credential config
 func (t *DBAuthTokenCredType) ConfigSchema() []*credential.FieldValidator {
 	return []*credential.FieldValidator{
+		// cloud_sql_iam_token stays listed so a spec naming it reaches ValidateConfig,
+		// which refuses it as unimplemented — dropping it here would answer the same
+		// spec with a generic "must be one of" that says nothing about why.
 		credential.StringField("mint_method").
 			OneOf("rds_iam_token", "redshift_iam_token", "cloud_sql_iam_token", "azure_db_iam_token").
-			Describe("Method for minting database IAM auth tokens").
+			Describe("Method for minting database IAM auth tokens (cloud_sql_iam_token is not implemented)").
 			Example("rds_iam_token"),
 
-		// db_user is required for rds_iam_token / cloud_sql_iam_token / azure_db_iam_token
-		// (enforced in ValidateConfig). Not required for redshift_iam_token because the
-		// Redshift API returns the database user mapped from the IAM identity.
+		// db_user is required for rds_iam_token / azure_db_iam_token (enforced in
+		// ValidateConfig). Not required for redshift_iam_token because the Redshift
+		// API returns the database user mapped from the IAM identity.
 		credential.StringField("db_user").
 			Describe("Database user to authenticate as").
 			Example("app_readonly"),
@@ -113,11 +116,11 @@ func (t *DBAuthTokenCredType) ConfigSchema() []*credential.FieldValidator {
 			Example("arn:aws:iam::123456789:role/db-access"),
 
 		credential.StringField("target_service_account").
-			Describe("GCP service account to impersonate (required for cloud_sql_iam_token)").
+			Describe("GCP service account to impersonate (for cloud_sql_iam_token, which is not implemented)").
 			Example("db-reader@myproject.iam.gserviceaccount.com"),
 
 		credential.StringField("instance_connection_name").
-			Describe("Cloud SQL instance connection name (optional metadata for cloud_sql_iam_token)").
+			Describe("Cloud SQL instance connection name (for cloud_sql_iam_token, which is not implemented)").
 			Example("myproject:us-central1:mydb"),
 
 		credential.StringField("resource_uri").
@@ -190,12 +193,12 @@ func (t *DBAuthTokenCredType) ValidateConfig(config credential.Config, sourceTyp
 		if sourceType != credential.SourceTypeGCP {
 			return fmt.Errorf("cloud_sql_iam_token requires a gcp source, got: %s", sourceType)
 		}
-		if config.Get("target_service_account") == "" {
-			return fmt.Errorf("cloud_sql_iam_token requires target_service_account")
-		}
-		if config.Get("db_user") == "" {
-			return fmt.Errorf("cloud_sql_iam_token requires db_user")
-		}
+		// No gcp mint path implements this method, so a spec accepted here would
+		// write cleanly and then fail on every request with an unsupported-method
+		// error naming a key the operator set deliberately. Refuse it where the
+		// mistake is made instead. Its target_service_account and db_user
+		// requirements go with it — they describe a shape nothing consumes.
+		return fmt.Errorf("cloud_sql_iam_token is not implemented for the gcp driver")
 	case "azure_db_iam_token":
 		if sourceType != credential.SourceTypeAzure {
 			return fmt.Errorf("azure_db_iam_token requires an azure source, got: %s", sourceType)

--- a/credential/types/db_auth_token_test.go
+++ b/credential/types/db_auth_token_test.go
@@ -102,7 +102,10 @@ func TestDBAuthTokenCredType_ValidateConfig_RDS_MissingEndpoint(t *testing.T) {
 	assert.Contains(t, err.Error(), "db_endpoint")
 }
 
-func TestDBAuthTokenCredType_ValidateConfig_CloudSQL(t *testing.T) {
+// No gcp mint path implements cloud_sql_iam_token, so a spec naming it is refused
+// where it is written. Accepting it here is what let one be stored and then fail on
+// every request with an error naming a key the operator set on purpose.
+func TestDBAuthTokenCredType_ValidateConfig_CloudSQL_Unimplemented(t *testing.T) {
 	ct := NewDBAuthTokenCredType()
 
 	config := map[string]string{
@@ -112,7 +115,8 @@ func TestDBAuthTokenCredType_ValidateConfig_CloudSQL(t *testing.T) {
 	}
 
 	err := ct.ValidateConfig(credential.NewConfig(config), credential.SourceTypeGCP)
-	assert.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not implemented")
 }
 
 func TestDBAuthTokenCredType_ValidateConfig_CloudSQL_WrongSource(t *testing.T) {


### PR DESCRIPTION
The GCP driver carried a set of defects that survived because the paths holding them had no coverage: the two static mint methods were never driven end to end, and the two service-account key calls rotation makes had none at all.

First of three. The next adds `secret_read`; the third drives it through the full chain.

## Security

- **Credential-type confusion.** `acquireToken` loaded the service account key with a constructor that dispatches on the document's own `type` field. A key declaring `external_account` or `impersonated_service_account` names a file or URL for that constructor to go and read, so writing a credential source could read host files and call arbitrary endpoints as this process. The type is now pinned, both at the grant and when the key is written. The repo already did this correctly in `core/oidc_publisher_gcs.go`.
- **TLS config silently ignored.** The same call passed a bare context, so the token exchange ran on `http.DefaultClient`: `ca_data`, `tls_skip_verify` and the request timeout applied to nothing on any static-auth mint.
- **Over-broad default scope.** `mint_method=access_token` vends the source service account's own token, shared by every caller asking for the same scopes, and defaulted to `cloud-platform` — the source's full authority, which on a rotating source includes minting its own replacement keys. Explicit `scopes` are now required.

## Correctness

- Neither static mint path bounded its lease by the spec's TTLs, and the access-token path returned a *cached* token's remaining life, so identical requests were leased anything from a minute to an hour. A grant carrying no usable expiry was cached as an already-expired credential and re-minted on every request.
- An impersonated token whose response omitted `expireTime` was leased a flat hour regardless of the lifetime asked for, serving a dead token from cache long after it expired. The lifetime validator accepted Go duration spellings the API rejects, so `"1h"` passed locally and failed on every mint.
- `PrepareRotation` neither verified nor reclaimed the key it created. The manager persists that config *before* committing, so an unusable key became the source's stored credential — and the orphan counted against a quota of ten per account, so a handful of failures left rotation permanently unable to succeed. `CommitRotation` published before verifying, with nothing to roll back to. `CleanupRotation` authenticated as the newly published key, the one whose propagation lag rotation is built around, rather than the retired key it deletes.
- Retries were configured with an empty retryable-status list and a single attempt, so one 429 from the key-creation quota or one 503 under load failed a mint outright.
- `splitScopes` never dropped empty elements and split on commas only, turning a trailing comma into a blank scope and a space-separated list (the form Google's own docs use) into one bogus scope. base64 decoding accepted only the padded standard alphabet. The token-race retry loop was unbounded and never checked cancellation, on the request path. A static source derived a `warden_resource` claim for a mint the exchange path refuses.

## Endpoint overrides

`sts_endpoint` and `iamcredentials_endpoint` become source config, rejected on a static source and refused alongside rotation. The IAM host stays internal — an override cannot redirect real key management — but is now a field rather than an inline URL, which is what makes rotation testable at all.

`cloud_sql_iam_token` is refused where a spec is written rather than on every request, in both the inferred and the stated-type paths.

## Behaviour change

Static `access_token` specs without explicit `scopes` will start failing at mint. No in-tree test breaks — the only two `MintCredential` unit tests are error paths — so the exposure is deployed operator specs. Wants a decision before merge.

## Verification

`go build`, `go vet`, full unit suite, `go test -race -run GCP ./credential/drivers/...`, and the complete e2e tree (all 20 packages, `rotation` included) against a rebuilt cluster.

One review claim I checked and rejected: the static impersonation path requesting `auth/iam` was flagged as a bug, but [Google's docs](https://docs.cloud.google.com/iam/docs/reference/credentials/rest/v1/projects.serviceAccounts/generateAccessToken) state `generateAccessToken` accepts either that scope or `cloud-platform`. It is normalised for consistency, not fixed.
