### PR TITLE
feat(gcp): read Secret Manager as a chaining source

### DIFF
--- a/credential/carriage.go
+++ b/credential/carriage.go
@@ -128,6 +128,7 @@ var reservedSpecConfigKeys = map[string]struct{}{
 	"kv2_mount":       {},
 	"secret_path":     {},
 	"secret_id":       {},
+	"secret_name":     {},
 	"role_arn":        {},
 	"version_stage":   {},
 	"version_id":      {},
@@ -135,6 +136,15 @@ var reservedSpecConfigKeys = map[string]struct{}{
 	"credential_type": {},
 	"json_key_map":    {},
 }
+
+// Deliberately absent: `project` and `target_service_account`, the other two keys a
+// gcp secret_read spec addresses its secret with. Both are ordinary words an operator
+// may already have named a credential field — an apikey source listing `project` in
+// credential_fields is entirely plausible — and reserving a name here stops that field
+// being carried, silently, on mounts that have nothing to do with GCP. Same reasoning
+// as mintParameterFields above: a name that is a locator for one source and a
+// credential field for another cannot be settled globally. `secret_name` is listed
+// because it is already Key Vault's locator too, and is nobody's credential field.
 
 // reservedRawDataPrefix marks keys that belong to the mint pipeline rather than
 // to the credential — RawAdjunctFieldsKey and the rotated-refresh-token keys. No

--- a/credential/config_helpers.go
+++ b/credential/config_helpers.go
@@ -175,15 +175,17 @@ var (
 	mintMethodsHonoringKeyMap = map[string]map[string]struct{}{
 		SourceTypeVault: {"static_aws": {}, "static_apikey": {}, "kv2_read": {}},
 		SourceTypeAWS:   {"secrets_manager": {}, "secret_read": {}},
+		SourceTypeGCP:   {"secret_read": {}},
 	}
 
 	// secret_version pins a revision, which each store spells its own way: a
-	// number for KV v2, an opaque identifier for Key Vault. A store that spells it
-	// differently again (version_id / version_stage on Secrets Manager) is absent
-	// here, so pinning there keeps using its own keys.
+	// number for KV v2 and for Secret Manager, an opaque identifier for Key Vault.
+	// A store that spells it differently again (version_id / version_stage on
+	// Secrets Manager) is absent here, so pinning there keeps using its own keys.
 	mintMethodsHonoringSecretVersion = map[string]map[string]struct{}{
 		SourceTypeVault: {"static_aws": {}, "static_apikey": {}, "kv2_read": {}},
 		SourceTypeAzure: {"key_vault_secret": {}},
+		SourceTypeGCP:   {"secret_read": {}},
 	}
 )
 
@@ -202,7 +204,7 @@ func ValidateSecretSelection(config Config, sourceType string) error {
 
 	if keyMap := config.Get("json_key_map"); keyMap != "" {
 		if _, ok := mintMethodsHonoringKeyMap[sourceType][mintMethod]; !ok {
-			return fmt.Errorf("'json_key_map' selects fields of a stored secret and is not supported by mint_method '%s'; it applies to static_aws, static_apikey and kv2_read on an hvault source, and secrets_manager and secret_read on an aws source", mintMethod)
+			return fmt.Errorf("'json_key_map' selects fields of a stored secret and is not supported by mint_method '%s'; it applies to static_aws, static_apikey and kv2_read on an hvault source, secrets_manager and secret_read on an aws source, and secret_read on a gcp source", mintMethod)
 		}
 		if err := validateKeyMapSyntax(keyMap); err != nil {
 			return err
@@ -210,7 +212,7 @@ func ValidateSecretSelection(config Config, sourceType string) error {
 	}
 
 	if _, ok := mintMethodsHonoringSecretVersion[sourceType][mintMethod]; !ok && config.Get("secret_version") != "" {
-		return fmt.Errorf("'secret_version' pins a revision of a stored secret and is not supported by mint_method '%s'; it applies to static_aws, static_apikey and kv2_read on an hvault source, and key_vault_secret on an azure source", mintMethod)
+		return fmt.Errorf("'secret_version' pins a revision of a stored secret and is not supported by mint_method '%s'; it applies to static_aws, static_apikey and kv2_read on an hvault source, key_vault_secret on an azure source, and secret_read on a gcp source", mintMethod)
 	}
 
 	return nil

--- a/credential/config_helpers_test.go
+++ b/credential/config_helpers_test.go
@@ -370,3 +370,29 @@ func TestValidateRequired(t *testing.T) {
 	assert.Error(t, ValidateRequired(NewConfig(cfg), "empty"))
 	assert.NoError(t, ValidateRequired(NewConfig(cfg)))
 }
+
+// Both selection keys fail open by nature — an ignored json_key_map vends the
+// unprojected payload, an ignored secret_version vends the current revision — so a
+// gcp secret_read spec setting either must be recognised here or it looks filtered or
+// pinned while being neither.
+func TestValidateSecretSelection_GCPSecretRead(t *testing.T) {
+	t.Run("both keys apply to secret_read", func(t *testing.T) {
+		require.NoError(t, ValidateSecretSelection(NewConfig(map[string]string{
+			"mint_method": "secret_read", "json_key_map": "api_key=token", "secret_version": "3",
+		}), SourceTypeGCP))
+	})
+
+	// Secret Manager numbers its versions, so secret_version is the right spelling
+	// here — unlike Secrets Manager, which has its own version_id/version_stage.
+	t.Run("neither applies to a token mint", func(t *testing.T) {
+		err := ValidateSecretSelection(NewConfig(map[string]string{
+			"mint_method": "access_token", "json_key_map": "a=b",
+		}), SourceTypeGCP)
+		require.Error(t, err)
+
+		err = ValidateSecretSelection(NewConfig(map[string]string{
+			"mint_method": "access_token", "secret_version": "3",
+		}), SourceTypeGCP)
+		require.Error(t, err)
+	})
+}

--- a/credential/drivers/gcp_driver.go
+++ b/credential/drivers/gcp_driver.go
@@ -5,9 +5,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"hash/crc32"
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -46,7 +48,19 @@ const (
 	defaultGCPSTSHost            = "https://sts.googleapis.com"
 	defaultGCPIAMCredentialsHost = "https://iamcredentials.googleapis.com"
 	defaultGCPIAMHost            = "https://iam.googleapis.com"
+	defaultGCPSecretManagerHost  = "https://secretmanager.googleapis.com"
 )
+
+// gcpMaxSecretPayloadSize is the largest secret Secret Manager stores. It bounds the
+// decoded payload, not the response: the payload arrives base64-encoded inside a JSON
+// envelope, so the body carrying a legal 64KiB secret is half again as large.
+const gcpMaxSecretPayloadSize = 64 * 1024
+
+// gcpFederatedFetchLifetime is how long the impersonated token used for a single
+// secret read is asked to live. The read happens immediately and the token is then
+// discarded, so this is a floor on clock skew rather than a working lifetime — the
+// spec's TTL bounds govern the secret it returns, not this.
+const gcpFederatedFetchLifetime = "900s"
 
 // OAuth2 scopes this driver requests. cloud-platform authorizes the token mints and
 // the impersonation call; the narrower iam scope authorizes only the key-management
@@ -133,6 +147,7 @@ type GCPDriver struct {
 	stsHost            string
 	iamCredentialsHost string
 	iamHost            string
+	secretManagerHost  string
 }
 
 // Config accessors — single source of truth is credSource.Config. Each takes authMu,
@@ -244,6 +259,11 @@ func (f *GCPDriverFactory) ValidateConfig(config credential.Config) error {
 			Describe("Override where service-account impersonation calls are sent (default: the public GCP endpoint). Does not apply to the IAM key-management calls rotation makes").
 			Example("https://iamcredentials.googleapis.com"),
 
+		credential.StringField("secretmanager_endpoint").
+			Custom(validateEndpointURL).
+			Describe("Override where Secret Manager reads are sent (default: the public GCP endpoint)").
+			Example("https://secretmanager.googleapis.com"),
+
 		credential.DurationField("activation_delay").
 			Describe("How long to wait after creating a rotated service-account key before activating it, covering IAM propagation").
 			Example("2m"),
@@ -304,12 +324,13 @@ func (f *GCPDriverFactory) ValidateConfig(config credential.Config) error {
 // oidc_federation, and a federated source is already refused a rotation_period
 // before any driver sees it. Naming it here would be a rule that can never fire.
 func (f *GCPDriverFactory) ValidateRotationConfig(config credential.Config) error {
-	if credential.GetString(config, "iamcredentials_endpoint", "") == "" {
+	if credential.GetString(config, "iamcredentials_endpoint", "") == "" &&
+		credential.GetString(config, "secretmanager_endpoint", "") == "" {
 		return nil
 	}
 	return fmt.Errorf("rotation_period cannot be set on a source that overrides " +
-		"iamcredentials_endpoint: rotation manages service account keys in the real " +
-		"project, which that override does not redirect")
+		"iamcredentials_endpoint or secretmanager_endpoint: rotation manages service " +
+		"account keys in the real project, which those overrides do not redirect")
 }
 
 // SensitiveConfigFields returns the list of config keys that should be masked in output
@@ -328,6 +349,10 @@ func (f *GCPDriverFactory) InferCredentialType(specConfig credential.Config) (st
 		// made. The same refusal lives in the db_auth_token validator, which is the
 		// path taken when the operator states `type` instead of leaving it inferred.
 		return "", fmt.Errorf("mint_method %q is not implemented for the gcp driver", mintMethod)
+	case "secret_read":
+		// A stored secret vended under its own key names, with no primary field to
+		// select — the shape a chained consumer reads by name.
+		return credential.TypeKeyValue, nil
 	case "", "access_token", "impersonated_access_token":
 		return credential.TypeGCPAccessToken, nil
 	default:
@@ -349,6 +374,8 @@ func (f *GCPDriverFactory) Create(config credential.Config, log *logger.GatedLog
 		iamCredentialsHost: strings.TrimRight(
 			credential.GetString(config, "iamcredentials_endpoint", defaultGCPIAMCredentialsHost), "/"),
 		iamHost: defaultGCPIAMHost,
+		secretManagerHost: strings.TrimRight(
+			credential.GetString(config, "secretmanager_endpoint", defaultGCPSecretManagerHost), "/"),
 	}
 
 	httpClient, err := BuildHTTPClient(config, 30*time.Second)
@@ -391,8 +418,10 @@ func (d *GCPDriver) MintCredential(ctx context.Context, spec *credential.CredSpe
 		return d.mintAccessToken(ctx, spec)
 	case "impersonated_access_token":
 		return d.mintImpersonatedAccessToken(ctx, spec)
+	case "secret_read":
+		return d.mintViaSecretRead(ctx, spec)
 	default:
-		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for GCP driver; use 'access_token' or 'impersonated_access_token'", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("unsupported mint_method '%s' for GCP driver; use 'access_token', 'impersonated_access_token' or 'secret_read'", mintMethod)
 	}
 }
 
@@ -615,6 +644,220 @@ func ttlFromExpireTime(expireTime string, fallback time.Duration) time.Duration 
 }
 
 // ============================================================================
+// Secret Manager reads (mint_method=secret_read)
+// ============================================================================
+
+// resolveSecretVersionPath builds the resource a secret read addresses, resolving any
+// {{user.<claim>}} / {{agent.<claim>}} template in the secret name first so one spec
+// can serve many callers and each reads only its own secret.
+//
+// secret_name may be a bare id or an already-qualified resource. A bare id needs the
+// project alongside it; a qualified one carries its own, and pairing it with `project`
+// is refused where the spec is written rather than silently preferring one of two
+// answers. An absent version reads the current one, which is how a spec follows
+// rotation of the secret it names.
+func resolveSecretVersionPath(spec *credential.CredSpec, userClaims, agentClaims map[string]string) (string, error) {
+	name, err := credential.GetStringRequired(spec.Config, "secret_name")
+	if err != nil {
+		return "", err
+	}
+	name, err = resolveClaimTemplate(name, userClaims, agentClaims, "secret_name")
+	if err != nil {
+		return "", err
+	}
+
+	// Every segment is escaped, as every other interpolated GCP path in this driver
+	// is. Without it a name carrying "#" truncates the request — reading a different
+	// version than the spec names while defeating the write-time rule against
+	// addressing two — and one carrying "?" turns the read into a different call
+	// entirely. The write-time charset checks make those unwritable; escaping here
+	// means a config that drifted past them still cannot reshape the request.
+	project := credential.GetString(spec.Config, "project", "")
+	secretID := name
+
+	if rest, ok := strings.CutPrefix(name, "projects/"); ok {
+		// A qualified resource carries its own project; its shape is checked where
+		// the spec is written.
+		parts := strings.Split(rest, "/secrets/")
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return "", fmt.Errorf("'secret_name' must read 'projects/<project>/secrets/<name>' when fully qualified, got: %s", name)
+		}
+		project, secretID = parts[0], parts[1]
+	} else if project == "" {
+		return "", fmt.Errorf("'project' is required when 'secret_name' is a bare secret id")
+	}
+
+	version := credential.GetString(spec.Config, "secret_version", "")
+	if version == "" {
+		version = "latest"
+	}
+
+	return fmt.Sprintf("projects/%s/secrets/%s/versions/%s",
+		url.PathEscape(project), url.PathEscape(secretID), url.PathEscape(version)), nil
+}
+
+// fetchSecret reads a Secret Manager payload with the given bearer token and returns
+// it as the credential's data. The token may be the source's own (static auth) or one
+// obtained for this caller through federation.
+//
+// The returned TTL is zero and there is no lease: a stored secret does not expire and
+// nothing here can revoke it. Its freshness is bounded by the consuming spec's
+// secret_cache_ttl, not by a lease this could invent.
+func (d *GCPDriver) fetchSecret(ctx context.Context, bearerToken string, spec *credential.CredSpec,
+	userClaims, agentClaims map[string]string) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+
+	versionPath, err := resolveSecretVersionPath(spec, userClaims, agentClaims)
+	if err != nil {
+		return nil, nil, 0, "", err
+	}
+
+	respBody, err := d.doGCPRequest(ctx, gcpAPIRequest{
+		method:      "GET",
+		url:         d.secretManagerHost + "/v1/" + versionPath + ":access",
+		bearerToken: bearerToken,
+		okStatuses:  []int{http.StatusOK},
+		operation:   "accessSecretVersion",
+	})
+	if err != nil {
+		return nil, nil, 0, "", fmt.Errorf("failed to read secret %q: %w", versionPath, err)
+	}
+
+	var accessResp struct {
+		Name    string `json:"name"`
+		Payload struct {
+			Data       string `json:"data"`
+			DataCrc32c string `json:"dataCrc32c"`
+		} `json:"payload"`
+	}
+	if err := json.Unmarshal(respBody, &accessResp); err != nil {
+		return nil, nil, 0, "", fmt.Errorf("failed to decode secret response: %w", err)
+	}
+
+	decoded, err := base64Decode(accessResp.Payload.Data)
+	if err != nil {
+		return nil, nil, 0, "", fmt.Errorf("failed to decode secret payload: %w", err)
+	}
+	if len(decoded) == 0 {
+		return nil, nil, 0, "", fmt.Errorf("secret %q has an empty payload", versionPath)
+	}
+	if len(decoded) > gcpMaxSecretPayloadSize {
+		return nil, nil, 0, "", fmt.Errorf("secret %q payload is %d bytes, beyond the %d Secret Manager stores", versionPath, len(decoded), gcpMaxSecretPayloadSize)
+	}
+	// The service returns a checksum for exactly this purpose. Verifying it costs a
+	// pass over bytes we already hold and turns a truncated payload into an error
+	// rather than a credential that is quietly wrong.
+	if err := verifySecretCRC32C(decoded, accessResp.Payload.DataCrc32c); err != nil {
+		return nil, nil, 0, "", fmt.Errorf("secret %q failed its integrity check: %w", versionPath, err)
+	}
+
+	rawData, err := parseSecretPayload(decoded)
+	if err != nil {
+		return nil, nil, 0, "", fmt.Errorf("secret %q: %w", versionPath, err)
+	}
+	rawData = credential.ApplyKeyMap(rawData, credential.GetString(spec.Config, "json_key_map", ""))
+	if len(rawData) == 0 {
+		return nil, nil, 0, "", fmt.Errorf("secret %q yielded no fields; check 'json_key_map' against the stored payload", versionPath)
+	}
+
+	if d.logger != nil {
+		d.logger.Debug("read GCP Secret Manager secret",
+			logger.String("spec", spec.Name),
+			logger.String("secret", versionPath),
+		)
+	}
+
+	return rawData, nil, 0, "", nil
+}
+
+// parseSecretPayload turns raw secret bytes into the credential's fields.
+//
+// Secret Manager stores arbitrary bytes, so unlike a store that holds documents there
+// is no single right shape. A JSON object of scalars is vended under its own key names
+// — the multi-field secret a chained consumer reads by name, with numbers and booleans
+// rendered as strings because that is the only shape this credential type carries.
+// Anything that is not a JSON object at all, a plain API key being the common case, is
+// vended whole under "value".
+//
+// A document containing a nested object or array is refused rather than vended either
+// way. Blobbing it under "value" would be actively dangerous: a consuming spec that
+// names no secret_field takes the sole key when there is only one, so the entire
+// document — every secret stored beside the wanted one — would be sent upstream as the
+// credential. Dropping the nested field and keeping the rest would be quietly lossy.
+// Neither is worth the convenience of accepting a shape nothing here can represent.
+func parseSecretPayload(decoded []byte) (map[string]interface{}, error) {
+	var fields map[string]interface{}
+	if err := json.Unmarshal(decoded, &fields); err != nil || fields == nil {
+		// Not a JSON object: the payload is one opaque secret.
+		return map[string]interface{}{"value": string(decoded)}, nil
+	}
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("payload is an empty JSON object, carrying no secret")
+	}
+
+	out := make(map[string]interface{}, len(fields))
+	for k, v := range fields {
+		switch typed := v.(type) {
+		case string:
+			out[k] = typed
+		case bool:
+			out[k] = strconv.FormatBool(typed)
+		case float64:
+			// encoding/json decodes every JSON number as a float64. Render integers
+			// without a decimal point so a stored port or id reads back as written.
+			out[k] = strconv.FormatFloat(typed, 'f', -1, 64)
+		case nil:
+			return nil, fmt.Errorf("payload field %q is null", k)
+		default:
+			return nil, fmt.Errorf("payload field %q holds a nested object or array, which a key/value credential cannot carry; store it as its own secret, or as a string", k)
+		}
+	}
+	return out, nil
+}
+
+// verifySecretCRC32C checks the payload against the checksum the service reports.
+//
+// The field is optional, so its absence is not a failure — refusing a secret the
+// service chose not to checksum would fail closed on something carrying no evidence of
+// corruption. A checksum that is present but unreadable is different: the envelope is
+// then demonstrably not what the service sends, which is exactly what this guards
+// against, so it fails rather than skipping the check.
+func verifySecretCRC32C(payload []byte, want string) error {
+	if want == "" {
+		return nil
+	}
+	expected, err := strconv.ParseUint(want, 10, 32)
+	if err != nil {
+		return fmt.Errorf("reported checksum %q is not a 32-bit value: %w", want, err)
+	}
+	if got := uint64(crc32.Checksum(payload, crc32.MakeTable(crc32.Castagnoli))); got != expected {
+		return fmt.Errorf("checksum %d does not match the %d reported", got, expected)
+	}
+	return nil
+}
+
+// mintViaSecretRead reads the secret with the source's own credentials.
+//
+// Neither principal's claims are available here: this path runs when the spec sets no
+// subject_token_source, so nothing on the request was verified into claims. Passing
+// nil means a templated secret_name fails closed rather than being sent literally —
+// which matters, because a store will happily return a secret actually named
+// "prod/{{user.sub}}" to whoever can create one.
+func (d *GCPDriver) mintViaSecretRead(ctx context.Context, spec *credential.CredSpec) (map[string]interface{}, map[string]interface{}, time.Duration, string, error) {
+	// target_service_account is honoured only over federation, where the caller's own
+	// assertion authorizes the impersonation. Accepting it here and reading as the
+	// source instead would vend a secret under an authority the operator did not name.
+	if credential.GetString(spec.Config, "target_service_account", "") != "" {
+		return nil, nil, 0, "", fmt.Errorf("gcp: 'target_service_account' applies to mint_method=secret_read only over auth_method=oidc_federation; a static source reads as itself")
+	}
+
+	token, _, err := d.getSourceToken(ctx, []string{gcpCloudPlatformScope})
+	if err != nil {
+		return nil, nil, 0, "", fmt.Errorf("failed to acquire GCP access token: %w", err)
+	}
+	return d.fetchSecret(ctx, token, spec, nil, nil)
+}
+
+// ============================================================================
 // ExchangeMinter Interface Implementation (Workload Identity Federation)
 // ============================================================================
 
@@ -727,8 +970,29 @@ func (d *GCPDriver) MintCredentialWithExchange(ctx context.Context, spec *creden
 		}
 		return rawData, metadata, ttl, "", nil
 
+	case "secret_read":
+		// The credential is the stored secret, not the token that reads it, so the
+		// token is asked for a short fixed life and discarded straight after. The
+		// caller's claims travel with the fetch: a templated secret name resolves
+		// from them, scoping the read to the principals on this request.
+		fedToken, _, err := d.exchangeWIFToken(ctx, inputs.SubjectToken, inputs.SubjectTokenType, gcpFederationScope)
+		if err != nil {
+			return nil, nil, 0, "", err
+		}
+
+		readToken := fedToken
+		if targetSA := credential.GetString(spec.Config, "target_service_account", ""); targetSA != "" {
+			readToken, _, err = d.generateAccessToken(ctx, fedToken, targetSA,
+				[]string{gcpCloudPlatformScope}, gcpFederatedFetchLifetime)
+			if err != nil {
+				return nil, nil, 0, "", err
+			}
+		}
+
+		return d.fetchSecret(ctx, readToken, spec, inputs.UserClaims, inputs.AgentClaims)
+
 	default:
-		return nil, nil, 0, "", fmt.Errorf("gcp: mint_method %q is not supported over auth_method=oidc_federation (supported: impersonated_access_token, access_token)", mintMethod)
+		return nil, nil, 0, "", fmt.Errorf("gcp: mint_method %q is not supported over auth_method=oidc_federation (supported: impersonated_access_token, access_token, secret_read)", mintMethod)
 	}
 }
 
@@ -851,6 +1115,15 @@ func gcpAssertionResource(sourceCfg, specCfg credential.Config) (string, bool) {
 	case "access_token":
 		if p := credential.GetString(sourceCfg, "workload_identity_provider", ""); p != "" {
 			return "gcp-wif:" + p, true
+		}
+	case "secret_read":
+		// A templated secret name is carried unresolved, as every templated coordinate
+		// is here: this runs before the exchange that produces the claims it would
+		// resolve from. A policy conditioning on this claim therefore pins the spec,
+		// not the individual secret — per-principal scoping is enforced where the
+		// resolved read happens, by the permissions on the identity doing it.
+		if n := credential.GetString(specCfg, "secret_name", ""); n != "" {
+			return "gcp-secretmanager:" + n, true
 		}
 	}
 	return "", false

--- a/credential/drivers/gcp_secret_read_test.go
+++ b/credential/drivers/gcp_secret_read_test.go
@@ -1,0 +1,510 @@
+package drivers
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"hash/crc32"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stephnangue/warden/credential"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// secretManagerStub answers the Secret Manager access call, recording the resource it
+// was asked for and the bearer that asked, so a test can tell which identity did the
+// read and which version it addressed.
+type secretManagerStub struct {
+	*httptest.Server
+
+	lastPath   atomic.Value // string: the version resource, without the :access suffix
+	lastBearer atomic.Value // string
+	payload    []byte
+	corruptCRC bool
+}
+
+func newSecretManagerStub(t *testing.T, payload string) *secretManagerStub {
+	t.Helper()
+	s := &secretManagerStub{payload: []byte(payload)}
+	s.Server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/v1/")
+		path = strings.TrimSuffix(path, ":access")
+		s.lastPath.Store(path)
+		s.lastBearer.Store(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+
+		sum := crc32.Checksum(s.payload, crc32.MakeTable(crc32.Castagnoli))
+		if s.corruptCRC {
+			sum++
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"name": path,
+			"payload": map[string]string{
+				"data":       base64.StdEncoding.EncodeToString(s.payload),
+				"dataCrc32c": strconv.FormatInt(int64(sum), 10),
+			},
+		})
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func secretSpec(cfg map[string]string) *credential.CredSpec {
+	full := map[string]string{"mint_method": "secret_read"}
+	for k, v := range cfg {
+		full[k] = v
+	}
+	return &credential.CredSpec{Name: "secret-spec", Config: credential.NewConfig(full)}
+}
+
+// A chaining source is minted as the calling principal, which forces the exchange
+// path, so this is the shape the feature actually runs in.
+func newSecretReadFederationDriver(t *testing.T, stsURL, smURL, iamCredURL string) *GCPDriver {
+	t.Helper()
+	d := newFederationDriver(testWIFProvider, stsURL, iamCredURL)
+	d.secretManagerHost = smURL
+	return d
+}
+
+func gcpSTSStub(t *testing.T, token string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": token, "expires_in": 3600, "token_type": "Bearer",
+		})
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestResolveSecretVersionPath(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  map[string]string
+		want string
+	}{
+		{
+			name: "bare id with project reads the current version",
+			cfg:  map[string]string{"secret_name": "datadog-keys", "project": "acme-prod"},
+			want: "projects/acme-prod/secrets/datadog-keys/versions/latest",
+		},
+		{
+			name: "qualified resource carries its own project",
+			cfg:  map[string]string{"secret_name": "projects/acme-prod/secrets/datadog-keys"},
+			want: "projects/acme-prod/secrets/datadog-keys/versions/latest",
+		},
+		{
+			name: "a pinned version is addressed by number",
+			cfg:  map[string]string{"secret_name": "datadog-keys", "project": "acme-prod", "secret_version": "3"},
+			want: "projects/acme-prod/secrets/datadog-keys/versions/3",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveSecretVersionPath(secretSpec(tc.cfg), nil, nil)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("a bare id without a project cannot be addressed", func(t *testing.T) {
+		_, err := resolveSecretVersionPath(secretSpec(map[string]string{"secret_name": "datadog-keys"}), nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "project")
+	})
+
+	t.Run("resolves the agent principal", func(t *testing.T) {
+		got, err := resolveSecretVersionPath(
+			secretSpec(map[string]string{"secret_name": "per-agent-{{agent.sub}}", "project": "acme-prod"}),
+			nil, map[string]string{"sub": "e2e-agent"})
+		require.NoError(t, err)
+		assert.Equal(t, "projects/acme-prod/secrets/per-agent-e2e-agent/versions/latest", got)
+	})
+
+	// Without claims a template would otherwise be sent literally, and a store will
+	// happily return a secret actually named "per-agent-{{agent.sub}}" to whoever can
+	// create one.
+	t.Run("fails closed when there are no claims to resolve from", func(t *testing.T) {
+		_, err := resolveSecretVersionPath(
+			secretSpec(map[string]string{"secret_name": "per-agent-{{agent.sub}}", "project": "acme-prod"}), nil, nil)
+		require.Error(t, err)
+	})
+}
+
+// Secret Manager stores arbitrary bytes, so there is no single right shape. A flat
+// object of strings is the multi-field secret a chained consumer reads by name;
+// anything else is vended whole, because the key_value type keeps only string fields
+// and admitting a nested document would silently drop part of it.
+func TestParseSecretPayload(t *testing.T) {
+	t.Run("object of scalars is vended under its own keys", func(t *testing.T) {
+		got, err := parseSecretPayload([]byte(`{"api_key":"k1","port":5432,"tls":true}`))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{
+			"api_key": "k1",
+			"port":    "5432",
+			"tls":     "true",
+		}, got, "numbers render without a decimal point, as stored")
+	})
+
+	for name, payload := range map[string]string{
+		"a plain api key":    "not-json-at-all",
+		"a JSON array":       `["a","b"]`,
+		"a bare JSON string": `"just-a-string"`,
+		"a JSON number":      `12345`,
+	} {
+		t.Run(name+" is one opaque secret", func(t *testing.T) {
+			got, err := parseSecretPayload([]byte(payload))
+			require.NoError(t, err)
+			assert.Equal(t, map[string]interface{}{"value": payload}, got)
+		})
+	}
+
+	// A consuming spec naming no secret_field takes the sole key when there is only
+	// one, so blobbing a document under "value" would send every secret stored beside
+	// the wanted one upstream as the credential. Dropping the nested field instead
+	// would be quietly lossy. Neither is acceptable, so the shape is refused.
+	t.Run("a nested document is refused, not blobbed", func(t *testing.T) {
+		for _, payload := range []string{
+			`{"api_key":"k","meta":{"env":"prod"}}`,
+			`{"api_key":"k","hosts":["a","b"]}`,
+		} {
+			_, err := parseSecretPayload([]byte(payload))
+			require.Errorf(t, err, "%s must be refused", payload)
+			assert.Contains(t, err.Error(), "nested")
+		}
+	})
+
+	t.Run("a null field is refused", func(t *testing.T) {
+		_, err := parseSecretPayload([]byte(`{"api_key":null}`))
+		require.Error(t, err)
+	})
+
+	t.Run("an empty object carries no secret", func(t *testing.T) {
+		_, err := parseSecretPayload([]byte(`{}`))
+		require.Error(t, err)
+	})
+}
+
+func TestGCPDriver_SecretRead_Federated(t *testing.T) {
+	const payload = `{"api_key":"dd-key","application_key":"dd-app"}`
+
+	t.Run("reads with the federated token and vends the payload", func(t *testing.T) {
+		sm := newSecretManagerStub(t, payload)
+		sts := gcpSTSStub(t, "FED-TOKEN")
+		d := newSecretReadFederationDriver(t, sts.URL, sm.URL, "")
+
+		data, meta, ttl, leaseID, err := d.MintCredentialWithExchange(context.TODO(),
+			secretSpec(map[string]string{"secret_name": "datadog-keys", "project": "acme-prod"}),
+			&credential.ExchangeInputs{SubjectToken: "caller-assertion"})
+		require.NoError(t, err)
+
+		assert.Equal(t, map[string]interface{}{"api_key": "dd-key", "application_key": "dd-app"}, data)
+		assert.Nil(t, meta)
+		assert.Zero(t, ttl, "a stored secret does not expire")
+		assert.Empty(t, leaseID, "a stored secret holds no lease")
+
+		assert.Equal(t, "projects/acme-prod/secrets/datadog-keys/versions/latest", sm.lastPath.Load())
+		assert.Equal(t, "FED-TOKEN", sm.lastBearer.Load(), "the read must use the caller's federated token")
+	})
+
+	t.Run("impersonates when the spec names a service account", func(t *testing.T) {
+		sm := newSecretManagerStub(t, payload)
+		sts := gcpSTSStub(t, "FED-TOKEN")
+
+		var impersonationBearer atomic.Value
+		iamCred := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			impersonationBearer.Store(strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer "))
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"accessToken": "IMPERSONATED"})
+		}))
+		defer iamCred.Close()
+
+		d := newSecretReadFederationDriver(t, sts.URL, sm.URL, iamCred.URL)
+
+		_, _, _, _, err := d.MintCredentialWithExchange(context.TODO(),
+			secretSpec(map[string]string{
+				"secret_name": "datadog-keys", "project": "acme-prod",
+				"target_service_account": "reader@acme-prod.iam.gserviceaccount.com",
+			}),
+			&credential.ExchangeInputs{SubjectToken: "caller-assertion"})
+		require.NoError(t, err)
+
+		assert.Equal(t, "FED-TOKEN", impersonationBearer.Load(), "the federated token authorizes the impersonation")
+		assert.Equal(t, "IMPERSONATED", sm.lastBearer.Load(), "the impersonated token performs the read")
+	})
+
+	t.Run("a templated name resolves from the caller's claims", func(t *testing.T) {
+		sm := newSecretManagerStub(t, payload)
+		sts := gcpSTSStub(t, "FED-TOKEN")
+		d := newSecretReadFederationDriver(t, sts.URL, sm.URL, "")
+
+		_, _, _, _, err := d.MintCredentialWithExchange(context.TODO(),
+			secretSpec(map[string]string{"secret_name": "per-agent-{{agent.sub}}", "project": "acme-prod"}),
+			&credential.ExchangeInputs{
+				SubjectToken: "caller-assertion",
+				AgentClaims:  map[string]string{"sub": "e2e-agent"},
+			})
+		require.NoError(t, err)
+		assert.Equal(t, "projects/acme-prod/secrets/per-agent-e2e-agent/versions/latest", sm.lastPath.Load())
+	})
+
+	t.Run("json_key_map projects the payload", func(t *testing.T) {
+		sm := newSecretManagerStub(t, payload)
+		sts := gcpSTSStub(t, "FED-TOKEN")
+		d := newSecretReadFederationDriver(t, sts.URL, sm.URL, "")
+
+		data, _, _, _, err := d.MintCredentialWithExchange(context.TODO(),
+			secretSpec(map[string]string{
+				"secret_name": "datadog-keys", "project": "acme-prod",
+				"json_key_map": "api_key=token",
+			}),
+			&credential.ExchangeInputs{SubjectToken: "caller-assertion"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{"token": "dd-key"}, data,
+			"a selection vends exactly the fields it names")
+	})
+
+	t.Run("a projection selecting nothing is an error, not an empty credential", func(t *testing.T) {
+		sm := newSecretManagerStub(t, payload)
+		sts := gcpSTSStub(t, "FED-TOKEN")
+		d := newSecretReadFederationDriver(t, sts.URL, sm.URL, "")
+
+		_, _, _, _, err := d.MintCredentialWithExchange(context.TODO(),
+			secretSpec(map[string]string{
+				"secret_name": "datadog-keys", "project": "acme-prod",
+				"json_key_map": "absent=token",
+			}),
+			&credential.ExchangeInputs{SubjectToken: "caller-assertion"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "json_key_map")
+	})
+
+	t.Run("a payload failing its checksum is refused", func(t *testing.T) {
+		sm := newSecretManagerStub(t, payload)
+		sm.corruptCRC = true
+		sts := gcpSTSStub(t, "FED-TOKEN")
+		d := newSecretReadFederationDriver(t, sts.URL, sm.URL, "")
+
+		_, _, _, _, err := d.MintCredentialWithExchange(context.TODO(),
+			secretSpec(map[string]string{"secret_name": "datadog-keys", "project": "acme-prod"}),
+			&credential.ExchangeInputs{SubjectToken: "caller-assertion"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "integrity")
+	})
+
+	t.Run("a plain secret is vended under value", func(t *testing.T) {
+		sm := newSecretManagerStub(t, "sk-plain-api-key")
+		sts := gcpSTSStub(t, "FED-TOKEN")
+		d := newSecretReadFederationDriver(t, sts.URL, sm.URL, "")
+
+		data, _, _, _, err := d.MintCredentialWithExchange(context.TODO(),
+			secretSpec(map[string]string{"secret_name": "openai", "project": "acme-prod"}),
+			&credential.ExchangeInputs{SubjectToken: "caller-assertion"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{"value": "sk-plain-api-key"}, data)
+	})
+}
+
+func TestGCPDriver_SecretRead_Static(t *testing.T) {
+	const payload = `{"api_key":"dd-key"}`
+
+	t.Run("reads as the source itself", func(t *testing.T) {
+		sm := newSecretManagerStub(t, payload)
+		grant := tokenGrantServer(t, 3600)
+
+		d := newStaticGCPDriver(t, grant.URL, newTestGCPSAKey(t, grant.URL+"/token", "sa@test-project.iam.gserviceaccount.com"))
+		d.secretManagerHost = sm.URL
+
+		data, _, ttl, _, err := d.MintCredential(context.TODO(),
+			secretSpec(map[string]string{"secret_name": "datadog-keys", "project": "acme-prod"}))
+		require.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{"api_key": "dd-key"}, data)
+		assert.Zero(t, ttl)
+	})
+
+	// Nothing on a static request was verified into claims, so a template has nothing
+	// to resolve from and must not be sent literally.
+	t.Run("a templated name fails closed", func(t *testing.T) {
+		sm := newSecretManagerStub(t, payload)
+		grant := tokenGrantServer(t, 3600)
+
+		d := newStaticGCPDriver(t, grant.URL, newTestGCPSAKey(t, grant.URL+"/token", "sa@test-project.iam.gserviceaccount.com"))
+		d.secretManagerHost = sm.URL
+
+		_, _, _, _, err := d.MintCredential(context.TODO(),
+			secretSpec(map[string]string{"secret_name": "per-agent-{{agent.sub}}", "project": "acme-prod"}))
+		require.Error(t, err)
+		assert.Nil(t, sm.lastPath.Load(), "no read may be attempted with an unresolved name")
+	})
+
+	// Impersonation is authorized by the caller's own assertion, which a static source
+	// does not have. Reading as the source instead would vend the secret under an
+	// authority the operator did not name.
+	t.Run("target_service_account is refused", func(t *testing.T) {
+		grant := tokenGrantServer(t, 3600)
+		d := newStaticGCPDriver(t, grant.URL, newTestGCPSAKey(t, grant.URL+"/token", "sa@test-project.iam.gserviceaccount.com"))
+
+		_, _, _, _, err := d.MintCredential(context.TODO(),
+			secretSpec(map[string]string{
+				"secret_name": "datadog-keys", "project": "acme-prod",
+				"target_service_account": "reader@acme-prod.iam.gserviceaccount.com",
+			}))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "target_service_account")
+	})
+}
+
+func TestGCPDriver_SecretRead_PayloadBounds(t *testing.T) {
+	t.Run("an empty payload is refused", func(t *testing.T) {
+		sm := newSecretManagerStub(t, "")
+		sts := gcpSTSStub(t, "FED-TOKEN")
+		d := newSecretReadFederationDriver(t, sts.URL, sm.URL, "")
+
+		_, _, _, _, err := d.MintCredentialWithExchange(context.TODO(),
+			secretSpec(map[string]string{"secret_name": "s", "project": "p"}),
+			&credential.ExchangeInputs{SubjectToken: "a"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "empty")
+	})
+
+	// The 64KiB ceiling is on the decoded payload. Base64 inside the JSON envelope
+	// makes the body half again as large, so bounding the body at 64KiB would have
+	// truncated any secret past roughly 48KiB.
+	t.Run("a secret at the documented ceiling still reads", func(t *testing.T) {
+		sm := newSecretManagerStub(t, strings.Repeat("x", gcpMaxSecretPayloadSize))
+		sts := gcpSTSStub(t, "FED-TOKEN")
+		d := newSecretReadFederationDriver(t, sts.URL, sm.URL, "")
+
+		data, _, _, _, err := d.MintCredentialWithExchange(context.TODO(),
+			secretSpec(map[string]string{"secret_name": "s", "project": "p"}),
+			&credential.ExchangeInputs{SubjectToken: "a"})
+		require.NoError(t, err)
+		assert.Len(t, data["value"], gcpMaxSecretPayloadSize)
+	})
+}
+
+func TestGCPDriver_SecretRead_InferenceAndAssertionResource(t *testing.T) {
+	f := &GCPDriverFactory{}
+
+	got, err := f.InferCredentialType(credential.NewConfig(map[string]string{"mint_method": "secret_read"}))
+	require.NoError(t, err)
+	assert.Equal(t, credential.TypeKeyValue, got)
+
+	res, ok := gcpAssertionResource(
+		credential.NewConfig(map[string]string{
+			"auth_method":                gcpAuthMethodOIDCFederation,
+			"workload_identity_provider": testWIFProvider,
+		}),
+		credential.NewConfig(map[string]string{"mint_method": "secret_read", "secret_name": "datadog-keys"}),
+	)
+	require.True(t, ok)
+	assert.Equal(t, "gcp-secretmanager:datadog-keys", res)
+
+	// Carried unresolved, like every templated coordinate here: this runs before the
+	// exchange that would produce the claims to resolve it from.
+	res, ok = gcpAssertionResource(
+		credential.NewConfig(map[string]string{
+			"auth_method":                gcpAuthMethodOIDCFederation,
+			"workload_identity_provider": testWIFProvider,
+		}),
+		credential.NewConfig(map[string]string{"mint_method": "secret_read", "secret_name": "per-agent-{{agent.sub}}"}),
+	)
+	require.True(t, ok)
+	assert.Equal(t, "gcp-secretmanager:per-agent-{{agent.sub}}", res)
+}
+
+func TestVerifySecretCRC32C(t *testing.T) {
+	payload := []byte("some-secret")
+	sum := strconv.FormatInt(int64(crc32.Checksum(payload, crc32.MakeTable(crc32.Castagnoli))), 10)
+
+	require.NoError(t, verifySecretCRC32C(payload, sum))
+	require.Error(t, verifySecretCRC32C([]byte("tampered"), sum))
+
+	// The checksum is optional, and refusing a secret because the service omitted it
+	// would fail closed on something carrying no evidence of corruption.
+	require.NoError(t, verifySecretCRC32C(payload, ""))
+
+	// One that is present but unreadable is the opposite case: the envelope is
+	// demonstrably not what the service sends, which is what this guards against.
+	require.Error(t, verifySecretCRC32C(payload, "not-a-number"))
+	require.Error(t, verifySecretCRC32C(payload, "-1"))
+	require.Error(t, verifySecretCRC32C(payload, "4294967296"))
+}
+
+func TestGCPDriver_SecretRead_EndpointOverrideDefaults(t *testing.T) {
+	sm := newSecretManagerStub(t, `{"k":"v"}`)
+
+	f := &GCPDriverFactory{}
+	require.NoError(t, f.ValidateConfig(credential.NewConfig(map[string]string{
+		"auth_method":                gcpAuthMethodOIDCFederation,
+		"workload_identity_provider": testWIFProvider,
+		"secretmanager_endpoint":     sm.URL,
+	})))
+
+	// Rotation manages real keys, which no endpoint override redirects.
+	err := f.ValidateRotationConfig(credential.NewConfig(map[string]string{"secretmanager_endpoint": sm.URL}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "secretmanager_endpoint")
+}
+
+// A trailing slash on the override must not produce a doubled separator in the URL.
+func TestGCPDriver_SecretManagerHostTrimsTrailingSlash(t *testing.T) {
+	sm := newSecretManagerStub(t, `{"k":"v"}`)
+	sts := gcpSTSStub(t, "FED-TOKEN")
+
+	d := newSecretReadFederationDriver(t, sts.URL, strings.TrimRight(sm.URL, "/"), "")
+	_, _, _, _, err := d.MintCredentialWithExchange(context.TODO(),
+		secretSpec(map[string]string{"secret_name": "s", "project": "p"}),
+		&credential.ExchangeInputs{SubjectToken: "a"})
+	require.NoError(t, err)
+	assert.Equal(t, "projects/p/secrets/s/versions/latest", sm.lastPath.Load())
+}
+
+// A locator becomes segments of the request path. Unescaped, a name carrying "#"
+// truncates the request — reading a different version than the spec names, while
+// defeating the write-time rule against addressing two — and one carrying "?" moves
+// the version into a query string, turning the read into a different call. The
+// write-time charset checks make these unwritable; escaping means a config that
+// drifted past them still cannot reshape the request.
+func TestResolveSecretVersionPath_EscapesEverySegment(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  map[string]string
+	}{
+		{"fragment truncation", map[string]string{"secret_name": "keys/versions/2:access#", "project": "p"}},
+		{"query injection", map[string]string{"secret_name": "keys?alt=media", "project": "p"}},
+		{"traversal", map[string]string{"secret_name": "../../other", "project": "p"}},
+		{"project fragment", map[string]string{"secret_name": "keys", "project": "p#x"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveSecretVersionPath(secretSpec(tc.cfg), nil, nil)
+			require.NoError(t, err)
+			for _, unsafe := range []string{"#", "?"} {
+				assert.NotContainsf(t, got, unsafe, "%q must not survive into the path: %s", unsafe, got)
+			}
+			assert.True(t, strings.HasSuffix(got, "/versions/latest"),
+				"the version this spec addresses must not be reachable from the name: %s", got)
+		})
+	}
+}
+
+// A qualified name is split on its own separators, so the project it carries is the
+// one used — and a malformed one is refused rather than silently reshaped.
+func TestResolveSecretVersionPath_QualifiedName(t *testing.T) {
+	got, err := resolveSecretVersionPath(
+		secretSpec(map[string]string{"secret_name": "projects/acme/secrets/dd-keys"}), nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "projects/acme/secrets/dd-keys/versions/latest", got)
+
+	for _, bad := range []string{"projects/acme/secrets/", "projects//secrets/x", "projects/acme/dd"} {
+		_, err := resolveSecretVersionPath(secretSpec(map[string]string{"secret_name": bad}), nil, nil)
+		require.Errorf(t, err, "%q must be refused", bad)
+	}
+}

--- a/credential/types/key_value.go
+++ b/credential/types/key_value.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -41,8 +42,20 @@ func (t *KeyValueCredType) ConfigSchema() []*credential.FieldValidator {
 	return []*credential.FieldValidator{
 		credential.StringField("mint_method").
 			OneOf("kv2_read", "transit_signer", "secret_read").
-			Describe("Mint method: kv2_read reads a KV v2 secret and transit_signer mints a scoped signing capability, both on an hvault source; secret_read reads a stored secret on an aws source").
+			Describe("Mint method: kv2_read reads a KV v2 secret and transit_signer mints a scoped signing capability, both on an hvault source; secret_read reads a stored secret on an aws or gcp source").
 			Example("kv2_read"),
+
+		credential.StringField("secret_name").
+			Describe("Secret to read, as a bare id or a 'projects/<project>/secrets/<name>' resource (gcp source, required for secret_read). Supports {{user.<claim>}} and {{agent.<claim>}} templating").
+			Example("prod-datadog-keys"),
+
+		credential.StringField("project").
+			Describe("Project holding the secret (gcp source; required when 'secret_name' is a bare id, rejected when it is a fully qualified resource)").
+			Example("acme-prod"),
+
+		credential.StringField("target_service_account").
+			Describe("Service account to impersonate before reading (gcp source, keyless only); omit to read as the federated principal itself").
+			Example("secrets-reader@acme-prod.iam.gserviceaccount.com"),
 
 		credential.StringField("kv2_mount").
 			Describe("KV v2 mount path (hvault source)").
@@ -82,7 +95,7 @@ func (t *KeyValueCredType) ConfigSchema() []*credential.FieldValidator {
 
 		credential.IntField("secret_version").
 			Min(1).
-			Describe("Pin a numbered revision of the secret; omit to read the current one. A pinned spec does not follow rotation").
+			Describe("Pin a numbered revision of the secret (hvault or gcp source); omit to read the current one. A pinned spec does not follow rotation").
 			Example("3"),
 	}
 }
@@ -103,6 +116,12 @@ var (
 	awsKeyValueLocators = []string{
 		"secret_id", "version_stage", "version_id", "role_arn", "session_name", "policy",
 	}
+	gcpKeyValueLocators = []string{
+		"secret_name", "project", "target_service_account",
+	}
+	// Keys that configure a gcp token mint rather than a stored-secret read. They
+	// belong to the gcp_access_token type, not this one.
+	gcpTokenMintFields = []string{"scopes", "lifetime"}
 )
 
 // ValidateConfig validates the Config for a key/value credential spec. Two source
@@ -110,21 +129,29 @@ var (
 // capability, and an aws source reading a stored secret.
 func (t *KeyValueCredType) ValidateConfig(config credential.Config, sourceType string) error {
 	switch sourceType {
-	case credential.SourceTypeVault, credential.SourceTypeAWS:
+	case credential.SourceTypeVault, credential.SourceTypeAWS, credential.SourceTypeGCP:
 		// Supported
 	default:
-		return fmt.Errorf("key_value credentials require an hvault or aws source, got: %s", sourceType)
+		return fmt.Errorf("key_value credentials require an hvault, aws or gcp source, got: %s", sourceType)
 	}
 
 	if err := credential.ValidateSchema(config, t.ConfigSchema()...); err != nil {
 		return err
 	}
 
+	// Each source names its own branch. The guard above already rejects anything not
+	// listed, so the default is unreachable — but it returns an error rather than
+	// falling through to one of the validators, because a source added to that guard
+	// and forgotten here would otherwise be checked against another store's rules.
 	switch sourceType {
 	case credential.SourceTypeVault:
 		return t.validateVaultConfig(config)
-	default:
+	case credential.SourceTypeAWS:
 		return t.validateAWSConfig(config)
+	case credential.SourceTypeGCP:
+		return t.validateGCPConfig(config)
+	default:
+		return fmt.Errorf("key_value credentials have no validation rules for source type: %s", sourceType)
 	}
 }
 
@@ -157,7 +184,10 @@ func (t *KeyValueCredType) validateVaultConfig(config credential.Config) error {
 		return fmt.Errorf("'mint_method' must be 'kv2_read' or 'transit_signer' for a key_value credential on an hvault source, got: %s", config.Get("mint_method"))
 	}
 
-	return rejectForeignLocators(config, awsKeyValueLocators, config.Get("mint_method"))
+	if err := rejectForeignLocators(config, awsKeyValueLocators, config.Get("mint_method")); err != nil {
+		return err
+	}
+	return rejectForeignLocators(config, gcpKeyValueLocators, config.Get("mint_method"))
 }
 
 // validateAWSConfig checks the single mint method an aws source offers for this
@@ -179,7 +209,108 @@ func (t *KeyValueCredType) validateAWSConfig(config credential.Config) error {
 	if config.Get("credential_type") != "" {
 		return fmt.Errorf("'credential_type' does not apply to mint_method=secret_read: the payload is vended under its own key names")
 	}
+	if err := rejectForeignLocators(config, gcpKeyValueLocators, "secret_read"); err != nil {
+		return err
+	}
 	return validateAWSSecretsManagerSpecConfig(config, "secret_read")
+}
+
+// validateGCPConfig checks the single mint method a gcp source offers for this type:
+// a Secret Manager read whose payload is vended under its own key names.
+func (t *KeyValueCredType) validateGCPConfig(config credential.Config) error {
+	if config.Get("mint_method") != "secret_read" {
+		return fmt.Errorf("'mint_method' must be 'secret_read' for a key_value credential on a gcp source, got: %s", config.Get("mint_method"))
+	}
+	if err := rejectForeignLocators(config, vaultKeyValueLocators, "secret_read"); err != nil {
+		return err
+	}
+	if err := rejectForeignPrefixes(config, vaultKeyValuePrefixes, "secret_read"); err != nil {
+		return err
+	}
+	if err := rejectForeignLocators(config, awsKeyValueLocators, "secret_read"); err != nil {
+		return err
+	}
+	// credential_type selects which shape a stored secret is parsed into. This method
+	// vends the payload under its own key names, so there is nothing to select.
+	if config.Get("credential_type") != "" {
+		return fmt.Errorf("'credential_type' does not apply to mint_method=secret_read: the payload is vended under its own key names")
+	}
+	// These configure a token mint. Reading a stored secret uses a token it obtains
+	// and discards itself, so both would be accepted and never read — a spec that
+	// looks scoped or time-bounded while being neither.
+	if err := rejectForeignLocators(config, gcpTokenMintFields, "secret_read"); err != nil {
+		return err
+	}
+	return validateGCPSecretManagerSpecConfig(config)
+}
+
+// validateGCPSecretManagerSpecConfig checks how a spec addresses its secret. The name
+// may be a bare id or a fully qualified resource; the two spell the project
+// differently, and accepting both spellings at once would leave two answers to the
+// same question with nothing to say which wins.
+func validateGCPSecretManagerSpecConfig(config credential.Config) error {
+	name := config.Get("secret_name")
+	if name == "" {
+		return fmt.Errorf("'secret_name' is required when mint_method is secret_read")
+	}
+
+	qualified := strings.HasPrefix(name, "projects/")
+	project := config.Get("project")
+
+	if qualified && project != "" {
+		return fmt.Errorf("'project' does not apply when 'secret_name' is a fully qualified resource: it already names its project")
+	}
+	if !qualified && project == "" {
+		return fmt.Errorf("'project' is required when 'secret_name' is a bare secret id")
+	}
+
+	// Both spellings end up as segments of the request path, so both are held to the
+	// charsets the service actually accepts. That is not only a typo check: a name
+	// carrying "#" or "?" would otherwise reshape the request — truncating it, or
+	// moving the version into a query string — so a spec could read a resource other
+	// than the one it appears to name, and other than the one recorded in audit.
+	if qualified {
+		m := gcpSecretResourcePattern.FindStringSubmatch(name)
+		if m == nil {
+			return fmt.Errorf("'secret_name' must read 'projects/<project>/secrets/<name>' when fully qualified, with each part a legal identifier, got: %s", name)
+		}
+		return nil
+	}
+
+	if !gcpProjectPattern.MatchString(project) {
+		return fmt.Errorf("'project' is not a legal project id or number: %s", project)
+	}
+	// A bare name may carry a claim template, whose values the driver allow-lists
+	// separately; check only the parts outside the template.
+	if !gcpSecretIDPattern.MatchString(stripClaimTemplates(name)) {
+		return fmt.Errorf("'secret_name' may contain only letters, digits, underscores and hyphens, got: %s", name)
+	}
+	return nil
+}
+
+var (
+	// A fully qualified secret, without the version suffix — the version is a
+	// separate key, so a name carrying one would be addressing two at once. The
+	// segments are held to the same charsets as the bare spelling.
+	gcpSecretResourcePattern = regexp.MustCompile(`^projects/([A-Za-z0-9][A-Za-z0-9-]{0,62})/secrets/([A-Za-z0-9_-]{1,255})$`)
+
+	// A project id (lowercase letters, digits, hyphens) or a bare project number.
+	gcpProjectPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9-]{0,62}$`)
+
+	// Secret Manager restricts a secret id to letters, digits, underscores and
+	// hyphens.
+	gcpSecretIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,255}$`)
+
+	// claimTemplateSpan matches a {{user.x}} / {{agent.x}} placeholder, which is
+	// replaced at mint time by a value the driver's own allow-list constrains.
+	claimTemplateSpan = regexp.MustCompile(`\{\{(user|agent)\.[A-Za-z0-9_.-]+\}\}`)
+)
+
+// stripClaimTemplates removes the placeholders from a locator so the literal parts
+// around them can be checked against the store's charset. A placeholder itself cannot
+// be checked here — it has no value yet — and is constrained where it is resolved.
+func stripClaimTemplates(s string) string {
+	return claimTemplateSpan.ReplaceAllString(s, "x")
 }
 
 // vaultKeyValuePrefixes are whole families of keys one source's mint methods read,

--- a/credential/types/key_value_test.go
+++ b/credential/types/key_value_test.go
@@ -94,7 +94,7 @@ func TestKeyValueCredType_ValidateConfig(t *testing.T) {
 			config:     map[string]string{"mint_method": "kv2_read", "kv2_mount": "secret", "secret_path": "github/ci"},
 			sourceType: credential.SourceTypeAzure,
 			wantErr:    true,
-			errMsg:     "require an hvault or aws source",
+			errMsg:     "require an hvault, aws or gcp source",
 		},
 		{
 			name:       "wrong mint_method",
@@ -327,4 +327,158 @@ func TestKeyValueCredType_NoSecretInConfig(t *testing.T) {
 	// The secret lives only in minted Data, never in persisted config.
 	assert.Nil(t, ct.SensitiveConfigFields())
 	assert.Nil(t, ct.FieldSchemas())
+}
+
+// A gcp source reading Secret Manager is the third shape this type carries. The rows
+// below pin what distinguishes it: how a secret is addressed, and that a spec cannot
+// mix one store's locators into another's.
+func TestKeyValueCredType_ValidateConfig_GCP(t *testing.T) {
+	ct := NewKeyValueCredType()
+
+	validate := func(cfg map[string]string) error {
+		return ct.ValidateConfig(credential.NewConfig(cfg), credential.SourceTypeGCP)
+	}
+
+	t.Run("bare id with its project", func(t *testing.T) {
+		require.NoError(t, validate(map[string]string{
+			"mint_method": "secret_read", "secret_name": "datadog-keys", "project": "acme-prod",
+		}))
+	})
+
+	t.Run("fully qualified resource", func(t *testing.T) {
+		require.NoError(t, validate(map[string]string{
+			"mint_method": "secret_read", "secret_name": "projects/acme-prod/secrets/datadog-keys",
+		}))
+	})
+
+	// The two spellings each name a project, and accepting both at once would leave
+	// two answers to the same question with nothing to say which wins.
+	t.Run("qualified resource rejects a separate project", func(t *testing.T) {
+		err := validate(map[string]string{
+			"mint_method": "secret_read", "secret_name": "projects/acme-prod/secrets/datadog-keys",
+			"project": "other",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already names its project")
+	})
+
+	t.Run("bare id requires a project", func(t *testing.T) {
+		err := validate(map[string]string{"mint_method": "secret_read", "secret_name": "datadog-keys"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "'project' is required")
+	})
+
+	t.Run("secret_name is required", func(t *testing.T) {
+		err := validate(map[string]string{"mint_method": "secret_read", "project": "acme-prod"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "secret_name")
+	})
+
+	// A version is a separate key, so a name carrying one would address two at once.
+	t.Run("a malformed qualified resource is refused", func(t *testing.T) {
+		for _, name := range []string{
+			"projects/acme-prod/secrets/datadog-keys/versions/3",
+			"projects/acme-prod/secrets",
+			"projects//secrets/x",
+		} {
+			err := validate(map[string]string{"mint_method": "secret_read", "secret_name": name})
+			require.Errorf(t, err, "%q must be refused", name)
+		}
+	})
+
+	t.Run("only secret_read is offered", func(t *testing.T) {
+		err := validate(map[string]string{"mint_method": "kv2_read", "secret_name": "x", "project": "p"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must be 'secret_read'")
+	})
+
+	t.Run("credential_type does not apply", func(t *testing.T) {
+		err := validate(map[string]string{
+			"mint_method": "secret_read", "secret_name": "x", "project": "p", "credential_type": "api_key",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "credential_type")
+	})
+
+	// A locator belonging to another store would be accepted and then never read,
+	// leaving a spec that reads as configured for something it is not doing.
+	t.Run("foreign locators are refused", func(t *testing.T) {
+		for _, key := range []string{"secret_id", "role_arn", "version_stage", "kv2_mount", "secret_path", "transit_key"} {
+			err := validate(map[string]string{
+				"mint_method": "secret_read", "secret_name": "x", "project": "p", key: "v",
+			})
+			require.Errorf(t, err, "%s must be refused on a gcp spec", key)
+		}
+	})
+}
+
+// The rejection runs in every direction: a gcp locator on an hvault or aws spec is as
+// inert as an aws locator on a gcp one.
+func TestKeyValueCredType_GCPLocatorsRejectedElsewhere(t *testing.T) {
+	ct := NewKeyValueCredType()
+
+	for _, key := range []string{"secret_name", "project", "target_service_account"} {
+		t.Run("hvault refuses "+key, func(t *testing.T) {
+			err := ct.ValidateConfig(credential.NewConfig(map[string]string{
+				"mint_method": "kv2_read", "kv2_mount": "secret", "secret_path": "a/b", key: "v",
+			}), credential.SourceTypeVault)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), key)
+		})
+
+		t.Run("aws refuses "+key, func(t *testing.T) {
+			err := ct.ValidateConfig(credential.NewConfig(map[string]string{
+				"mint_method": "secret_read", "secret_id": "prod/keys", key: "v",
+			}), credential.SourceTypeAWS)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), key)
+		})
+	}
+}
+
+// A locator becomes a segment of the request path, so its charset is enforced where
+// the spec is written. Without this a name carrying "#" or "?" reshapes the request,
+// letting a spec read a resource other than the one it appears to name.
+func TestKeyValueCredType_GCP_LocatorCharsets(t *testing.T) {
+	ct := NewKeyValueCredType()
+	validate := func(cfg map[string]string) error {
+		return ct.ValidateConfig(credential.NewConfig(cfg), credential.SourceTypeGCP)
+	}
+
+	for _, name := range []string{
+		"keys/versions/2:access#", "keys?alt=media", "../../other", "with space", "keys#frag",
+	} {
+		t.Run("bare name rejects "+name, func(t *testing.T) {
+			err := validate(map[string]string{"mint_method": "secret_read", "secret_name": name, "project": "acme-prod"})
+			require.Errorf(t, err, "%q must be refused", name)
+		})
+	}
+
+	for _, project := range []string{"p#x", "p?x", "p/x", "with space"} {
+		t.Run("project rejects "+project, func(t *testing.T) {
+			err := validate(map[string]string{"mint_method": "secret_read", "secret_name": "keys", "project": project})
+			require.Errorf(t, err, "%q must be refused", project)
+		})
+	}
+
+	// A template's value is constrained where it is resolved, so the literal parts
+	// around it are what get checked here.
+	t.Run("a claim template is allowed in a bare name", func(t *testing.T) {
+		require.NoError(t, validate(map[string]string{
+			"mint_method": "secret_read", "secret_name": "per-agent-{{agent.sub}}", "project": "acme-prod",
+		}))
+	})
+}
+
+// These configure a token mint. A stored-secret read obtains and discards its own
+// token, so both would be accepted and never read.
+func TestKeyValueCredType_GCP_RejectsTokenMintKeys(t *testing.T) {
+	ct := NewKeyValueCredType()
+	for _, key := range []string{"scopes", "lifetime"} {
+		err := ct.ValidateConfig(credential.NewConfig(map[string]string{
+			"mint_method": "secret_read", "secret_name": "keys", "project": "acme-prod", key: "v",
+		}), credential.SourceTypeGCP)
+		require.Errorf(t, err, "%s must be refused on a secret_read spec", key)
+		assert.Contains(t, err.Error(), key)
+	}
 }


### PR DESCRIPTION
Credential chaining lets a consuming spec name another spec whose minted credential is the secret it needs. Until now only an hvault KV read and an aws stored-secret read could sit at that end of a chain. This adds a third: `mint_method=secret_read` on a gcp source.

Second of three. **Stacked on #620** — review that first; this diff is against it.

## How it mints

A referenced spec is minted as the calling principal, which forces the exchange path, so the method is implemented for federation first: the caller's assertion is exchanged at STS and the resulting token performs the read, optionally after impersonating a service account the spec names.

The static path reads as the source itself and refuses `target_service_account` rather than quietly reading under an authority the operator did not name.

## Payload shape

Secret Manager stores arbitrary bytes, so there is no one right answer. A JSON object of scalars is vended under its own key names — the multi-field secret a chained consumer reads by name — with numbers and booleans rendered as strings, the only shape this credential type carries. Anything that is not a JSON object, a plain API key being the common case, is vended whole under `value`.

A document holding a nested object or array is refused outright. Vending it under `value` would be worse than lossy: a consuming spec that names no `secret_field` takes the sole key when there is only one, so the whole document — every secret stored beside the wanted one — would be sent upstream as the credential. Review caught this; the first version had exactly that hole.

## Locators

`secret_name` and `project` become segments of the request path, so both are held to the charsets the service accepts, and every segment is escaped at mint time as the rest of this driver already does. Without that a name carrying `#` truncates the request, reading a version other than the one the spec names while evading the rule against naming two; one carrying `?` turns the read into a different call entirely.

A secret is addressed either by bare id plus project or by a fully qualified resource. Both spell the project, so setting them together is refused rather than silently preferring one. The name may template on the caller's claims, and fails closed on the static path, where nothing was verified into claims to resolve from.

## Integrity and size

The payload's reported checksum is verified, and one that is present but unreadable fails the read rather than skipping the check. The 64KiB limit applies to the decoded secret, not the response body — base64 inside the JSON envelope makes the body half again as large, so bounding the body would have truncated any secret past roughly 48KiB.

## Also

- `secret_read` joins the two selection-key tables. Secret Manager numbers its versions, so `secret_version` is the right spelling for it — no need for AWS's `version_id`/`version_stage`.
- `scopes` and `lifetime` are refused on a `secret_read` spec, where they would configure a token mint that does not happen.
- `secretmanager_endpoint` joins the endpoint overrides and the rotation refusal.
- `secret_name` joins the reserved spec keys — but `project` and `target_service_account` deliberately do not, since both are ordinary words an operator may already carry as credential fields on an unrelated mount. Reserving them would silently stop those fields being carried.
- The `key_value` source switch now names each branch instead of routing its default to the aws validator: with a third source admitted, a fourth added to the guard and forgotten there would have been checked against another store's rules.

## Verification

`go build`, `go vet`, full unit suite, `-race` on the driver and types, and the complete e2e tree against a rebuilt cluster.
