### PR TITLE
feat(policy)!: rename the CEL `token` namespace to `agent`

### DIFF
--- a/audit/format_json.go
+++ b/audit/format_json.go
@@ -226,7 +226,7 @@ func (f *JSONFormat) saltPolicyResultsField(ctx context.Context, pr *PolicyResul
 	case "condition":
 		// "...condition.inputs" salts every referenced-input value;
 		// "...condition.inputs.<dotted-key>" salts one (the input map keys are
-		// themselves dotted, e.g. token.metadata.env, so rejoin the tail).
+		// themselves dotted, e.g. agent.metadata.env, so rejoin the tail).
 		if pr.Condition == nil || len(parts) < 2 || parts[1] != "inputs" {
 			return nil
 		}

--- a/audit/format_json_test.go
+++ b/audit/format_json_test.go
@@ -651,7 +651,7 @@ func TestFormatResponse(t *testing.T) {
 }
 
 // TestFormatConditionInputsSalting exercises salt_fields for the CEL condition
-// inputs map, whose keys are themselves dotted (token.metadata.env).
+// inputs map, whose keys are themselves dotted (agent.metadata.env).
 func TestFormatConditionInputsSalting(t *testing.T) {
 	mockSalt := func(ctx context.Context, data string) (string, error) {
 		return "hmac-sha256:" + data + "-salted", nil
@@ -664,9 +664,10 @@ func TestFormatConditionInputsSalting(t *testing.T) {
 					Allowed: false,
 					Condition: &logical.ConditionResult{
 						Decision:   "deny",
-						Expression: "token.metadata.env == 'prod'",
+						Expression: "agent.metadata.env == 'prod'",
 						Inputs: map[string]string{
-							"token.metadata.env": "staging",
+							"agent.metadata.env": "staging",
+							"agent.token_type":   "jwt_role",
 							"request.data.model": "opus",
 						},
 					},
@@ -695,25 +696,54 @@ func TestFormatConditionInputsSalting(t *testing.T) {
 
 	t.Run("clear by default", func(t *testing.T) {
 		in := format(t, nil)
-		if in["token.metadata.env"] != "staging" || in["request.data.model"] != "opus" {
+		if in["agent.metadata.env"] != "staging" || in["request.data.model"] != "opus" {
 			t.Errorf("inputs should be clear, got %v", in)
 		}
 	})
 
 	t.Run("salt all inputs", func(t *testing.T) {
 		in := format(t, []string{"auth.policy_results.condition.inputs"})
-		if !salted(in["token.metadata.env"]) || !salted(in["request.data.model"]) {
+		if !salted(in["agent.metadata.env"]) || !salted(in["request.data.model"]) {
 			t.Errorf("all inputs should be salted, got %v", in)
 		}
 	})
 
 	t.Run("salt one dotted key", func(t *testing.T) {
 		in := format(t, []string{"auth.policy_results.condition.inputs.request.data.model"})
-		if in["token.metadata.env"] != "staging" {
-			t.Errorf("other input must stay clear, got %q", in["token.metadata.env"])
+		if in["agent.metadata.env"] != "staging" {
+			t.Errorf("other input must stay clear, got %q", in["agent.metadata.env"])
 		}
 		if !salted(in["request.data.model"]) {
 			t.Errorf("request.data.model should be salted, got %q", in["request.data.model"])
+		}
+	})
+
+	// The `token` -> `agent` rename moved every condition-input key, and
+	// salt_fields matches those keys verbatim. A stale selector therefore does
+	// not error or warn — it simply stops matching, and the value it used to
+	// protect starts logging in clear. These two cases pin that fail-open so it
+	// is visible in the suite rather than in an audit log.
+	t.Run("pre-rename selector no longer matches", func(t *testing.T) {
+		in := format(t, []string{"auth.policy_results.condition.inputs.token.metadata.env"})
+		if salted(in["agent.metadata.env"]) {
+			t.Errorf("stale token.* selector must not salt the renamed key, got %q", in["agent.metadata.env"])
+		}
+		if in["agent.metadata.env"] != "staging" {
+			t.Errorf("value should be untouched and in clear, got %q", in["agent.metadata.env"])
+		}
+	})
+
+	// The three token_-prefixed fields are the sharp edge: substituting
+	// `token.` -> `agent.` across an audit config fixes agent.metadata.* but
+	// turns token.type into agent.type, which names nothing.
+	t.Run("token_-prefixed field needs the full new name", func(t *testing.T) {
+		naive := format(t, []string{"auth.policy_results.condition.inputs.agent.type"})
+		if salted(naive["agent.token_type"]) {
+			t.Errorf("agent.type must not match agent.token_type, got %q", naive["agent.token_type"])
+		}
+		correct := format(t, []string{"auth.policy_results.condition.inputs.agent.token_type"})
+		if !salted(correct["agent.token_type"]) {
+			t.Errorf("agent.token_type selector should salt, got %q", correct["agent.token_type"])
 		}
 	})
 }

--- a/core/audit_helpers.go
+++ b/core/audit_helpers.go
@@ -161,7 +161,7 @@ func buildAuditAuth(auth *logical.Auth, te *logical.TokenEntry) *audit.Auth {
 			}
 			// Surface the path-level CEL condition decision (non-MCP paths)
 			// so denials carry their reason. Already Sanitized at evaluation.
-			// The condition's referenced inputs (incl. any token.metadata.*
+			// The condition's referenced inputs (incl. any agent.metadata.*
 			// it read) ride ConditionResult.Inputs.
 			if auth.Condition != nil {
 				auditAuth.PolicyResults.Condition = auth.Condition

--- a/core/policy.go
+++ b/core/policy.go
@@ -498,7 +498,7 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 				"source_ip → cidrContains(\"…\", request.client_ip); "+
 				"time_window → now.getHours(tz)/getMinutes(tz); "+
 				"day_of_week → now.getDayOfWeek(\"UTC\"); "+
-				"token_metadata → token.metadata.<key>", key)
+				"token_metadata → agent.metadata.<key>", key)
 		}
 
 		if pc.ConditionHCL != "" {

--- a/core/policy_cbp_test.go
+++ b/core/policy_cbp_test.go
@@ -36,7 +36,7 @@ func testParsePolicy(t testing.TB, rules string) *Policy {
 // One CBP, two different tokens, opposite outcomes driven purely by token data.
 func TestCBP_ConditionIsIdentityIndependent(t *testing.T) {
 	ctx := testContext()
-	p := testParsePolicy(t, `path "secret/x" { capabilities = ["read"] condition = "token.metadata.env == 'prod'" }`)
+	p := testParsePolicy(t, `path "secret/x" { capabilities = ["read"] condition = "agent.metadata.env == 'prod'" }`)
 	cbp, err := NewCBP(ctx, []*Policy{p})
 	require.NoError(t, err)
 
@@ -64,7 +64,7 @@ func TestCBP_CompiledConditionSharedAcrossCallers(t *testing.T) {
 	ps := core.policyStore
 	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
 
-	p := testParsePolicy(t, `path "secret/x" { capabilities = ["read"] condition = "token.metadata.env == 'prod'" }`)
+	p := testParsePolicy(t, `path "secret/x" { capabilities = ["read"] condition = "agent.metadata.env == 'prod'" }`)
 	p.Name = "cond"
 	p.Type = PolicyTypeCBP
 	require.NoError(t, ps.SetPolicy(ctx, p, nil))

--- a/core/policy_cel.go
+++ b/core/policy_cel.go
@@ -28,11 +28,11 @@ import (
 // evaluator.
 //
 // Design notes:
-//   - Two envs: a base env (request/token/now) for path-level conditions and an
-//     MCP env (base + call) for mcp{} conditions. Two envs make a path-level
+//   - Two envs: a base env (request/agent/now) for path-level conditions and an
+//     MCP env (base + call) for MCP policies conditions. Two envs make a path-level
 //     condition that references call.* a COMPILE error, not a silent runtime
 //     deny.
-//   - request/token/call are map(string, dyn): the env is shared across every
+//   - request/agent/call are map(string, dyn): the env is shared across every
 //     tool/path and cannot know an arbitrary argument's type. Type discipline is
 //     achieved at activation-build time (values typed from their source); a
 //     type-mismatched comparison surfaces as a runtime error → fail-closed deny.
@@ -48,11 +48,16 @@ import (
 //	  request.mount_point, request.mount_type, request.mount_class,
 //	  request.mount_accessor, request.transparent, request.namespace,
 //	  request.data.<k>
-//	token.principal, token.role, token.type, token.namespace,
-//	  token.policies (list), token.metadata.<k>, token.actors (list of
-//	  {subject}), token.ttl_seconds, token.expires_at
+//	agent.principal, agent.role, agent.namespace, agent.policies (list),
+//	  agent.metadata.<k>, agent.actors (list of {subject}),
+//	  agent.token_type, agent.token_ttl_seconds, agent.token_expires_at
 //	now (timestamp)
-//	call.method, call.tool, call.args.<k>, call.batch_index   (mcp{} only)
+//	call.method, call.tool, call.args.<k>, call.batch_index   (MCP policy only)
+//
+// `agent` is the request's authenticating principal. The three token_-prefixed
+// fields describe the credential it authenticated with, not the principal
+// itself — agent.token_type carries values like jwt_role/cert_role, which name
+// how the agent authenticated rather than a kind of agent.
 //
 // Secret material (token value, accessor, client token) is never exposed.
 
@@ -71,7 +76,7 @@ const (
 	maxConditionCost uint64 = 1_000_000
 
 	// celInputSizeBound is the size (map entries / string length) the cost
-	// estimator assumes for the dynamic-map variables (request/token/call) that
+	// estimator assumes for the dynamic-map variables (request/agent/call) that
 	// cel-go cannot size itself. It is a heuristic for the *write-time* check —
 	// large enough to admit reasonable expressions, small enough to reject
 	// pathological ones (e.g. nested comprehensions, ~size² cost). It is
@@ -98,10 +103,10 @@ type celRequestInput struct {
 	Data          map[string]any
 }
 
-// celTokenInput is the non-secret token context mapped into the `token`
+// celPrincipalInput is the non-secret principal context mapped into the `agent`
 // namespace. Decoupled from *logical.TokenEntry so the activation builder stays
 // unit-testable; the wiring layer adapts the token entry into this.
-type celTokenInput struct {
+type celPrincipalInput struct {
 	Principal     string
 	Role          string
 	Type          string
@@ -120,7 +125,7 @@ func buildCELEnv(mcp bool) (*cel.Env, error) {
 	opts := []cel.EnvOption{
 		// request-wide namespaces; dyn maps (see design note).
 		cel.Variable("request", cel.MapType(cel.StringType, cel.DynType)),
-		cel.Variable("token", cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable("agent", cel.MapType(cel.StringType, cel.DynType)),
 		cel.Variable("now", cel.TimestampType),
 
 		// Optional types for concise optional-arg access: call.args.?x.orValue(d).
@@ -170,6 +175,9 @@ func celCIDRContainsFunc() cel.EnvOption {
 
 // celCostEstimator supplies input size bounds for our dynamic-map variables so
 // env.EstimateCost can bound an expression's worst-case cost at compile time.
+// Every dynamic-map root must appear in EstimateSize below: a root omitted here
+// falls through to cel-go's own default sizing, silently under-counting the
+// write-time bound for every expression that reads it.
 // cel-go owns the per-operation base costs; this only feeds the sizes cel-go
 // cannot infer.
 type celCostEstimator struct {
@@ -179,7 +187,7 @@ type celCostEstimator struct {
 func (e celCostEstimator) EstimateSize(node checker.AstNode) *checker.SizeEstimate {
 	if path := node.Path(); len(path) > 0 {
 		switch path[0] {
-		case "request", "token", "call":
+		case "request", "agent", "call":
 			return &checker.SizeEstimate{Min: 0, Max: e.maxSize}
 		}
 	}
@@ -206,7 +214,7 @@ func compileCELCondition(env *cel.Env, src string) (*compiledCondition, error) {
 func compileCELConditionWithLimits(env *cel.Env, src string, maxCost, sizeBound uint64) (*compiledCondition, error) {
 	ast, iss := env.Compile(src)
 	if iss != nil && iss.Err() != nil {
-		return nil, fmt.Errorf("condition does not compile: %w", iss.Err())
+		return nil, fmt.Errorf("condition does not compile: %w", celRenameHint(iss.Err()))
 	}
 	if !ast.OutputType().IsExactType(cel.BoolType) {
 		return nil, fmt.Errorf("condition must evaluate to bool, got %s", ast.OutputType())
@@ -237,16 +245,36 @@ func compileCELConditionWithLimits(env *cel.Env, src string, maxCost, sizeBound 
 	if err != nil {
 		return nil, fmt.Errorf("condition program construction failed: %w", err)
 	}
-	paths, segs, reqF, tokF, callF := celAnalyzeRefs(ast)
+	paths, segs, reqF, agtF, callF := celAnalyzeRefs(ast)
 	return &compiledCondition{
 		Source:     src,
 		Program:    prg,
 		RefPaths:   paths,
 		RefSegs:    segs,
 		ReqFields:  reqF,
-		TokFields:  tokF,
+		AgtFields:  agtF,
 		CallFields: callF,
 	}, nil
+}
+
+// celRenameHint appends migration guidance when a compile failure is an
+// undeclared reference to `token` — the namespace `agent` replaced. Both the
+// policy-write path and the policy-load path surface compile errors, so an
+// operator upgrading with stored `token.*` conditions meets this error at the
+// moment they most need to be told what changed, rather than a bare
+// "undeclared reference".
+func celRenameHint(err error) error {
+	if err == nil {
+		return nil
+	}
+	s := err.Error()
+	if !strings.Contains(s, "undeclared reference to 'token'") {
+		return err
+	}
+	return fmt.Errorf("%w (the `token` namespace was renamed to `agent`: "+
+		"token.principal/role/namespace/policies/metadata/actors are now agent.*, "+
+		"and token.type/ttl_seconds/expires_at are now "+
+		"agent.token_type/token_ttl_seconds/token_expires_at)", err)
 }
 
 // celCostIsSizeDependent reports whether an expression's worst-case cost grows
@@ -303,7 +331,7 @@ func unionFieldSets(a, b fieldSet) fieldSet {
 }
 
 // celAnalyzeRefs walks the checked AST once and returns both (a) the dotted
-// audit paths an expression reads — e.g. token.metadata.env — and (b) the
+// audit paths an expression reads — e.g. agent.metadata.env — and (b) the
 // top-level field-sets per root used to prune the activation.
 //
 // Audit paths capture only clean, Ident-rooted field-selection chains; has()
@@ -317,8 +345,8 @@ func unionFieldSets(a, b fieldSet) fieldSet {
 // A bare root Ident that is not a Select operand sets all=true for that root, so
 // pruning never drops a field the expression needs (an under-built field would
 // be a missing key → fail-closed deny).
-func celAnalyzeRefs(a *cel.Ast) (paths []string, segs [][]string, req, tok, call fieldSet) {
-	req, tok, call = fieldSet{fields: map[string]bool{}}, fieldSet{fields: map[string]bool{}}, fieldSet{fields: map[string]bool{}}
+func celAnalyzeRefs(a *cel.Ast) (paths []string, segs [][]string, req, agt, call fieldSet) {
+	req, agt, call = fieldSet{fields: map[string]bool{}}, fieldSet{fields: map[string]bool{}}, fieldSet{fields: map[string]bool{}}
 	native := a.NativeRep()
 	if native == nil || native.Expr() == nil {
 		return
@@ -328,7 +356,7 @@ func celAnalyzeRefs(a *cel.Ast) (paths []string, segs [][]string, req, tok, call
 	consumed := map[int64]bool{}     // operand of some Select — an intermediate node
 	skip := map[int64]bool{}         // container of an index/optional access — not a field path
 	identCovered := map[int64]bool{} // root-Ident IDs that are a Select operand
-	var rootIdents []celast.Expr     // Idents named request/token/call
+	var rootIdents []celast.Expr     // Idents named request/agent/call
 	celast.PostOrderVisit(native.Expr(), celast.NewExprVisitor(func(e celast.Expr) {
 		switch e.Kind() {
 		case celast.SelectKind:
@@ -341,8 +369,8 @@ func celAnalyzeRefs(a *cel.Ast) (paths []string, segs [][]string, req, tok, call
 				case "request":
 					req.fields[s.FieldName()] = true
 					identCovered[op.ID()] = true
-				case "token":
-					tok.fields[s.FieldName()] = true
+				case "agent":
+					agt.fields[s.FieldName()] = true
 					identCovered[op.ID()] = true
 				case "call":
 					call.fields[s.FieldName()] = true
@@ -351,7 +379,7 @@ func celAnalyzeRefs(a *cel.Ast) (paths []string, segs [][]string, req, tok, call
 			}
 		case celast.IdentKind:
 			switch e.AsIdent() {
-			case "request", "token", "call":
+			case "request", "agent", "call":
 				rootIdents = append(rootIdents, e)
 			}
 		case celast.CallKind:
@@ -395,8 +423,8 @@ func celAnalyzeRefs(a *cel.Ast) (paths []string, segs [][]string, req, tok, call
 		switch id.AsIdent() {
 		case "request":
 			req.all = true
-		case "token":
-			tok.all = true
+		case "agent":
+			agt.all = true
 		case "call":
 			call.all = true
 		}
@@ -405,8 +433,13 @@ func celAnalyzeRefs(a *cel.Ast) (paths []string, segs [][]string, req, tok, call
 }
 
 // celSelectPath reconstructs the dotted path for a Select chain top (e.g.
-// token.metadata.env). Returns ok=false if the chain contains a test-only
-// select (has()) or does not bottom out on a request/token/call Ident.
+// agent.metadata.env). Returns ok=false if the chain contains a test-only
+// select (has()) or does not bottom out on a request/agent/call Ident.
+//
+// The returned path is the operator's own spelling and is what lands in
+// ConditionResult.Inputs — and therefore what an audit device's salt_fields
+// entry must match verbatim. Renaming a namespace or field here renames the
+// audit key with it.
 func celSelectPath(e celast.Expr) (string, bool) {
 	var fields []string
 	cur := e
@@ -422,7 +455,7 @@ func celSelectPath(e celast.Expr) (string, bool) {
 		return "", false
 	}
 	switch cur.AsIdent() {
-	case "request", "token", "call":
+	case "request", "agent", "call":
 	default:
 		return "", false
 	}
@@ -492,42 +525,51 @@ func buildRequestNS(req celRequestInput, f fieldSet) map[string]any {
 	return m
 }
 
-// emptyStringMap is a shared, never-mutated empty map bound to token.metadata
-// when a token carries none — non-nil (so absent-key access fails closed)
+// emptyStringMap is a shared, never-mutated empty map bound to agent.metadata
+// when a principal carries none — non-nil (so absent-key access fails closed)
 // without a per-request allocation.
 var emptyStringMap = map[string]string{}
 
-// buildTokenNS builds the `token` namespace, including only the fields f marks
-// as referenced (all fields when f.all). The expensive fields (metadata copy,
-// actors/policies slices) are built only when referenced. metadata is non-nil.
-func buildTokenNS(tok celTokenInput, f fieldSet) map[string]any {
+// buildPrincipalNS builds a principal namespace, including only the fields f
+// marks as referenced (all fields when f.all). The expensive fields (metadata
+// copy, actors/policies slices) are built only when referenced. metadata is
+// non-nil.
+//
+// The token_-prefixed keys describe the credential rather than the principal:
+// token_type carries values like jwt_role/cert_role, which name how the
+// principal authenticated, not a kind of principal.
+func buildPrincipalNS(p celPrincipalInput, f fieldSet) map[string]any {
 	m := make(map[string]any, len(f.fields))
 	if f.has("principal") {
-		m["principal"] = tok.Principal
+		m["principal"] = p.Principal
 	}
 	if f.has("role") {
-		m["role"] = tok.Role
+		m["role"] = p.Role
 	}
-	if f.has("type") {
-		m["type"] = tok.Type
+	if f.has("token_type") {
+		m["token_type"] = p.Type
 	}
 	if f.has("namespace") {
-		m["namespace"] = tok.NamespacePath
+		m["namespace"] = p.NamespacePath
 	}
 	if f.has("metadata") {
 		// Bind the string map by reference — CEL adapts it via reflection — rather
 		// than copying into a map[string]any. emptyStringMap keeps it non-nil (so
-		// has(token.metadata.x) is false and absent-key access fails closed)
+		// has(agent.metadata.x) is false and absent-key access fails closed)
 		// without allocating.
-		if tok.Metadata != nil {
-			m["metadata"] = tok.Metadata
+		//
+		// Safe only because a TokenEntry's Metadata is never mutated post-mint:
+		// the entry is a shared cached pointer, so a post-mint write would be a
+		// data race against concurrent evaluations.
+		if p.Metadata != nil {
+			m["metadata"] = p.Metadata
 		} else {
 			m["metadata"] = emptyStringMap
 		}
 	}
 	if f.has("actors") {
-		acts := make([]any, 0, len(tok.Actors))
-		for _, a := range tok.Actors {
+		acts := make([]any, 0, len(p.Actors))
+		for _, a := range p.Actors {
 			acts = append(acts, map[string]any{
 				"subject": a.Subject,
 			})
@@ -535,17 +577,17 @@ func buildTokenNS(tok celTokenInput, f fieldSet) map[string]any {
 		m["actors"] = acts
 	}
 	if f.has("policies") {
-		policies := make([]any, 0, len(tok.Policies))
-		for _, p := range tok.Policies {
-			policies = append(policies, p)
+		policies := make([]any, 0, len(p.Policies))
+		for _, pol := range p.Policies {
+			policies = append(policies, pol)
 		}
 		m["policies"] = policies
 	}
-	if f.has("ttl_seconds") {
-		m["ttl_seconds"] = tok.TTLSeconds
+	if f.has("token_ttl_seconds") {
+		m["token_ttl_seconds"] = p.TTLSeconds
 	}
-	if f.has("expires_at") {
-		m["expires_at"] = tok.ExpiresAtUnix
+	if f.has("token_expires_at") {
+		m["token_expires_at"] = p.ExpiresAtUnix
 	}
 	return m
 }
@@ -553,34 +595,34 @@ func buildTokenNS(tok celTokenInput, f fieldSet) map[string]any {
 // buildBaseActivation eagerly builds the full activation map. Retained for unit
 // tests; the request path uses celActivation (lazy) to avoid building
 // namespaces an expression never references.
-func buildBaseActivation(req celRequestInput, tok celTokenInput, now time.Time) map[string]any {
+func buildBaseActivation(req celRequestInput, agt celPrincipalInput, now time.Time) map[string]any {
 	return map[string]any{
 		"request": buildRequestNS(req, fieldSet{all: true}),
-		"token":   buildTokenNS(tok, fieldSet{all: true}),
+		"agent":   buildPrincipalNS(agt, fieldSet{all: true}),
 		"now":     now,
 	}
 }
 
 // celActivation is a lazy interpreter.Activation: it builds each top-level
-// namespace (request/token/call) only when the expression resolves it, so an
+// namespace (request/agent/call) only when the expression resolves it, so an
 // expression touching only one namespace doesn't allocate the others. One
 // activation is built per evaluation (never shared), so the memoization is not
 // a concurrency concern.
 type celActivation struct {
 	req        celRequestInput
 	reqFields  fieldSet
-	tok        celTokenInput
-	tokFields  fieldSet
+	agt        celPrincipalInput
+	agtFields  fieldSet
 	callFields fieldSet // used when building the per-call namespace (MCP)
 	now        time.Time
 	call       map[string]any // nil for path-level conditions
 
 	reqNS map[string]any
-	tokNS map[string]any
+	agtNS map[string]any
 }
 
-func newCELActivation(req celRequestInput, reqFields fieldSet, tok celTokenInput, tokFields fieldSet, now time.Time, call map[string]any) *celActivation {
-	return &celActivation{req: req, reqFields: reqFields, tok: tok, tokFields: tokFields, now: now, call: call}
+func newCELActivation(req celRequestInput, reqFields fieldSet, agt celPrincipalInput, agtFields fieldSet, now time.Time, call map[string]any) *celActivation {
+	return &celActivation{req: req, reqFields: reqFields, agt: agt, agtFields: agtFields, now: now, call: call}
 }
 
 func (a *celActivation) Parent() interpreter.Activation { return nil }
@@ -592,11 +634,11 @@ func (a *celActivation) ResolveName(name string) (any, bool) {
 			a.reqNS = buildRequestNS(a.req, a.reqFields)
 		}
 		return a.reqNS, true
-	case "token":
-		if a.tokNS == nil {
-			a.tokNS = buildTokenNS(a.tok, a.tokFields)
+	case "agent":
+		if a.agtNS == nil {
+			a.agtNS = buildPrincipalNS(a.agt, a.agtFields)
 		}
-		return a.tokNS, true
+		return a.agtNS, true
 	case "now":
 		return a.now, true
 	case "call":
@@ -610,7 +652,7 @@ func (a *celActivation) ResolveName(name string) (any, bool) {
 }
 
 // addCallToActivation layers the per-call `call` namespace onto a base
-// activation for an mcp{} condition. args are typed from ParamValue.Kind;
+// activation for an MCP Policy condition. args are typed from ParamValue.Kind;
 // non-scalar / null / missing values are omitted so absent-key access fails
 // closed. Mutates and returns base.
 func addCallToActivation(base map[string]any, method, tool string, matchArgs map[string]logical.ParamValue, batchIndex int) map[string]any {
@@ -672,20 +714,20 @@ func paramValueToCEL(pv logical.ParamValue) (any, bool) {
 type compiledCondition struct {
 	Source  string
 	Program cel.Program
-	// RefPaths are the dotted request/token/call variable paths the expression
+	// RefPaths are the dotted request/agent/call variable paths the expression
 	// reads, snapshotted into the audited ConditionResult.Inputs at eval time.
 	// RefSegs is the pre-split form (compile-time) so eval avoids strings.Split.
 	RefPaths []string
 	RefSegs  [][]string
-	// ReqFields/TokFields/CallFields are the top-level namespace fields the
+	// ReqFields/AgtFields/CallFields are the top-level namespace fields the
 	// expression reads, used to build only the referenced parts of the activation.
 	ReqFields  fieldSet
-	TokFields  fieldSet
+	AgtFields  fieldSet
 	CallFields fieldSet
 }
 
 // Package-level envs, built once and reused. The base env compiles path-level
-// conditions; the MCP env (base + call.*) compiles mcp{} conditions.
+// conditions; the MCP env (base + call.*) compiles MCP policy conditions.
 var (
 	baseEnvOnce sync.Once
 	baseEnv     *cel.Env
@@ -709,7 +751,7 @@ func mcpCELEnv() (*cel.Env, error) {
 // celRequestInputFromRequest adapts a *logical.Request into the request context
 // exposed to expressions. All fields are populated before policy evaluation.
 // nsPath is the request's target namespace (namespace.FromContext at eval),
-// exposed as request.namespace — distinct from token.namespace (where the token
+// exposed as request.namespace — distinct from agent.namespace (where the token
 // was minted). It is not derivable from mount_point, which concatenates the
 // namespace prefix with the mount path.
 func celRequestInputFromRequest(req *logical.Request, nsPath string) celRequestInput {
@@ -730,19 +772,19 @@ func celRequestInputFromRequest(req *logical.Request, nsPath string) celRequestI
 	}
 }
 
-// celTokenInputFromEntry adapts a *logical.TokenEntry into the non-secret token
-// context exposed to expressions. now is the once-per-request snapshot used to
-// derive the remaining TTL.
-func celTokenInputFromEntry(te *logical.TokenEntry, now time.Time) celTokenInput {
+// celPrincipalInputFromEntry adapts a *logical.TokenEntry into the non-secret
+// principal context exposed to expressions. now is the once-per-request
+// snapshot used to derive the remaining TTL.
+func celPrincipalInputFromEntry(te *logical.TokenEntry, now time.Time) celPrincipalInput {
 	if te == nil {
-		return celTokenInput{}
+		return celPrincipalInput{}
 	}
 	var ttl, expires int64
 	if !te.ExpireAt.IsZero() {
 		ttl = int64(te.ExpireAt.Sub(now).Seconds())
 		expires = te.ExpireAt.Unix()
 	}
-	return celTokenInput{
+	return celPrincipalInput{
 		Principal:     te.PrincipalID,
 		Role:          te.RoleName,
 		Type:          te.Type,
@@ -781,12 +823,12 @@ func evaluatePathConditions(conds []*compiledCondition, req *logical.Request, te
 	}
 	// Build the activation pruned to the union of fields the conditions read.
 	// The common single-condition case reuses its field-sets with no allocation.
-	reqF, tokF := conds[0].ReqFields, conds[0].TokFields
+	reqF, agtF := conds[0].ReqFields, conds[0].AgtFields
 	for _, c := range conds[1:] {
 		reqF = unionFieldSets(reqF, c.ReqFields)
-		tokF = unionFieldSets(tokF, c.TokFields)
+		agtF = unionFieldSets(agtF, c.AgtFields)
 	}
-	act := newCELActivation(celRequestInputFromRequest(req, nsPath), reqF, celTokenInputFromEntry(te, now), tokF, now, nil)
+	act := newCELActivation(celRequestInputFromRequest(req, nsPath), reqF, celPrincipalInputFromEntry(te, now), agtF, now, nil)
 
 	var deciding *logical.ConditionResult
 	for _, c := range conds {
@@ -830,7 +872,7 @@ func resolveConditionInputs(refPaths []string, refSegs [][]string, act *celActiv
 			case map[string]any:
 				cur, ok = mm[s]
 			case map[string]string:
-				// token.metadata is bound as a string map (see buildTokenNS).
+				// agent.metadata is bound as a string map (see buildPrincipalNS).
 				cur, ok = mm[s]
 			default:
 				cur, ok = nil, false
@@ -851,8 +893,8 @@ func resolveConditionInputs(refPaths []string, refSegs [][]string, act *celActiv
 }
 
 // formatCELValue renders a resolved activation value as an audit string.
-// Scalars format precisely; non-scalars (lists/maps such as token.policies /
-// token.actors) fall back to %v.
+// Scalars format precisely; non-scalars (lists/maps such as agent.policies /
+// agent.actors) fall back to %v.
 func formatCELValue(v any) string {
 	switch t := v.(type) {
 	case string:

--- a/core/policy_cel_mcp_test.go
+++ b/core/policy_cel_mcp_test.go
@@ -135,7 +135,7 @@ path "mcp/gateway/*" {
 path "mcp/gateway/*" {
   methods { allowed = ["tools/call"] }
   tools { allowed = ["create_payment"] }
-  condition = "token.metadata.env == 'prod'"
+  condition = "agent.metadata.env == 'prod'"
 }
 `)
 	body := `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"create_payment","arguments":{"amount":1}},"id":1}`

--- a/core/policy_cel_path_test.go
+++ b/core/policy_cel_path_test.go
@@ -4,6 +4,7 @@
 package core
 
 import (
+	"strconv"
 	"testing"
 	"time"
 
@@ -16,7 +17,7 @@ import (
 
 // TestCBP_PathCondition_EndToEnd parses a policy with a path-level CEL
 // condition, compiles it into a CBP, and exercises allow/deny through
-// AllowOperation. The condition reads request.data (body) and token.metadata
+// AllowOperation. The condition reads request.data (body) and agent.metadata
 // (from the TokenEntry threaded into AllowOperation).
 func TestCBP_PathCondition_EndToEnd(t *testing.T) {
 	ctx := testContext()
@@ -24,7 +25,7 @@ func TestCBP_PathCondition_EndToEnd(t *testing.T) {
 	policy := testParsePolicy(t, `
 		path "db/issue-grant" {
 			capabilities = ["create"]
-			condition = "request.data.ttl_seconds <= 3600 && token.metadata.env == 'prod'"
+			condition = "request.data.ttl_seconds <= 3600 && agent.metadata.env == 'prod'"
 		}
 	`)
 	cbp, err := NewCBP(ctx, []*Policy{policy})
@@ -60,7 +61,7 @@ func TestCBP_PathCondition_EndToEnd(t *testing.T) {
 }
 
 // TestCBP_PathCondition_RecordsInputs confirms a deciding path-level condition
-// snapshots its referenced request/token values into ConditionResult.Inputs
+// snapshots its referenced request/agent values into ConditionResult.Inputs
 // (in clear — salting is an audit-layer opt-in).
 func TestCBP_PathCondition_RecordsInputs(t *testing.T) {
 	ctx := testContext()
@@ -68,7 +69,7 @@ func TestCBP_PathCondition_RecordsInputs(t *testing.T) {
 	policy := testParsePolicy(t, `
 		path "db/issue-grant" {
 			capabilities = ["create"]
-			condition = "request.data.model == 'sonnet' && token.metadata.env == 'prod'"
+			condition = "request.data.model == 'sonnet' && agent.metadata.env == 'prod'"
 		}
 	`)
 	cbp, err := NewCBP(ctx, []*Policy{policy})
@@ -85,7 +86,7 @@ func TestCBP_PathCondition_RecordsInputs(t *testing.T) {
 	require.NotNil(t, res.Condition)
 	require.NotNil(t, res.Condition.Inputs)
 	assert.Equal(t, "opus", res.Condition.Inputs["request.data.model"])
-	assert.Equal(t, "prod", res.Condition.Inputs["token.metadata.env"])
+	assert.Equal(t, "prod", res.Condition.Inputs["agent.metadata.env"])
 }
 
 // TestCBP_PathCondition_MissingDataFailsClosed confirms a condition over an
@@ -183,8 +184,8 @@ func TestCBP_PathCondition_CapCheckOnlySkips(t *testing.T) {
 // the same path OR across policies (more policies admit more requests).
 func TestCBP_PathCondition_MultiPolicyOR(t *testing.T) {
 	ctx := testContext()
-	a := testParsePolicy(t, `path "x" { capabilities = ["read"] condition = "token.metadata.team == 'red'" }`)
-	b := testParsePolicy(t, `path "x" { capabilities = ["read"] condition = "token.metadata.team == 'blue'" }`)
+	a := testParsePolicy(t, `path "x" { capabilities = ["read"] condition = "agent.metadata.team == 'red'" }`)
+	b := testParsePolicy(t, `path "x" { capabilities = ["read"] condition = "agent.metadata.team == 'blue'" }`)
 	cbp, err := NewCBP(ctx, []*Policy{a, b})
 	require.NoError(t, err)
 
@@ -198,13 +199,13 @@ func TestCBP_PathCondition_MultiPolicyOR(t *testing.T) {
 
 // TestCBP_PathCondition_MergeUnionBuildsAllFields guards the activation-pruning
 // union: two merged conditions read *different* namespace fields, so the shared
-// activation must build the union (request.data AND token.metadata). If it
+// activation must build the union (request.data AND agent.metadata). If it
 // pruned to only the first condition's fields, the second would hit a missing
 // key and fail closed — so "gold" (satisfying only policy B) proves both were
 // built.
 func TestCBP_PathCondition_MergeUnionBuildsAllFields(t *testing.T) {
 	ctx := testContext()
-	a := testParsePolicy(t, `path "kv/x" { capabilities = ["read"] condition = "token.metadata.env == 'prod'" }`)
+	a := testParsePolicy(t, `path "kv/x" { capabilities = ["read"] condition = "agent.metadata.env == 'prod'" }`)
 	b := testParsePolicy(t, `path "kv/x" { capabilities = ["read"] condition = "request.data.tier == 'gold'" }`)
 	cbp, err := NewCBP(ctx, []*Policy{a, b})
 	require.NoError(t, err)
@@ -225,7 +226,7 @@ func TestCBP_PathCondition_MergeUnionBuildsAllFields(t *testing.T) {
 // admits everything), overriding another policy's condition.
 func TestCBP_PathCondition_UnconditionalGrantWins(t *testing.T) {
 	ctx := testContext()
-	a := testParsePolicy(t, `path "x" { capabilities = ["read"] condition = "token.metadata.team == 'red'" }`)
+	a := testParsePolicy(t, `path "x" { capabilities = ["read"] condition = "agent.metadata.team == 'red'" }`)
 	b := testParsePolicy(t, `path "x" { capabilities = ["read"] }`) // unconditional
 	cbp, err := NewCBP(ctx, []*Policy{a, b})
 	require.NoError(t, err)
@@ -268,17 +269,17 @@ func TestCBP_ConditionsBlockRemoved(t *testing.T) {
 	`)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "conditions {} block has been removed")
-	assert.Contains(t, err.Error(), "token.metadata")
+	assert.Contains(t, err.Error(), "agent.metadata")
 }
 
 // TestCBP_RequestNamespace confirms request.namespace (the request's target
-// namespace) is exposed and can be compared against token.namespace (where the
+// namespace) is exposed and can be compared against agent.namespace (where the
 // token was minted) — e.g. to deny a parent-namespace token acting in a child
 // namespace. Both values are captured in the audited Inputs.
 func TestCBP_RequestNamespace(t *testing.T) {
 	env, err := baseCELEnv()
 	require.NoError(t, err)
-	src := "token.namespace == request.namespace"
+	src := "agent.namespace == request.namespace"
 	cond, err := compileCELCondition(env, src)
 	require.NoError(t, err)
 
@@ -292,7 +293,7 @@ func TestCBP_RequestNamespace(t *testing.T) {
 	require.NotNil(t, res)
 	assert.Equal(t, "allow", res.Decision)
 	assert.Equal(t, "team-a/", res.Inputs["request.namespace"])
-	assert.Equal(t, "team-a/", res.Inputs["token.namespace"])
+	assert.Equal(t, "team-a/", res.Inputs["agent.namespace"])
 
 	// Same token acting in child namespace team-a/team-b/ -> deny.
 	ok, res = evaluatePathConditions([]*compiledCondition{cond}, req, te, now, "team-a/team-b/")
@@ -343,7 +344,7 @@ func BenchmarkAllowOperation_WithCondition(b *testing.B) {
 	policy, _ := ParseCBPPolicy(namespace.RootNamespace, `
 		path "db/issue-grant" {
 			capabilities = ["create"]
-			condition = "request.data.ttl_seconds <= 3600 && token.metadata.env == 'prod'"
+			condition = "request.data.ttl_seconds <= 3600 && agent.metadata.env == 'prod'"
 		}
 	`)
 	cbp, _ := NewCBP(ctx, []*Policy{policy})
@@ -356,5 +357,49 @@ func BenchmarkAllowOperation_WithCondition(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_ = cbp.AllowOperation(ctx, req, te, false)
+	}
+}
+
+// TestCBP_PathCondition_RenamedFields drives the three token_-prefixed fields
+// through the real pruned path: compile -> celAnalyzeRefs -> AgtFields ->
+// lazy activation -> eval.
+//
+// This is the regression guard for the rename's sharpest edge. celAnalyzeRefs
+// records the CEL field name ("token_type") and buildPrincipalNS gates on
+// f.has("token_type"); if those two strings ever disagree, the field is pruned
+// away, the expression hits a missing key, and every request denies. Because
+// `agent` is a dyn map that is not a compile error — so only an end-to-end
+// evaluation catches it. A unit test over buildPrincipalNS with all:true cannot:
+// has() short-circuits on all and returns true for any string.
+func TestCBP_PathCondition_RenamedFields(t *testing.T) {
+	ctx := testContext()
+
+	policy := testParsePolicy(t, `
+		path "db/issue-grant" {
+			capabilities = ["create"]
+			condition = "agent.token_type == 'cert_role' && agent.token_ttl_seconds <= 3600 && agent.token_expires_at > 0"
+		}
+	`)
+	cbp, err := NewCBP(ctx, []*Policy{policy})
+	require.NoError(t, err)
+
+	expireAt := time.Now().Add(30 * time.Minute)
+	te := &logical.TokenEntry{Type: "cert_role", ExpireAt: expireAt}
+	res := cbp.AllowOperation(ctx, &logical.Request{
+		Operation: logical.CreateOperation,
+		Path:      "db/issue-grant",
+	}, te, false)
+
+	assert.True(t, res.Allowed, "renamed fields must resolve through the pruned activation")
+	require.NotNil(t, res.Condition)
+	require.NotNil(t, res.Condition.Inputs)
+	// The audit keys carry the new spelling — this is what a salt_fields entry
+	// has to match.
+	assert.Equal(t, "cert_role", res.Condition.Inputs["agent.token_type"])
+	assert.Contains(t, res.Condition.Inputs, "agent.token_ttl_seconds")
+	assert.Equal(t, strconv.FormatInt(expireAt.Unix(), 10), res.Condition.Inputs["agent.token_expires_at"])
+	// The pre-rename spellings must not appear as audit keys.
+	for _, k := range []string{"agent.type", "agent.ttl_seconds", "agent.expires_at"} {
+		assert.NotContains(t, res.Condition.Inputs, k)
 	}
 }

--- a/core/policy_cel_test.go
+++ b/core/policy_cel_test.go
@@ -56,14 +56,14 @@ func mustCompile(t *testing.T, env *cel.Env, src string) cel.Program {
 	return c.Program
 }
 
-// baseAct is a minimal request/token activation for path-level tests.
-func baseAct(req celRequestInput, tok celTokenInput, now time.Time) map[string]any {
-	return buildBaseActivation(req, tok, now)
+// baseAct is a minimal request/agent activation for path-level tests.
+func baseAct(req celRequestInput, agt celPrincipalInput, now time.Time) map[string]any {
+	return buildBaseActivation(req, agt, now)
 }
 
 // mcpAct is a base activation plus a single call namespace.
 func mcpAct(now time.Time, tool string, args map[string]logical.ParamValue) map[string]any {
-	base := buildBaseActivation(celRequestInput{Path: "mcp/x", Operation: "update"}, celTokenInput{}, now)
+	base := buildBaseActivation(celRequestInput{Path: "mcp/x", Operation: "update"}, celPrincipalInput{}, now)
 	return addCallToActivation(base, "tools/call", tool, args, 0)
 }
 
@@ -128,7 +128,7 @@ func TestCEL_RuntimeCostLimitDenies(t *testing.T) {
 		t.Fatalf("expected the expression to compile under the injected bound: %v", err)
 	}
 	now := time.Unix(0, 0).UTC()
-	act := buildBaseActivation(celRequestInput{Data: bigStringKeyMap(500)}, celTokenInput{}, now)
+	act := buildBaseActivation(celRequestInput{Data: bigStringKeyMap(500)}, celPrincipalInput{}, now)
 	ok, err := evalCELCondition(c.Program, act)
 	if ok {
 		t.Fatal("cost-exceeded eval must not allow")
@@ -175,7 +175,7 @@ func TestCEL_ErrorKind(t *testing.T) {
 		t.Fatalf("seam compile: %v", err)
 	}
 	_, err = evalCELCondition(c.Program,
-		buildBaseActivation(celRequestInput{Data: bigStringKeyMap(500)}, celTokenInput{}, now))
+		buildBaseActivation(celRequestInput{Data: bigStringKeyMap(500)}, celPrincipalInput{}, now))
 	mustErrKind("cost limit", err, "cost_exceeded")
 
 	// eval_error — any error outside the known categories maps to the catch-all.
@@ -191,9 +191,9 @@ func TestCEL_ErrorKind(t *testing.T) {
 func TestCEL_ActorVerifiedKeyDenies(t *testing.T) {
 	base := mustEnv(t, false)
 	now := time.Unix(0, 0).UTC()
-	act := baseAct(celRequestInput{}, celTokenInput{Actors: []logical.ActorRef{{Subject: "agent"}}}, now)
+	act := baseAct(celRequestInput{}, celPrincipalInput{Actors: []logical.ActorRef{{Subject: "agent"}}}, now)
 
-	_, err := evalCELCondition(mustCompile(t, base, "token.actors.all(a, a.verified)"), act)
+	_, err := evalCELCondition(mustCompile(t, base, "agent.actors.all(a, a.verified)"), act)
 	if err == nil {
 		t.Fatal("referencing the removed a.verified key must error at eval, not pass")
 	}
@@ -202,13 +202,13 @@ func TestCEL_ActorVerifiedKeyDenies(t *testing.T) {
 	}
 
 	// The surviving field still evaluates cleanly.
-	got, err := evalCELCondition(mustCompile(t, base, "token.actors.all(a, a.subject != '')"), act)
+	got, err := evalCELCondition(mustCompile(t, base, "agent.actors.all(a, a.subject != '')"), act)
 	if err != nil || !got {
 		t.Fatalf("a.subject must evaluate true: got=%v err=%v", got, err)
 	}
 }
 
-// TestCEL_ReferencedPaths locks in the dotted request/token/call paths captured
+// TestCEL_ReferencedPaths locks in the dotted request/agent/call paths captured
 // for audit Inputs: clean field-selection chains are captured; has(),
 // index/optional access, and now.* are not.
 func TestCEL_ReferencedPaths(t *testing.T) {
@@ -218,18 +218,18 @@ func TestCEL_ReferencedPaths(t *testing.T) {
 		src  string
 		want []string
 	}{
-		{"token+call scalars", true,
-			"token.metadata.env == 'prod' && call.args.amount <= 1500",
-			[]string{"call.args.amount", "token.metadata.env"}},
+		{"agent+call scalars", true,
+			"agent.metadata.env == 'prod' && call.args.amount <= 1500",
+			[]string{"agent.metadata.env", "call.args.amount"}},
 		{"has and index and optional contribute nothing", true,
 			`has(request.data.x) && request.data["k"] == "v" && call.args.?y.orValue(0) <= 3`,
 			nil},
 		{"nested token + list arg", false,
-			"token.principal == 'a' && size(token.policies) > 0",
-			[]string{"token.policies", "token.principal"}},
+			"agent.principal == 'a' && size(agent.policies) > 0",
+			[]string{"agent.policies", "agent.principal"}},
 		{"now not captured", false,
-			`now.getHours("UTC") < 18 && token.metadata.env == "prod"`,
-			[]string{"token.metadata.env"}},
+			`now.getHours("UTC") < 18 && agent.metadata.env == "prod"`,
+			[]string{"agent.metadata.env"}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -261,16 +261,16 @@ func TestCEL_FieldRefs(t *testing.T) {
 		name           string
 		mcp            bool
 		src            string
-		req, tok, cal  map[string]bool
-		reqAll, tokAll bool
+		req, agt, cal  map[string]bool
+		reqAll, agtAll bool
 	}{
-		{name: "scalar select", src: "token.metadata.env == 'prod'", tok: fs("metadata")},
+		{name: "scalar select", src: "agent.metadata.env == 'prod'", agt: fs("metadata")},
 		{name: "has()", src: "has(request.data.x)", req: fs("data")},
 		{name: "index", src: `request.data["k"] == "v"`, req: fs("data")},
 		{name: "optional", mcp: true, src: "call.args.?amount.orValue(0) <= 3", cal: fs("args")},
-		{name: "comprehension", src: "size(token.actors) > 0 && token.actors.all(a, a.subject != '')", tok: fs("actors")},
-		{name: "multi-field", src: "request.data.x <= 1 && request.namespace == token.namespace", req: fs("data", "namespace"), tok: fs("namespace")},
-		{name: "bare root -> all", src: "size(token) > 0 || token.metadata.env == 'x'", tok: fs("metadata"), tokAll: true},
+		{name: "comprehension", src: "size(agent.actors) > 0 && agent.actors.all(a, a.subject != '')", agt: fs("actors")},
+		{name: "multi-field", src: "request.data.x <= 1 && request.namespace == agent.namespace", req: fs("data", "namespace"), agt: fs("namespace")},
+		{name: "bare root -> all", src: "size(agent) > 0 || agent.metadata.env == 'x'", agt: fs("metadata"), agtAll: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -287,7 +287,7 @@ func TestCEL_FieldRefs(t *testing.T) {
 				}
 			}
 			check("request", c.ReqFields, tc.reqAll, tc.req)
-			check("token", c.TokFields, tc.tokAll, tc.tok)
+			check("agent", c.AgtFields, tc.agtAll, tc.agt)
 			check("call", c.CallFields, false, tc.cal)
 		})
 	}
@@ -346,32 +346,32 @@ func TestCEL_StringVsNumericFailsClosed(t *testing.T) {
 }
 
 func TestCEL_TokenMetadataSet(t *testing.T) {
-	prg := mustCompile(t, mustEnv(t, false), "token.metadata.env in ['dev', 'staging']")
+	prg := mustCompile(t, mustEnv(t, false), "agent.metadata.env in ['dev', 'staging']")
 	now := time.Unix(0, 0).UTC()
 
-	got, err := evalCELCondition(prg, baseAct(celRequestInput{}, celTokenInput{Metadata: map[string]string{"env": "dev"}}, now))
+	got, err := evalCELCondition(prg, baseAct(celRequestInput{}, celPrincipalInput{Metadata: map[string]string{"env": "dev"}}, now))
 	if err != nil || !got {
 		t.Fatalf("env=dev: got=%v err=%v, want true", got, err)
 	}
-	got, err = evalCELCondition(prg, baseAct(celRequestInput{}, celTokenInput{Metadata: map[string]string{"env": "prod"}}, now))
+	got, err = evalCELCondition(prg, baseAct(celRequestInput{}, celPrincipalInput{Metadata: map[string]string{"env": "prod"}}, now))
 	if err != nil || got {
 		t.Fatalf("env=prod: got=%v err=%v, want false", got, err)
 	}
 	// Absent key fails closed (matches the old token_metadata semantics).
-	if _, err := evalCELCondition(prg, baseAct(celRequestInput{}, celTokenInput{}, now)); err == nil {
+	if _, err := evalCELCondition(prg, baseAct(celRequestInput{}, celPrincipalInput{}, now)); err == nil {
 		t.Fatal("absent metadata key: expected eval error (fail-closed)")
 	}
 }
 
 func TestCEL_PoliciesMembership(t *testing.T) {
-	prg := mustCompile(t, mustEnv(t, false), "'admin' in token.policies")
+	prg := mustCompile(t, mustEnv(t, false), "'admin' in agent.policies")
 	now := time.Unix(0, 0).UTC()
 
-	got, err := evalCELCondition(prg, baseAct(celRequestInput{}, celTokenInput{Policies: []string{"admin", "reader"}}, now))
+	got, err := evalCELCondition(prg, baseAct(celRequestInput{}, celPrincipalInput{Policies: []string{"admin", "reader"}}, now))
 	if err != nil || !got {
 		t.Fatalf("admin present: got=%v err=%v, want true", got, err)
 	}
-	got, err = evalCELCondition(prg, baseAct(celRequestInput{}, celTokenInput{Policies: []string{"reader"}}, now))
+	got, err = evalCELCondition(prg, baseAct(celRequestInput{}, celPrincipalInput{Policies: []string{"reader"}}, now))
 	if err != nil || got {
 		t.Fatalf("admin absent: got=%v err=%v, want false", got, err)
 	}
@@ -381,16 +381,16 @@ func TestCEL_CIDRContains(t *testing.T) {
 	prg := mustCompile(t, mustEnv(t, false), "cidrContains('10.0.0.0/8', request.client_ip)")
 	now := time.Unix(0, 0).UTC()
 
-	got, err := evalCELCondition(prg, baseAct(celRequestInput{ClientIP: "10.1.2.3"}, celTokenInput{}, now))
+	got, err := evalCELCondition(prg, baseAct(celRequestInput{ClientIP: "10.1.2.3"}, celPrincipalInput{}, now))
 	if err != nil || !got {
 		t.Fatalf("in-range: got=%v err=%v, want true", got, err)
 	}
-	got, err = evalCELCondition(prg, baseAct(celRequestInput{ClientIP: "192.168.1.1"}, celTokenInput{}, now))
+	got, err = evalCELCondition(prg, baseAct(celRequestInput{ClientIP: "192.168.1.1"}, celPrincipalInput{}, now))
 	if err != nil || got {
 		t.Fatalf("out-of-range: got=%v err=%v, want false", got, err)
 	}
 	// A malformed client IP yields an error (fail-closed).
-	if _, err := evalCELCondition(prg, baseAct(celRequestInput{ClientIP: "not-an-ip"}, celTokenInput{}, now)); err == nil {
+	if _, err := evalCELCondition(prg, baseAct(celRequestInput{ClientIP: "not-an-ip"}, celPrincipalInput{}, now)); err == nil {
 		t.Fatal("invalid ip: expected eval error")
 	}
 }
@@ -399,12 +399,12 @@ func TestCEL_TimeFunctions(t *testing.T) {
 	prg := mustCompile(t, mustEnv(t, false), `now.getHours("UTC") >= 8 && now.getHours("UTC") < 18`)
 
 	inHours := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
-	got, err := evalCELCondition(prg, baseAct(celRequestInput{}, celTokenInput{}, inHours))
+	got, err := evalCELCondition(prg, baseAct(celRequestInput{}, celPrincipalInput{}, inHours))
 	if err != nil || !got {
 		t.Fatalf("09:00 UTC: got=%v err=%v, want true", got, err)
 	}
 	outHours := time.Date(2026, 6, 30, 22, 0, 0, 0, time.UTC)
-	got, err = evalCELCondition(prg, baseAct(celRequestInput{}, celTokenInput{}, outHours))
+	got, err = evalCELCondition(prg, baseAct(celRequestInput{}, celPrincipalInput{}, outHours))
 	if err != nil || got {
 		t.Fatalf("22:00 UTC: got=%v err=%v, want false", got, err)
 	}
@@ -414,12 +414,88 @@ func TestCEL_RequestMountFields(t *testing.T) {
 	prg := mustCompile(t, mustEnv(t, false), `request.mount_type == "aws" && request.transparent`)
 	now := time.Unix(0, 0).UTC()
 
-	got, err := evalCELCondition(prg, baseAct(celRequestInput{MountType: "aws", Transparent: true}, celTokenInput{}, now))
+	got, err := evalCELCondition(prg, baseAct(celRequestInput{MountType: "aws", Transparent: true}, celPrincipalInput{}, now))
 	if err != nil || !got {
 		t.Fatalf("aws+transparent: got=%v err=%v, want true", got, err)
 	}
-	got, err = evalCELCondition(prg, baseAct(celRequestInput{MountType: "vault", Transparent: true}, celTokenInput{}, now))
+	got, err = evalCELCondition(prg, baseAct(celRequestInput{MountType: "vault", Transparent: true}, celPrincipalInput{}, now))
 	if err != nil || got {
 		t.Fatalf("vault: got=%v err=%v, want false", got, err)
+	}
+}
+
+// TestCEL_TokenNamespaceRemoved pins the hard cut. `token` is no longer a
+// declared namespace, so every stored condition using it fails to compile —
+// which, because policies are re-parsed on load, is what makes the upgrade
+// breaking. The error must name the replacement: an operator meets it at policy
+// load with no other signal about what changed.
+func TestCEL_TokenNamespaceRemoved(t *testing.T) {
+	for _, src := range []string{
+		"token.metadata.env == 'prod'",
+		"token.principal == 'x'",
+		"size(token.actors) > 0",
+		"token.type == 'jwt_role'",
+		"size(token) > 0",
+	} {
+		t.Run(src, func(t *testing.T) {
+			_, err := compileCELCondition(mustEnv(t, false), src)
+			if err == nil {
+				t.Fatalf("compile %q: want error, got none", src)
+			}
+			if !strings.Contains(err.Error(), "renamed to `agent`") {
+				t.Errorf("compile %q: error does not name the rename: %v", src, err)
+			}
+		})
+	}
+}
+
+// TestCEL_AgentFieldNames pins the field set exactly. The three token_-prefixed
+// names are the half-rename an implementer is most likely to leave behind, and
+// a stale name is not a compile error — `agent` is a dyn map, so it resolves to
+// a runtime no-such-key and a fail-closed deny that reads as a policy decision
+// rather than a bug.
+func TestCEL_AgentFieldNames(t *testing.T) {
+	now := time.Unix(1_757_404_800, 0)
+	agt := celPrincipalInput{
+		Principal:     "agent-gateway",
+		Role:          "gw",
+		Type:          "cert_role",
+		NamespacePath: "team-a/",
+		Policies:      []string{"p"},
+		Metadata:      map[string]string{"team": "platform"},
+		Actors:        []logical.ActorRef{{Subject: "broker"}},
+		TTLSeconds:    60,
+		ExpiresAtUnix: now.Add(time.Minute).Unix(),
+	}
+	// all:true deliberately: this asserts the builder's key set in isolation.
+	// It cannot catch a fieldSet-key/map-key disagreement, because has() short
+	// -circuits on all — TestCBP_PathCondition_RenamedFields drives the pruned
+	// path for that.
+	ns := buildPrincipalNS(agt, fieldSet{all: true})
+
+	for _, k := range []string{
+		"principal", "role", "namespace", "policies", "metadata", "actors",
+		"token_type", "token_ttl_seconds", "token_expires_at",
+	} {
+		if _, ok := ns[k]; !ok {
+			t.Errorf("agent.%s missing", k)
+		}
+	}
+	// The pre-rename spellings must be gone, not merely aliased.
+	for _, k := range []string{"type", "ttl_seconds", "expires_at"} {
+		if _, ok := ns[k]; ok {
+			t.Errorf("agent.%s still built — half-rename", k)
+		}
+	}
+	// Assert values, not just presence: the two time fields are adjacent
+	// int64s, so a builder that swapped them would pass a presence-only check.
+	if got := ns["token_type"]; got != "cert_role" {
+		t.Errorf("agent.token_type = %v, want cert_role", got)
+	}
+	if got := ns["token_ttl_seconds"]; got != int64(60) {
+		t.Errorf("agent.token_ttl_seconds = %v, want 60", got)
+	}
+	if got := ns["token_expires_at"]; got != now.Add(time.Minute).Unix() {
+		t.Errorf("agent.token_expires_at = %v, want %v", got, now.Add(time.Minute).Unix())
 	}
 }

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -457,8 +457,8 @@ func evaluateMCPDescriptor(sets []*CBPMCPRules, desc *logical.MCPRequestDescript
 	// when at least one set carries a CEL condition; nil otherwise so the
 	// common no-condition path allocates nothing extra.
 	var act *celActivation
-	if reqF, tokF, callF, found := mcpConditionFields(sets); found {
-		act = newCELActivation(celRequestInputFromRequest(req, nsPath), reqF, celTokenInputFromEntry(te, now), tokF, now, nil)
+	if reqF, agtF, callF, found := mcpConditionFields(sets); found {
+		act = newCELActivation(celRequestInputFromRequest(req, nsPath), reqF, celPrincipalInputFromEntry(te, now), agtF, now, nil)
 		act.callFields = callF
 	}
 
@@ -486,18 +486,18 @@ func evaluateMCPDescriptor(sets []*CBPMCPRules, desc *logical.MCPRequestDescript
 // sets that carry a CEL condition, and whether any condition exists. The union
 // prunes the shared per-request activation to only the fields the conditions
 // read (reused across every call in a batch).
-func mcpConditionFields(sets []*CBPMCPRules) (reqF, tokF, callF fieldSet, found bool) {
+func mcpConditionFields(sets []*CBPMCPRules) (reqF, agtF, callF fieldSet, found bool) {
 	for _, s := range sets {
 		if s == nil || s.Condition == nil {
 			continue
 		}
 		if !found {
-			reqF, tokF, callF = s.Condition.ReqFields, s.Condition.TokFields, s.Condition.CallFields
+			reqF, agtF, callF = s.Condition.ReqFields, s.Condition.AgtFields, s.Condition.CallFields
 			found = true
 			continue
 		}
 		reqF = unionFieldSets(reqF, s.Condition.ReqFields)
-		tokF = unionFieldSets(tokF, s.Condition.TokFields)
+		agtF = unionFieldSets(agtF, s.Condition.AgtFields)
 		callF = unionFieldSets(callF, s.Condition.CallFields)
 	}
 	return


### PR DESCRIPTION
The `token` namespace names the request's authenticating principal, which on a gateway mount is the agent. Rename it so a condition reads as what it is, ahead of a `user` namespace landing beside it and sharing the same builder.

## The rename is not 1:1

Six fields are properties of the principal and carry over unchanged. Three describe the *credential* rather than the principal and take a `token_` prefix — `token.type` was the worst of them, since its values (`jwt_role`, `cert_role`, …) name how the principal authenticated, not a kind of principal:

| Before | After |
|---|---|
| `token.type` | `agent.token_type` |
| `token.ttl_seconds` | `agent.token_ttl_seconds` |
| `token.expires_at` | `agent.token_expires_at` |

## BREAKING

`token` is removed outright, with no alias. Policies are re-parsed on load and a parse failure is returned as an error, so a stored condition using `token.*` fails to load after upgrade.

**There is no rewrite-first migration.** The pre-upgrade binary does not declare `agent`, so neither spelling is accepted by both versions. The real sequence is:

1. **Export every policy text before upgrading** — afterwards the broken policy cannot be read back, because the read handler parses before returning `Raw`.
2. Upgrade.
3. Immediately push the rewritten `agent.*` policies.

Between 2 and 3 there is a bounded enforcement outage for affected policies. Unseal is unaffected; the runtime symptom is HTTP 400 for tokens holding an affected policy, not a 403.

Compile failures naming `token` now carry the replacement spelling, on both the write and load paths.

## The quiet half

The rename moves every audit key: `celSelectPath` writes referenced paths straight into `ConditionResult.Inputs`, which is what an audit device's `salt_fields` entry matches verbatim. A stale selector does not error — it stops matching, and the value it protected begins logging in clear. Regression tests pin both the pre-rename spelling and the `agent.type` / `agent.token_type` trap a mechanical `token.` → `agent.` substitution falls into.

## Testing

`TestCBP_PathCondition_RenamedFields` drives the full compile → analyze → prune → eval path rather than the builder alone. `celAnalyzeRefs` records a CEL field name and `buildPrincipalNS` gates on it; if those strings disagree the field is pruned away and every request denies — and since `agent` is a dyn map that is not a compile error. Verified by injecting the disagreement: the round-trip test fails, a builder-only test does not.

Full unit suite and `go vet` clean.

## Out of scope

Docs and CHANGELOG (release prep). ~11 files still teach `token.*`, and `from-v0-18.md` recommends a rewrite that no longer compiles.