### PR TITLE
feat(policy): expose the user principal to CEL conditions

### DIFF
--- a/auth/method/jwt/metadata_test.go
+++ b/auth/method/jwt/metadata_test.go
@@ -92,3 +92,58 @@ func TestExtractMetadata_NonStringClaimErrors(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, md)
 }
+
+// TestExtractMetadata_ActSubConsentBinding pins the claim mapping the
+// agent-user binding rests on. RFC 8693 §4.1 defines `act` as "agent A acting
+// for user B", so on a USER token act.sub names the agent — mapping it to a
+// metadata key is what lets a policy compare it to agent.principal.
+//
+// This is deliberately specific rather than folded into the generic JSON
+// Pointer tests: /act/sub is the one mapping the consent check cannot work
+// without, and it is otherwise only exercised end-to-end.
+func TestExtractMetadata_ActSubConsentBinding(t *testing.T) {
+	mapping := map[string]string{"/act/sub": "acting_agent", "team": "team"}
+
+	t.Run("maps the acting agent", func(t *testing.T) {
+		md, err := extractMetadata(map[string]interface{}{
+			"sub":  "user-8f21c3",
+			"team": "platform",
+			"act":  map[string]interface{}{"sub": "agent-gateway"},
+		}, mapping)
+		require.NoError(t, err)
+		assert.Equal(t, "agent-gateway", md["acting_agent"])
+		assert.Equal(t, "platform", md["team"])
+	})
+
+	t.Run("takes the outermost actor of a delegation chain", func(t *testing.T) {
+		// /act/sub is the immediate actor, matching actors[0] from
+		// extractActChain — the party acting directly for the user.
+		md, err := extractMetadata(map[string]interface{}{
+			"sub": "user-8f21c3",
+			"act": map[string]interface{}{
+				"sub": "broker-beta",
+				"act": map[string]interface{}{"sub": "agent-gateway"},
+			},
+		}, mapping)
+		require.NoError(t, err)
+		assert.Equal(t, "broker-beta", md["acting_agent"])
+	})
+
+	t.Run("absent act leaves the key unset so the binding fails closed", func(t *testing.T) {
+		// A user token minted without consent carries no `act`. The claim is
+		// skipped rather than erroring, so the key is simply missing and the
+		// policy condition denies on a no-such-key rather than passing.
+		md, err := extractMetadata(map[string]interface{}{
+			"sub": "user-8f21c3", "team": "platform",
+		}, mapping)
+		require.NoError(t, err)
+		assert.NotContains(t, md, "acting_agent")
+	})
+
+	t.Run("malformed act is rejected, not coerced", func(t *testing.T) {
+		_, err := extractMetadata(map[string]interface{}{
+			"act": map[string]interface{}{"sub": 42},
+		}, mapping)
+		assert.Error(t, err, "a non-string act.sub must not be flattened into metadata")
+	})
+}

--- a/core/policy.go
+++ b/core/policy.go
@@ -133,16 +133,18 @@ type PathRules struct {
 	// gates). Compiled at parse time into pc.Permissions.Conditions.
 	ConditionHCL string `hcl:"condition"`
 
-	// MCPHCL is the parsed `mcp { }` block. Nil when no such block is
-	// present on this path stanza. Stored on PathRules as the HCL
-	// decode target; the parser then validates it and appends a
-	// CBPMCPRules entry to pc.Permissions.MCP.
+	// MCPHCL is the decode target for the removed `mcp { }` block. It exists
+	// only so parsePaths can detect a policy still carrying one and reject it
+	// with a directed error pointing at sys/policies/mcp/<name>; a non-nil
+	// value never reaches canonicalisation.
 	MCPHCL *MCPRulesHCL `hcl:"mcp"`
 }
 
-// MCPRulesHCL is the HCL decode shape of one `mcp { }` block. Each
-// field corresponds to one operator-facing key inside the block; the
-// parser canonicalises (lowercases) all entries and validates wildcard
+// MCPRulesHCL is the canonical decode shape of one MCP rule-set. An MCP
+// policy's path stanza flattens into it (see mcpPolicyPathHCL.flatten), and
+// it is also the decode target for the removed `mcp { }` block so that block
+// can be detected and rejected. Each field corresponds to one
+// operator-facing key; the parser canonicalises (lowercases) all entries and validates wildcard
 // patterns before populating the internal CBPMCPRules form.
 type MCPRulesHCL struct {
 	AllowedMethods   []string            `hcl:"allowed_methods"`
@@ -169,16 +171,16 @@ type CBPPermissions struct {
 	// (OR across policies). Programs are immutable and shared (not deep-copied)
 	// across merged CBPs.
 	Conditions []*compiledCondition
-	// MCP holds mcp { } rule-sets from all merged policies for this path.
+	// MCP holds MCP rule-sets from all merged policies for this path.
 	// nil/empty means no MCP enforcement applies. Non-nil: each entry is one
-	// source stanza's mcp block; a request is allowed if at least one set
+	// source stanza's rules; a request is allowed if at least one set
 	// allows it (OR between sets), with the strongest-reason audit picked
 	// on full deny. Populated by parsePaths via append per stanza so multiple
 	// `path` blocks at the same path layer naturally into multiple rule-sets.
 	MCP []*CBPMCPRules
 }
 
-// CBPMCPRules holds one merged mcp { } rule-set after validation and
+// CBPMCPRules holds one merged MCP rule-set after validation and
 // canonicalisation. All list entries are lowercased; param-name keys
 // are lowercased and hyphens preserved. Patterns use trailing-`*` only
 // per the policy Semantics; the parser rejects leading or internal `*`
@@ -391,9 +393,11 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 			return multierror.Prefix(err, fmt.Sprintf("path %q:", key))
 		}
 
-		// Checked here rather than beside the other rule handling further down:
-		// the deny capability jumps to PathFinished, which would skip a check
-		// placed there and let a denying stanza carry the removed block forever.
+		// Checked before the deny capability's `goto PathFinished`, which would
+		// skip a check placed later in the loop body and let a denying stanza
+		// carry the removed block forever. Because this rejects every non-nil
+		// MCPHCL, no `mcp { }` block ever reaches canonicalisation — MCPHCL is
+		// a detector, not a decode path (see its field doc).
 		if pc.MCPHCL != nil {
 			return fmt.Errorf("path %q: the mcp { } block has been removed from capability policies — "+
 				"MCP rules now live in their own policy, written to sys/policies/mcp/<name>, whose "+
@@ -512,14 +516,6 @@ func parsePaths(result *Policy, list *ast.ObjectList) error {
 			}
 			pc.Permissions.Conditions = []*compiledCondition{cond}
 		}
-
-		if pc.MCPHCL != nil {
-			rules, err := canonicaliseMCPRules(pc.MCPHCL)
-			if err != nil {
-				return fmt.Errorf("path %q: %w", key, err)
-			}
-			pc.Permissions.MCP = append(pc.Permissions.MCP, rules)
-		}
 	PathFinished:
 		paths = append(paths, &pc)
 	}
@@ -567,7 +563,7 @@ func normalizePathPattern(ns *namespace.Namespace, key string) (path string, isP
 	return path, isPrefix, hasSegmentWildcards, nil
 }
 
-// canonicaliseMCPRules converts a parsed mcp { } HCL block into the
+// canonicaliseMCPRules converts a parsed MCP rule-set into the
 // internal CBPMCPRules form, validating wildcard patterns and
 // lowercasing all entries so AllowOperation can do case-insensitive
 // equality and prefix matching at request time without re-canonicalising.

--- a/core/policy_cbp.go
+++ b/core/policy_cbp.go
@@ -259,8 +259,8 @@ func NewCBP(ctx context.Context, policies []*Policy) (*CBP, error) {
 //
 // Stanzas at the same normalized path key merge additively, so several MCP
 // policies covering one path contribute several rule-sets and evaluateMCPCall's
-// cross-set OR decides between them — the same shape the mcp { } block had when
-// two CBP policies named the same path.
+// cross-set OR decides between them — the same shape the removed `mcp { }`
+// block had when two CBP policies named the same path.
 func (a *CBP) insertMCPPolicy(policy *Policy) error {
 	for _, pc := range policy.Paths {
 		if !pc.Expiration.IsZero() && time.Now().After(pc.Expiration) {

--- a/core/policy_cel.go
+++ b/core/policy_cel.go
@@ -48,16 +48,33 @@ import (
 //	  request.mount_point, request.mount_type, request.mount_class,
 //	  request.mount_accessor, request.transparent, request.namespace,
 //	  request.data.<k>
-//	agent.principal, agent.role, agent.namespace, agent.policies (list),
-//	  agent.metadata.<k>, agent.actors (list of {subject}),
-//	  agent.token_type, agent.token_ttl_seconds, agent.token_expires_at
+//	agent.present, agent.principal, agent.role, agent.namespace,
+//	  agent.policies (list), agent.metadata.<k>, agent.actors (list of
+//	  {subject}), agent.token_type, agent.token_ttl_seconds,
+//	  agent.token_expires_at
+//	user.<same, minus policies>
 //	now (timestamp)
 //	call.method, call.tool, call.args.<k>, call.batch_index   (MCP policy only)
 //
-// `agent` is the request's authenticating principal. The three token_-prefixed
-// fields describe the credential it authenticated with, not the principal
-// itself — agent.token_type carries values like jwt_role/cert_role, which name
-// how the agent authenticated rather than a kind of agent.
+// `agent` is the request's authenticating principal and the sole authorizer.
+// `user` is the optional second principal it acts for, resolved before the
+// policy decision and identity-only — it never authorizes, which is why
+// user.policies is not exposed. user.present is false when no user credential
+// rode the request; that is tolerated by design, so a condition wanting one
+// must say `user.present && …`. Note a condition must evaluate to bool while a
+// dyn-map field types as dyn, so a bare `user.present` is rejected at write
+// time — use it as a guard (as above) or compare it explicitly.
+//
+// The three token_-prefixed fields describe the credential a principal
+// authenticated with, not the principal itself — token_type carries values like
+// jwt_role/cert_role, which name how it authenticated rather than a kind of
+// principal.
+//
+// Two caveats worth knowing before writing a `user` condition: the user leg is
+// resolved only for gateway (streaming) requests, so user.present is always
+// false elsewhere; and user.role is the auth-mount role fixed by the mount's
+// user_auth_role — not the person's organisational role — while
+// user.namespace always equals request.namespace. Gate on user.metadata.<k>.
 //
 // Secret material (token value, accessor, client token) is never exposed.
 
@@ -104,9 +121,16 @@ type celRequestInput struct {
 }
 
 // celPrincipalInput is the non-secret principal context mapped into the `agent`
-// namespace. Decoupled from *logical.TokenEntry so the activation builder stays
-// unit-testable; the wiring layer adapts the token entry into this.
+// and `user` namespaces. Decoupled from *logical.TokenEntry so the activation
+// builder stays unit-testable; the wiring layer adapts the token entry into this.
 type celPrincipalInput struct {
+	// Present is false when no principal occupied this leg. It exists so an
+	// operator can write `user.present && …`: a user credential is optional on
+	// a protected-resource mount, and without this field its absence would be a
+	// missing-key deny that reads as a bug rather than a policy decision. On the
+	// agent leg it is always true wherever a condition evaluates, since
+	// CheckToken has a token entry by then.
+	Present       bool
 	Principal     string
 	Role          string
 	Type          string
@@ -118,6 +142,19 @@ type celPrincipalInput struct {
 	ExpiresAtUnix int64
 }
 
+// principalLeg distinguishes the two principals that share buildPrincipalNS. It
+// gates the fields that exist on only one of them.
+//
+// Named legAgent/legUser rather than agentLeg/userLeg because this package
+// already uses `userLeg bool` for a different thing — whether a mount is a
+// protected resource, so Authorization carries the user (see ExtractTokens).
+type principalLeg bool
+
+const (
+	legAgent principalLeg = false
+	legUser  principalLeg = true
+)
+
 // buildCELEnv constructs a CEL environment. When mcp is true the env also
 // declares the per-call `call` namespace, producing the MCP env; otherwise it
 // is the base (path-level) env.
@@ -126,6 +163,7 @@ func buildCELEnv(mcp bool) (*cel.Env, error) {
 		// request-wide namespaces; dyn maps (see design note).
 		cel.Variable("request", cel.MapType(cel.StringType, cel.DynType)),
 		cel.Variable("agent", cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable("user", cel.MapType(cel.StringType, cel.DynType)),
 		cel.Variable("now", cel.TimestampType),
 
 		// Optional types for concise optional-arg access: call.args.?x.orValue(d).
@@ -175,9 +213,11 @@ func celCIDRContainsFunc() cel.EnvOption {
 
 // celCostEstimator supplies input size bounds for our dynamic-map variables so
 // env.EstimateCost can bound an expression's worst-case cost at compile time.
-// Every dynamic-map root must appear in EstimateSize below: a root omitted here
-// falls through to cel-go's own default sizing, silently under-counting the
-// write-time bound for every expression that reads it.
+// Every dynamic-map root must appear in EstimateSize below. A root omitted here
+// gets no size from us, and cel-go falls through to UnknownSizeEstimate
+// (max = MaxUint64) — so any size-dependent expression over that root estimates
+// as effectively infinite and is REJECTED at write time, even when it is
+// perfectly reasonable. The failure is a spurious rejection, not a missed bound.
 // cel-go owns the per-operation base costs; this only feeds the sizes cel-go
 // cannot infer.
 type celCostEstimator struct {
@@ -187,7 +227,7 @@ type celCostEstimator struct {
 func (e celCostEstimator) EstimateSize(node checker.AstNode) *checker.SizeEstimate {
 	if path := node.Path(); len(path) > 0 {
 		switch path[0] {
-		case "request", "agent", "call":
+		case "request", "agent", "user", "call":
 			return &checker.SizeEstimate{Min: 0, Max: e.maxSize}
 		}
 	}
@@ -245,7 +285,7 @@ func compileCELConditionWithLimits(env *cel.Env, src string, maxCost, sizeBound 
 	if err != nil {
 		return nil, fmt.Errorf("condition program construction failed: %w", err)
 	}
-	paths, segs, reqF, agtF, callF := celAnalyzeRefs(ast)
+	paths, segs, reqF, agtF, usrF, callF := celAnalyzeRefs(ast)
 	return &compiledCondition{
 		Source:     src,
 		Program:    prg,
@@ -253,6 +293,7 @@ func compileCELConditionWithLimits(env *cel.Env, src string, maxCost, sizeBound 
 		RefSegs:    segs,
 		ReqFields:  reqF,
 		AgtFields:  agtF,
+		UsrFields:  usrF,
 		CallFields: callF,
 	}, nil
 }
@@ -345,8 +386,8 @@ func unionFieldSets(a, b fieldSet) fieldSet {
 // A bare root Ident that is not a Select operand sets all=true for that root, so
 // pruning never drops a field the expression needs (an under-built field would
 // be a missing key → fail-closed deny).
-func celAnalyzeRefs(a *cel.Ast) (paths []string, segs [][]string, req, agt, call fieldSet) {
-	req, agt, call = fieldSet{fields: map[string]bool{}}, fieldSet{fields: map[string]bool{}}, fieldSet{fields: map[string]bool{}}
+func celAnalyzeRefs(a *cel.Ast) (paths []string, segs [][]string, req, agt, usr, call fieldSet) {
+	req, agt, usr, call = fieldSet{fields: map[string]bool{}}, fieldSet{fields: map[string]bool{}}, fieldSet{fields: map[string]bool{}}, fieldSet{fields: map[string]bool{}}
 	native := a.NativeRep()
 	if native == nil || native.Expr() == nil {
 		return
@@ -356,7 +397,7 @@ func celAnalyzeRefs(a *cel.Ast) (paths []string, segs [][]string, req, agt, call
 	consumed := map[int64]bool{}     // operand of some Select — an intermediate node
 	skip := map[int64]bool{}         // container of an index/optional access — not a field path
 	identCovered := map[int64]bool{} // root-Ident IDs that are a Select operand
-	var rootIdents []celast.Expr     // Idents named request/agent/call
+	var rootIdents []celast.Expr     // Idents named request/agent/user/call
 	celast.PostOrderVisit(native.Expr(), celast.NewExprVisitor(func(e celast.Expr) {
 		switch e.Kind() {
 		case celast.SelectKind:
@@ -372,6 +413,9 @@ func celAnalyzeRefs(a *cel.Ast) (paths []string, segs [][]string, req, agt, call
 				case "agent":
 					agt.fields[s.FieldName()] = true
 					identCovered[op.ID()] = true
+				case "user":
+					usr.fields[s.FieldName()] = true
+					identCovered[op.ID()] = true
 				case "call":
 					call.fields[s.FieldName()] = true
 					identCovered[op.ID()] = true
@@ -379,7 +423,7 @@ func celAnalyzeRefs(a *cel.Ast) (paths []string, segs [][]string, req, agt, call
 			}
 		case celast.IdentKind:
 			switch e.AsIdent() {
-			case "request", "agent", "call":
+			case "request", "agent", "user", "call":
 				rootIdents = append(rootIdents, e)
 			}
 		case celast.CallKind:
@@ -425,6 +469,8 @@ func celAnalyzeRefs(a *cel.Ast) (paths []string, segs [][]string, req, agt, call
 			req.all = true
 		case "agent":
 			agt.all = true
+		case "user":
+			usr.all = true
 		case "call":
 			call.all = true
 		}
@@ -434,7 +480,7 @@ func celAnalyzeRefs(a *cel.Ast) (paths []string, segs [][]string, req, agt, call
 
 // celSelectPath reconstructs the dotted path for a Select chain top (e.g.
 // agent.metadata.env). Returns ok=false if the chain contains a test-only
-// select (has()) or does not bottom out on a request/agent/call Ident.
+// select (has()) or does not bottom out on a request/agent/user/call Ident.
 //
 // The returned path is the operator's own spelling and is what lands in
 // ConditionResult.Inputs — and therefore what an audit device's salt_fields
@@ -455,7 +501,7 @@ func celSelectPath(e celast.Expr) (string, bool) {
 		return "", false
 	}
 	switch cur.AsIdent() {
-	case "request", "agent", "call":
+	case "request", "agent", "user", "call":
 	default:
 		return "", false
 	}
@@ -538,8 +584,11 @@ var emptyStringMap = map[string]string{}
 // The token_-prefixed keys describe the credential rather than the principal:
 // token_type carries values like jwt_role/cert_role, which name how the
 // principal authenticated, not a kind of principal.
-func buildPrincipalNS(p celPrincipalInput, f fieldSet) map[string]any {
+func buildPrincipalNS(p celPrincipalInput, f fieldSet, leg principalLeg) map[string]any {
 	m := make(map[string]any, len(f.fields))
+	if f.has("present") {
+		m["present"] = p.Present
+	}
 	if f.has("principal") {
 		m["principal"] = p.Principal
 	}
@@ -576,7 +625,13 @@ func buildPrincipalNS(p celPrincipalInput, f fieldSet) map[string]any {
 		}
 		m["actors"] = acts
 	}
-	if f.has("policies") {
+	// The user principal never authorizes — CBP is evaluated against the agent's
+	// token alone — so `"admin" in user.policies` would read like an authorization
+	// check that it is not. Suppressed at the builder rather than by withholding
+	// the field from the caller's fieldSet, so a future field-set path cannot
+	// reintroduce it by forgetting. Absent means a runtime no-such-key deny, not a
+	// compile error: `user` is a dyn map.
+	if f.has("policies") && leg != legUser {
 		policies := make([]any, 0, len(p.Policies))
 		for _, pol := range p.Policies {
 			policies = append(policies, pol)
@@ -595,10 +650,11 @@ func buildPrincipalNS(p celPrincipalInput, f fieldSet) map[string]any {
 // buildBaseActivation eagerly builds the full activation map. Retained for unit
 // tests; the request path uses celActivation (lazy) to avoid building
 // namespaces an expression never references.
-func buildBaseActivation(req celRequestInput, agt celPrincipalInput, now time.Time) map[string]any {
+func buildBaseActivation(req celRequestInput, agt, usr celPrincipalInput, now time.Time) map[string]any {
 	return map[string]any{
 		"request": buildRequestNS(req, fieldSet{all: true}),
-		"agent":   buildPrincipalNS(agt, fieldSet{all: true}),
+		"agent":   buildPrincipalNS(agt, fieldSet{all: true}, legAgent),
+		"user":    buildPrincipalNS(usr, fieldSet{all: true}, legUser),
 		"now":     now,
 	}
 }
@@ -613,16 +669,19 @@ type celActivation struct {
 	reqFields  fieldSet
 	agt        celPrincipalInput
 	agtFields  fieldSet
+	usr        celPrincipalInput
+	usrFields  fieldSet
 	callFields fieldSet // used when building the per-call namespace (MCP)
 	now        time.Time
 	call       map[string]any // nil for path-level conditions
 
 	reqNS map[string]any
 	agtNS map[string]any
+	usrNS map[string]any
 }
 
-func newCELActivation(req celRequestInput, reqFields fieldSet, agt celPrincipalInput, agtFields fieldSet, now time.Time, call map[string]any) *celActivation {
-	return &celActivation{req: req, reqFields: reqFields, agt: agt, agtFields: agtFields, now: now, call: call}
+func newCELActivation(req celRequestInput, reqFields fieldSet, agt celPrincipalInput, agtFields fieldSet, usr celPrincipalInput, usrFields fieldSet, now time.Time, call map[string]any) *celActivation {
+	return &celActivation{req: req, reqFields: reqFields, agt: agt, agtFields: agtFields, usr: usr, usrFields: usrFields, now: now, call: call}
 }
 
 func (a *celActivation) Parent() interpreter.Activation { return nil }
@@ -636,9 +695,14 @@ func (a *celActivation) ResolveName(name string) (any, bool) {
 		return a.reqNS, true
 	case "agent":
 		if a.agtNS == nil {
-			a.agtNS = buildPrincipalNS(a.agt, a.agtFields)
+			a.agtNS = buildPrincipalNS(a.agt, a.agtFields, legAgent)
 		}
 		return a.agtNS, true
+	case "user":
+		if a.usrNS == nil {
+			a.usrNS = buildPrincipalNS(a.usr, a.usrFields, legUser)
+		}
+		return a.usrNS, true
 	case "now":
 		return a.now, true
 	case "call":
@@ -714,15 +778,16 @@ func paramValueToCEL(pv logical.ParamValue) (any, bool) {
 type compiledCondition struct {
 	Source  string
 	Program cel.Program
-	// RefPaths are the dotted request/agent/call variable paths the expression
+	// RefPaths are the dotted request/agent/user/call variable paths the expression
 	// reads, snapshotted into the audited ConditionResult.Inputs at eval time.
 	// RefSegs is the pre-split form (compile-time) so eval avoids strings.Split.
 	RefPaths []string
 	RefSegs  [][]string
-	// ReqFields/AgtFields/CallFields are the top-level namespace fields the
-	// expression reads, used to build only the referenced parts of the activation.
+	// ReqFields/AgtFields/UsrFields/CallFields are the top-level namespace fields
+	// the expression reads, used to build only the referenced parts of the activation.
 	ReqFields  fieldSet
 	AgtFields  fieldSet
+	UsrFields  fieldSet
 	CallFields fieldSet
 }
 
@@ -785,6 +850,7 @@ func celPrincipalInputFromEntry(te *logical.TokenEntry, now time.Time) celPrinci
 		expires = te.ExpireAt.Unix()
 	}
 	return celPrincipalInput{
+		Present:       true,
 		Principal:     te.PrincipalID,
 		Role:          te.RoleName,
 		Type:          te.Type,
@@ -795,6 +861,30 @@ func celPrincipalInputFromEntry(te *logical.TokenEntry, now time.Time) celPrinci
 		TTLSeconds:    ttl,
 		ExpiresAtUnix: expires,
 	}
+}
+
+// celUserInputFromPrincipal adapts a *logical.UserPrincipal into the non-secret
+// principal context exposed as `user`. A nil principal — or one carrying no
+// validated token entry — yields {Present: false} rather than a zero value that
+// would read as an anonymous user.
+//
+// UserPrincipal.RawToken is deliberately not read: it is a bearer secret, kept
+// off audit serialization, and must never reach an activation.
+func celUserInputFromPrincipal(up *logical.UserPrincipal, now time.Time) celPrincipalInput {
+	if up == nil {
+		return celPrincipalInput{}
+	}
+	return celPrincipalInputFromEntry(up.TokenEntry, now)
+}
+
+// celUserInputFromRequest is celUserInputFromPrincipal over a request that may
+// itself be nil — the condition evaluators tolerate a nil request (see
+// celRequestInputFromRequest), so reading req.User bare would panic there.
+func celUserInputFromRequest(req *logical.Request, now time.Time) celPrincipalInput {
+	if req == nil {
+		return celPrincipalInput{}
+	}
+	return celUserInputFromPrincipal(req.User, now)
 }
 
 // celErrorKind maps a CEL evaluation error to a coarse, sanitized category for
@@ -823,12 +913,17 @@ func evaluatePathConditions(conds []*compiledCondition, req *logical.Request, te
 	}
 	// Build the activation pruned to the union of fields the conditions read.
 	// The common single-condition case reuses its field-sets with no allocation.
-	reqF, agtF := conds[0].ReqFields, conds[0].AgtFields
+	reqF, agtF, usrF := conds[0].ReqFields, conds[0].AgtFields, conds[0].UsrFields
 	for _, c := range conds[1:] {
 		reqF = unionFieldSets(reqF, c.ReqFields)
 		agtF = unionFieldSets(agtF, c.AgtFields)
+		usrF = unionFieldSets(usrF, c.UsrFields)
 	}
-	act := newCELActivation(celRequestInputFromRequest(req, nsPath), reqF, celPrincipalInputFromEntry(te, now), agtF, now, nil)
+	act := newCELActivation(
+		celRequestInputFromRequest(req, nsPath), reqF,
+		celPrincipalInputFromEntry(te, now), agtF,
+		celUserInputFromRequest(req, now), usrF,
+		now, nil)
 
 	var deciding *logical.ConditionResult
 	for _, c := range conds {

--- a/core/policy_cel_mcp_test.go
+++ b/core/policy_cel_mcp_test.go
@@ -272,3 +272,97 @@ func BenchmarkMCPDecide_Batch3_NoCondition(b *testing.B) {
 func BenchmarkMCPDecide_Batch3_WithCondition(b *testing.B) {
 	benchMCP(b, benchMCPWithCond, benchMCPBatch, nil)
 }
+
+// TestMCPCond_UserNamespace confirms the user leg reaches MCP policy condition, and
+// that mcpConditionFields unions UsrFields across rule-sets.
+//
+// The union is the sharp edge here: it prunes the activation shared by every
+// call in a batch, so a set whose UsrFields is dropped evaluates against a
+// namespace missing the field it reads — a no-such-key deny with no compile
+// error.
+//
+// Set ordering is load-bearing. mcpConditionFields seeds its field-sets from
+// the first condition-carrying set and unions the rest, so the user-referencing
+// set must come SECOND: put it first and it is seeded rather than unioned, and
+// the test passes even with the union removed.
+func TestMCPCond_UserNamespace(t *testing.T) {
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["pay"] }
+  condition = "call.args.amount <= 1"
+}
+
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["pay"] }
+  condition = "user.present && user.metadata.acting_agent == agent.principal"
+}
+`)
+	body := `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"pay","arguments":{"amount":9000}},"id":1}`
+	agentTE := &logical.TokenEntry{PrincipalID: "agent-gateway"}
+
+	withUser := func(actingAgent string) *logical.Request {
+		req := mcpReq(t, body)
+		req.User = &logical.UserPrincipal{
+			TokenEntry: &logical.TokenEntry{
+				Metadata: map[string]string{"acting_agent": actingAgent},
+			},
+		}
+		return req
+	}
+
+	bound := cbp.AllowOperation(testContext(), withUser("agent-gateway"), agentTE, false)
+	assert.True(t, bound.Allowed, "user condition must resolve in an MCP policy condition")
+
+	other := cbp.AllowOperation(testContext(), withUser("agent-other"), agentTE, false)
+	assert.False(t, other.Allowed, "amount 9000 fails the amount set, mismatched agent fails the binding set")
+
+	// No user credential. Asserting !Allowed alone proves nothing here — the
+	// amount set already denies — so assert the binding set reached a clean
+	// guard denial rather than erroring on a missing key.
+	none := cbp.AllowOperation(testContext(), mcpReq(t, body), agentTE, false)
+	assert.False(t, none.Allowed)
+	require.NotNil(t, none.MCPDecision)
+	require.NotNil(t, none.MCPDecision.Condition)
+	assert.Empty(t, none.MCPDecision.Condition.ErrorKind,
+		"user.present false is a policy decision, not an eval error")
+}
+
+// TestMCPCond_UserNamespaceSeeded covers the other arm of mcpConditionFields.
+// TestMCPCond_UserNamespace puts the user-referencing set second so its
+// UsrFields arrive via the union; that leaves the seed arm — where the first
+// condition-carrying set is the one reading user.* — uncovered. A single
+// user-binding rule-set is also the shape an operator writes first, so a
+// seeding regression would deny every request.
+func TestMCPCond_UserNamespaceSeeded(t *testing.T) {
+	cbp := mustCBPWithMCP(t, `
+path "mcp/gateway/*" {
+  capabilities = ["update"]
+}
+`, `
+path "mcp/gateway/*" {
+  methods { allowed = ["tools/call"] }
+  tools { allowed = ["pay"] }
+  condition = "user.present && user.metadata.acting_agent == agent.principal"
+}
+`)
+	body := `{"jsonrpc":"2.0","method":"tools/call","params":{"name":"pay","arguments":{"amount":1}},"id":1}`
+	agentTE := &logical.TokenEntry{PrincipalID: "agent-gateway"}
+
+	req := mcpReq(t, body)
+	req.User = &logical.UserPrincipal{
+		TokenEntry: &logical.TokenEntry{Metadata: map[string]string{"acting_agent": "agent-gateway"}},
+	}
+	assert.True(t, cbp.AllowOperation(testContext(), req, agentTE, false).Allowed)
+
+	bad := mcpReq(t, body)
+	bad.User = &logical.UserPrincipal{
+		TokenEntry: &logical.TokenEntry{Metadata: map[string]string{"acting_agent": "agent-other"}},
+	}
+	assert.False(t, cbp.AllowOperation(testContext(), bad, agentTE, false).Allowed)
+}

--- a/core/policy_cel_mcp_test.go
+++ b/core/policy_cel_mcp_test.go
@@ -124,9 +124,9 @@ func TestMCPCond_RecordsInputs(t *testing.T) {
 	assert.Equal(t, "2000", res.MCPDecision.Condition.Inputs["call.args.amount"])
 }
 
-// TestMCPCond_TokenNamespace confirms an MCP condition can read the token
+// TestMCPCond_AgentNamespace confirms an MCP condition can read the agent
 // namespace (threaded via the TokenEntry), not just call.*.
-func TestMCPCond_TokenNamespace(t *testing.T) {
+func TestMCPCond_AgentNamespace(t *testing.T) {
 	cbp := mustCBPWithMCP(t, `
 path "mcp/gateway/*" {
   capabilities = ["update"]

--- a/core/policy_cel_path_test.go
+++ b/core/policy_cel_path_test.go
@@ -403,3 +403,115 @@ func TestCBP_PathCondition_RenamedFields(t *testing.T) {
 		assert.NotContains(t, res.Condition.Inputs, k)
 	}
 }
+
+// userReq builds a gateway-shaped request carrying a user principal.
+func userReq(path string, userMeta map[string]string) *logical.Request {
+	req := &logical.Request{Operation: logical.CreateOperation, Path: path}
+	if userMeta != nil {
+		req.User = &logical.UserPrincipal{
+			TokenEntry: &logical.TokenEntry{
+				PrincipalID: "user-8f21c3",
+				RoleName:    "human",
+				Metadata:    userMeta,
+			},
+			// A bearer secret. It must never reach an activation, which the
+			// audit assertion below checks.
+			RawToken: "eyJ.super.secret",
+		}
+	}
+	return req
+}
+
+// TestCBP_UserCondition_ConsentBinding drives the agent-user binding end to end
+// through the pruned activation: allow when the IdP's act.sub (mapped to the
+// acting_agent metadata key) names this agent, deny when it names another.
+//
+// This is the round-trip guard for the user leg's pruning invariant, the same
+// class of defect TestCBP_PathCondition_RenamedFields covers for the agent leg:
+// if celAnalyzeRefs and buildPrincipalNS ever disagree on a key, the field is
+// pruned away and every request denies, with no compile error to catch it.
+func TestCBP_UserCondition_ConsentBinding(t *testing.T) {
+	ctx := testContext()
+
+	policy := testParsePolicy(t, `
+		path "vault-gw/gateway" {
+			capabilities = ["create"]
+			condition = "user.present && user.metadata.acting_agent == agent.principal && user.metadata.team == agent.metadata.team"
+		}
+	`)
+	cbp, err := NewCBP(ctx, []*Policy{policy})
+	require.NoError(t, err)
+
+	agentTE := &logical.TokenEntry{
+		PrincipalID: "agent-gateway",
+		Metadata:    map[string]string{"team": "platform"},
+	}
+
+	t.Run("allows when act.sub names this agent", func(t *testing.T) {
+		req := userReq("vault-gw/gateway", map[string]string{
+			"acting_agent": "agent-gateway",
+			"team":         "platform",
+		})
+		res := cbp.AllowOperation(ctx, req, agentTE, false)
+		assert.True(t, res.Allowed)
+	})
+
+	t.Run("denies when act.sub names a different agent", func(t *testing.T) {
+		req := userReq("vault-gw/gateway", map[string]string{
+			"acting_agent": "agent-other",
+			"team":         "platform",
+		})
+		res := cbp.AllowOperation(ctx, req, agentTE, false)
+		assert.False(t, res.Allowed, "a user token minted for another agent must be denied")
+
+		// Auditability is the reason this binding reads a mapped metadata key
+		// rather than indexing user.actors: both sides of the comparison have
+		// to land in the record, or the operator sees a denial without the
+		// value that caused it.
+		require.NotNil(t, res.Condition)
+		require.NotNil(t, res.Condition.Inputs)
+		assert.Equal(t, "agent-other", res.Condition.Inputs["user.metadata.acting_agent"])
+		assert.Equal(t, "agent-gateway", res.Condition.Inputs["agent.principal"])
+	})
+
+	t.Run("denies when no user credential rode the request", func(t *testing.T) {
+		res := cbp.AllowOperation(ctx, userReq("vault-gw/gateway", nil), agentTE, false)
+		assert.False(t, res.Allowed, "user.present false must deny, not error")
+		require.NotNil(t, res.Condition)
+		assert.Empty(t, res.Condition.ErrorKind, "absence is a policy decision, not an eval error")
+	})
+
+	// evaluatePathConditions seeds its field-sets from the first condition and
+	// unions the rest. With a single condition only the seed runs, so a dropped
+	// union goes unnoticed until two policies name the same path — then the
+	// second condition's user fields are pruned away and it denies on a missing
+	// key. Cross-policy OR means the binding must still allow here.
+	t.Run("unions user fields across two policies on one path", func(t *testing.T) {
+		unrelated := testParsePolicy(t, `
+			path "vault-gw/gateway" {
+				capabilities = ["create"]
+				condition = "agent.principal == 'nobody'"
+			}
+		`)
+		merged, err := NewCBP(ctx, []*Policy{unrelated, policy})
+		require.NoError(t, err)
+
+		req := userReq("vault-gw/gateway", map[string]string{
+			"acting_agent": "agent-gateway",
+			"team":         "platform",
+		})
+		res := merged.AllowOperation(ctx, req, agentTE, false)
+		assert.True(t, res.Allowed,
+			"the second policy's user.* fields must survive the field-set union")
+	})
+
+	t.Run("denies when the acting_agent mapping is absent", func(t *testing.T) {
+		// Dropping /act/sub from the role's metadata_claims removes the key, so
+		// the binding fails closed rather than silently passing.
+		req := userReq("vault-gw/gateway", map[string]string{"team": "platform"})
+		res := cbp.AllowOperation(ctx, req, agentTE, false)
+		assert.False(t, res.Allowed)
+		require.NotNil(t, res.Condition)
+		assert.Equal(t, "no_such_key", res.Condition.ErrorKind)
+	})
+}

--- a/core/policy_cel_test.go
+++ b/core/policy_cel_test.go
@@ -5,6 +5,7 @@ package core
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -56,14 +57,20 @@ func mustCompile(t *testing.T, env *cel.Env, src string) cel.Program {
 	return c.Program
 }
 
-// baseAct is a minimal request/agent activation for path-level tests.
+// baseAct is a minimal request/agent activation for path-level tests. The user
+// leg is absent (Present false), which is the common shape.
 func baseAct(req celRequestInput, agt celPrincipalInput, now time.Time) map[string]any {
-	return buildBaseActivation(req, agt, now)
+	return buildBaseActivation(req, agt, celPrincipalInput{}, now)
+}
+
+// userAct is baseAct with both legs occupied.
+func userAct(req celRequestInput, agt, usr celPrincipalInput, now time.Time) map[string]any {
+	return buildBaseActivation(req, agt, usr, now)
 }
 
 // mcpAct is a base activation plus a single call namespace.
 func mcpAct(now time.Time, tool string, args map[string]logical.ParamValue) map[string]any {
-	base := buildBaseActivation(celRequestInput{Path: "mcp/x", Operation: "update"}, celPrincipalInput{}, now)
+	base := buildBaseActivation(celRequestInput{Path: "mcp/x", Operation: "update"}, celPrincipalInput{}, celPrincipalInput{}, now)
 	return addCallToActivation(base, "tools/call", tool, args, 0)
 }
 
@@ -128,7 +135,7 @@ func TestCEL_RuntimeCostLimitDenies(t *testing.T) {
 		t.Fatalf("expected the expression to compile under the injected bound: %v", err)
 	}
 	now := time.Unix(0, 0).UTC()
-	act := buildBaseActivation(celRequestInput{Data: bigStringKeyMap(500)}, celPrincipalInput{}, now)
+	act := buildBaseActivation(celRequestInput{Data: bigStringKeyMap(500)}, celPrincipalInput{}, celPrincipalInput{}, now)
 	ok, err := evalCELCondition(c.Program, act)
 	if ok {
 		t.Fatal("cost-exceeded eval must not allow")
@@ -175,7 +182,7 @@ func TestCEL_ErrorKind(t *testing.T) {
 		t.Fatalf("seam compile: %v", err)
 	}
 	_, err = evalCELCondition(c.Program,
-		buildBaseActivation(celRequestInput{Data: bigStringKeyMap(500)}, celPrincipalInput{}, now))
+		buildBaseActivation(celRequestInput{Data: bigStringKeyMap(500)}, celPrincipalInput{}, celPrincipalInput{}, now))
 	mustErrKind("cost limit", err, "cost_exceeded")
 
 	// eval_error — any error outside the known categories maps to the catch-all.
@@ -471,7 +478,7 @@ func TestCEL_AgentFieldNames(t *testing.T) {
 	// It cannot catch a fieldSet-key/map-key disagreement, because has() short
 	// -circuits on all — TestCBP_PathCondition_RenamedFields drives the pruned
 	// path for that.
-	ns := buildPrincipalNS(agt, fieldSet{all: true})
+	ns := buildPrincipalNS(agt, fieldSet{all: true}, legAgent)
 
 	for _, k := range []string{
 		"principal", "role", "namespace", "policies", "metadata", "actors",
@@ -497,5 +504,149 @@ func TestCEL_AgentFieldNames(t *testing.T) {
 	}
 	if got := ns["token_expires_at"]; got != now.Add(time.Minute).Unix() {
 		t.Errorf("agent.token_expires_at = %v, want %v", got, now.Add(time.Minute).Unix())
+	}
+}
+
+// TestCEL_UserNamespace covers the user leg's field set: what it exposes, what
+// it deliberately does not, and how absence reads.
+func TestCEL_UserNamespace(t *testing.T) {
+	base := mustEnv(t, false)
+	now := time.Unix(1_757_404_800, 0)
+	agt := celPrincipalInput{
+		Present: true, Principal: "agent-gateway", Type: "cert_role",
+		Policies: []string{"vault-gw-bound"},
+		Metadata: map[string]string{"team": "platform"},
+	}
+	usr := celPrincipalInput{
+		Present: true, Principal: "user-8f21c3", Role: "human", Type: "jwt_role",
+		Policies: []string{"should-never-surface"},
+		Metadata: map[string]string{"team": "platform"},
+	}
+
+	t.Run("fields resolve and mirror the agent leg", func(t *testing.T) {
+		act := userAct(celRequestInput{}, agt, usr, now)
+		for _, src := range []string{
+			"user.present == true",
+			"user.principal == 'user-8f21c3'",
+			"user.role == 'human'",
+			"user.token_type == 'jwt_role'",
+			"user.metadata.team == agent.metadata.team",
+		} {
+			ok, err := evalCELCondition(mustCompile(t, base, src), act)
+			if err != nil || !ok {
+				t.Errorf("%q: ok=%v err=%v", src, ok, err)
+			}
+		}
+	})
+
+	// The user never authorizes, so exposing its policy list would invite
+	// `"admin" in user.policies` — a condition that reads like an authorization
+	// check and is not one. Suppression is at the builder, so it holds even
+	// under all:true.
+	t.Run("policies suppressed on the user leg only", func(t *testing.T) {
+		if _, ok := buildPrincipalNS(usr, fieldSet{all: true}, legUser)["policies"]; ok {
+			t.Error("user.policies must not be built")
+		}
+		if _, ok := buildPrincipalNS(agt, fieldSet{all: true}, legAgent)["policies"]; !ok {
+			t.Error("agent.policies must still be built")
+		}
+		// It is a runtime no-such-key deny, not a compile error: `user` is a
+		// dyn map, so the checker cannot reject the field.
+		act := userAct(celRequestInput{}, agt, usr, now)
+		ok, err := evalCELCondition(mustCompile(t, base, "'admin' in user.policies"), act)
+		if ok {
+			t.Error("user.policies must not evaluate true")
+		}
+		if got := celErrorKind(err); got != "no_such_key" {
+			t.Errorf("error kind = %q, want no_such_key (err: %v)", got, err)
+		}
+	})
+
+	// The user's raw credential is a bearer secret. celPrincipalInput has no
+	// field to carry it, so today this is structural — the assertion exists to
+	// fail loudly if someone ever adds one and wires it into the namespace.
+	t.Run("raw user credential cannot reach the namespace", func(t *testing.T) {
+		const secret = "eyJ.super.secret"
+		in := celUserInputFromPrincipal(&logical.UserPrincipal{
+			TokenEntry: &logical.TokenEntry{
+				PrincipalID: "user-8f21c3",
+				Metadata:    map[string]string{"team": "platform"},
+			},
+			RawToken: secret,
+		}, now)
+		for k, v := range buildPrincipalNS(in, fieldSet{all: true}, legUser) {
+			if strings.Contains(fmt.Sprint(v), secret) {
+				t.Errorf("raw user credential surfaced at user.%s", k)
+			}
+		}
+	})
+
+	t.Run("absent user leg is present=false, not an error", func(t *testing.T) {
+		act := baseAct(celRequestInput{}, agt, now) // user leg empty
+		ok, err := evalCELCondition(mustCompile(t, base, "user.present == true"), act)
+		if err != nil {
+			t.Fatalf("user.present must resolve even with no user: %v", err)
+		}
+		if ok {
+			t.Error("user.present should be false with no user credential")
+		}
+		// agent.present is always true wherever a condition evaluates.
+		ok, err = evalCELCondition(mustCompile(t, base, "agent.present == true"), act)
+		if err != nil || !ok {
+			t.Errorf("agent.present: ok=%v err=%v", ok, err)
+		}
+	})
+
+	// A condition must evaluate to bool, and a dyn-map field types as dyn — so a
+	// bare `user.present` is rejected at write time while the guard form that
+	// operators actually write compiles, because `_&&_` yields bool. This is
+	// pre-existing for every dyn-map boolean (request.transparent behaves the
+	// same); pinned here so the guard idiom cannot regress.
+	t.Run("guard idiom compiles, bare field does not", func(t *testing.T) {
+		if _, err := compileCELCondition(base, "user.present && user.metadata.team == 'platform'"); err != nil {
+			t.Errorf("guard idiom must compile: %v", err)
+		}
+		_, err := compileCELCondition(base, "user.present")
+		if err == nil {
+			t.Error("a bare dyn field is not a bool condition; expected rejection")
+		} else if !strings.Contains(err.Error(), "must evaluate to bool") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("absent metadata key fails closed", func(t *testing.T) {
+		act := userAct(celRequestInput{}, agt, usr, now)
+		ok, err := evalCELCondition(mustCompile(t, base, "user.metadata.nope == 'x'"), act)
+		if ok {
+			t.Error("absent metadata key must not allow")
+		}
+		if got := celErrorKind(err); got != "no_such_key" {
+			t.Errorf("error kind = %q, want no_such_key", got)
+		}
+	})
+}
+
+// TestCEL_UserCostEstimated proves `user` is wired into celCostEstimator.
+//
+// The discriminating assertion is the ACCEPTANCE one. A root missing from
+// EstimateSize gets no size from us and cel-go falls back to
+// UnknownSizeEstimate (MaxUint64), so a single comprehension over user.metadata
+// would estimate as infinite and be rejected at write time. Asserting that a
+// pathological expression is rejected proves nothing — that happens either way.
+func TestCEL_UserCostEstimated(t *testing.T) {
+	env := mustEnv(t, false)
+
+	// Fails iff `user` is dropped from EstimateSize.
+	if _, err := compileCELCondition(env, "user.metadata.exists(k, k == 'team')"); err != nil {
+		t.Fatalf("a single comprehension over user.metadata must compile: %v", err)
+	}
+
+	// The budget still bites for genuinely pathological input.
+	_, err := compileCELCondition(env, "user.metadata.all(k, user.metadata.all(j, k == j))")
+	if err == nil {
+		t.Fatal("nested comprehension over user.metadata should be rejected at write time")
+	}
+	if !strings.Contains(err.Error(), "exceeds limit") {
+		t.Fatalf("expected a cost-limit error, got: %v", err)
 	}
 }

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -393,7 +393,7 @@ func decideMCP(sets []*CBPMCPRules, req *logical.Request, te *logical.TokenEntry
 	case desc.Calls == nil && desc.ParseErr == nil:
 		// Backend opted out of MCP enforcement for this specific
 		// request shape (e.g. non-POST verb on a multi-method MCP
-		// endpoint). The mcp{} block doesn't apply to body-less
+		// endpoint). MCP rules don't apply to body-less
 		// verbs; return nil so the cap-level check decides.
 		return nil
 	case desc.ParseErr != nil:

--- a/core/policy_mcp.go
+++ b/core/policy_mcp.go
@@ -15,7 +15,7 @@ import (
 )
 
 // MCP rule_type values produced by AllowOperation when evaluating an
-// mcp { } block. These strings appear in audit records under
+// MCP rule-set. These strings appear in audit records under
 // auth.policy_results.mcp_decision.rule_type and the response-body
 // renderer keys off them to pick the per-rule-type message template.
 //
@@ -457,8 +457,12 @@ func evaluateMCPDescriptor(sets []*CBPMCPRules, desc *logical.MCPRequestDescript
 	// when at least one set carries a CEL condition; nil otherwise so the
 	// common no-condition path allocates nothing extra.
 	var act *celActivation
-	if reqF, agtF, callF, found := mcpConditionFields(sets); found {
-		act = newCELActivation(celRequestInputFromRequest(req, nsPath), reqF, celPrincipalInputFromEntry(te, now), agtF, now, nil)
+	if reqF, agtF, usrF, callF, found := mcpConditionFields(sets); found {
+		act = newCELActivation(
+			celRequestInputFromRequest(req, nsPath), reqF,
+			celPrincipalInputFromEntry(te, now), agtF,
+			celUserInputFromRequest(req, now), usrF,
+			now, nil)
 		act.callFields = callF
 	}
 
@@ -486,18 +490,19 @@ func evaluateMCPDescriptor(sets []*CBPMCPRules, desc *logical.MCPRequestDescript
 // sets that carry a CEL condition, and whether any condition exists. The union
 // prunes the shared per-request activation to only the fields the conditions
 // read (reused across every call in a batch).
-func mcpConditionFields(sets []*CBPMCPRules) (reqF, agtF, callF fieldSet, found bool) {
+func mcpConditionFields(sets []*CBPMCPRules) (reqF, agtF, usrF, callF fieldSet, found bool) {
 	for _, s := range sets {
 		if s == nil || s.Condition == nil {
 			continue
 		}
 		if !found {
-			reqF, agtF, callF = s.Condition.ReqFields, s.Condition.AgtFields, s.Condition.CallFields
+			reqF, agtF, usrF, callF = s.Condition.ReqFields, s.Condition.AgtFields, s.Condition.UsrFields, s.Condition.CallFields
 			found = true
 			continue
 		}
 		reqF = unionFieldSets(reqF, s.Condition.ReqFields)
 		agtF = unionFieldSets(agtF, s.Condition.AgtFields)
+		usrF = unionFieldSets(usrF, s.Condition.UsrFields)
 		callF = unionFieldSets(callF, s.Condition.CallFields)
 	}
 	return

--- a/core/policy_mcp_body_test.go
+++ b/core/policy_mcp_body_test.go
@@ -15,7 +15,7 @@ import (
 // Production switch: a request reaches AllowOperation with no
 // descriptor attached (e.g. the routed backend doesn't implement
 // MCPPolicyEnforced or declined this request) and the matched policy
-// has an mcp{} block in scope. Body-authoritative enforcement fails
+// has MCP rules in scope. Body-authoritative enforcement fails
 // CLOSED — the decision is deny with rule_type missing_body.
 func TestDecideMCP_NilDescriptorDeniesMissingBody(t *testing.T) {
 	sets := []*CBPMCPRules{{
@@ -93,13 +93,13 @@ func TestDecideMCP_DescriptorMatcherAllows(t *testing.T) {
 // ShouldEnforceMCPPolicy declines for a specific request (typically a
 // non-POST verb on a multi-method MCP endpoint). decideMCP must
 // return nil (skip evaluation) for this shape so the cap-level check
-// can decide — the mcp{} block is body-authoritative and can't
+// can decide — an MCP policy is body-authoritative and can't
 // meaningfully gate a verb the backend declared body-less.
 //
 // This is what lets MCP Streamable HTTP's GET (notification SSE
 // stream) and DELETE (session terminate) share the same URL as the
-// POST that mcp{} gates without the multi-method path tripping
-// missing_body. The nil-descriptor case (genuine misconfig: mcp{}
+// POST that an MCP policy gates without the multi-method path tripping
+// missing_body. The nil-descriptor case (genuine misconfig: MCP rules
 // bound to a non-MCP backend) still fails closed, covered by
 // TestDecideMCP_DescriptorMissingFailsClosed.
 func TestDecideMCP_EmptyDescriptorSkipsEvaluation(t *testing.T) {
@@ -115,7 +115,7 @@ func TestDecideMCP_EmptyDescriptorSkipsEvaluation(t *testing.T) {
 	assert.Nil(t, d, "decideMCP must return nil for the per-request opt-out sentinel so the cap-level check decides")
 }
 
-// Empty sets — no mcp{} block in scope — returns nil. The
+// Empty sets — no MCP rules in scope — returns nil. The
 // AllowOperation caller treats nil as "no MCP enforcement applied"
 // and continues to parameter validation.
 func TestDecideMCP_EmptySetsReturnNil(t *testing.T) {

--- a/core/policy_mcp_descriptor_test.go
+++ b/core/policy_mcp_descriptor_test.go
@@ -52,7 +52,7 @@ func TestEvaluateMCPDescriptor_BatchAllAllowed(t *testing.T) {
 }
 
 // Empty descriptor (zero calls) returns nil — the caller is
-// responsible for denying when an mcp{} block is in scope but no body
+// responsible for denying when MCP rules are in scope but no body
 // was parseable. decideMCP handles that in the evaluator wrapper.
 func TestEvaluateMCPDescriptor_NoCallsReturnsNil(t *testing.T) {
 	sets := []*CBPMCPRules{{

--- a/core/policy_mcp_e2e_test.go
+++ b/core/policy_mcp_e2e_test.go
@@ -63,7 +63,7 @@ func (b *mcpMockBackendAlt) ShouldEnforceMCPPolicy(_ *logical.Request) (bool, in
 
 // nonMCPBackend deliberately does NOT implement MCPPolicyEnforced.
 // Used to prove the extractor fails the type assertion and leaves the
-// descriptor nil, so decideMCP denies missing_body when mcp{} is in
+// descriptor nil, so decideMCP denies missing_body when MCP rules are in
 // scope.
 type nonMCPBackend struct {
 	logical.Backend
@@ -394,14 +394,14 @@ path "mcp/gateway/*" {
 
 // =============================================================================
 // Opt-out paths — the backend declines per-request or doesn't
-// implement the marker at all. With mcp{} in scope this is a deny
-// (defence in depth); without mcp{} this is a clean passthrough.
+// implement the marker at all. With MCP rules in scope this is a deny
+// (defence in depth); without them this is a clean passthrough.
 // =============================================================================
 
 // Backend opts out per-request (ShouldEnforceMCPPolicy returns false)
-// and mcp{} is in scope → request passes through. This is the canonical
+// and MCP rules are in scope → request passes through. This is the canonical
 // MCP Streamable HTTP shape: GET on the same /gateway URL as the POST
-// that mcp{} gates. The body-authoritative block can't meaningfully
+// that an MCP policy gates. Body-authoritative rules can't meaningfully
 // apply to a verb the backend declared body-less, so decideMCP skips
 // evaluation and the cap-level check decides. Without this behavior,
 // every MCP-spec-compliant client that opens an SSE notification
@@ -430,11 +430,11 @@ path "mcp/gateway/*" {
 
 	assert.True(t, res.Allowed)
 	assert.Nil(t, res.MCPDecision,
-		"empty sentinel skips mcp{} evaluation; cap-level check decides")
+		"empty sentinel skips MCP evaluation; cap-level check decides")
 }
 
-// Same opt-out, no mcp{} in scope → matcher never runs, request
-// passes through cleanly. Symmetry with the mcp{}-in-scope test: the
+// Same opt-out, no MCP rules in scope → matcher never runs, request
+// passes through cleanly. Symmetry with the rules-in-scope test: the
 // empty sentinel is installed either way, and decideMCP isn't even
 // called because permissions.MCP is empty.
 func TestMCPE2E_PerRequestOptOut_NoMCPBlock_PassesThrough(t *testing.T) {
@@ -447,7 +447,7 @@ path "mcp/gateway/*" {
 	runExtract(req, &mcpMockBackend{enforce: false, cap: 0})
 
 	require.NotNil(t, req.MCPDescriptor,
-		"opt-out installs the empty sentinel regardless of whether mcp{} is in scope")
+		"opt-out installs the empty sentinel regardless of whether MCP rules are in scope")
 	require.Nil(t, req.MCPDescriptor.Calls)
 	require.Nil(t, req.MCPDescriptor.ParseErr)
 

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -170,7 +170,7 @@ func (c *Core) CheckToken(ctx context.Context, req *logical.Request, unauth bool
 	auth.PolicyResults = &sdklogical.PolicyResults{
 		Allowed: accessControlResults.Allowed,
 	}
-	// Carry the MCP decision (when an mcp { } rule-set was consulted)
+	// Carry the MCP decision (when an MCP rule-set was consulted)
 	// through to buildAuditAuth — that's where it gets surfaced in the
 	// audit record — and to the deny-response path below for the
 	// typed-error wrap.
@@ -187,7 +187,7 @@ func (c *Core) CheckToken(ctx context.Context, req *logical.Request, unauth bool
 
 		if accessControlResults.Error.ErrorOrNil() == nil || accessControlResults.DeniedError {
 			// Wrap the permission-denied error with the MCP decision
-			// when the denial came from an mcp { } gate, so the HTTP
+			// when the denial came from an MCP gate, so the HTTP
 			// layer can render the OAuth-shaped 403 body. Unwrap()
 			// returns ErrPermissionDenied so every existing
 			// errors.Is(err, ErrPermissionDenied) call site keeps

--- a/core/request_handler_mcp_test.go
+++ b/core/request_handler_mcp_test.go
@@ -69,7 +69,7 @@ func TestExtractMCPDescriptor_NotMCPBackend(t *testing.T) {
 // (non-nil, no Calls, no ParseErr). decideMCP uses this to distinguish
 // "backend declined for this request shape" from "no MCP-aware backend
 // at all", which lets MCP Streamable HTTP's GET/DELETE share the URL
-// with the POST that mcp{} gates.
+// with the POST that an MCP policy gates.
 func TestExtractMCPDescriptor_OptsOutPerRequest(t *testing.T) {
 	c := &Core{}
 	req := newReq(t, `{"jsonrpc":"2.0","method":"tools/list"}`)

--- a/logical/auth.go
+++ b/logical/auth.go
@@ -35,10 +35,10 @@ type Auth struct {
 	// requesting path.
 	PolicyResults *sdklogical.PolicyResults `json:"policy_results"`
 
-	// MCPDecision carries the MCP-specific policy decision when an mcp { }
-	// block was consulted during CBP evaluation. nil when no such block
-	// applied (every non-MCP request, plus MCP-mount requests whose bound
-	// policies contain no mcp block). Flows through buildAuditAuth into
+	// MCPDecision carries the MCP-specific policy decision when an MCP
+	// rule-set was consulted during CBP evaluation. nil when no rule-set
+	// applied (every non-MCP request, plus MCP-mount requests with no MCP
+	// policy rule-set at the path). Flows through buildAuditAuth into
 	// audit.PolicyResults.MCPDecision and is also consumed by the
 	// deny-response path to populate the WWW-Authenticate header and the
 	// OAuth-shaped 403 body.
@@ -77,7 +77,7 @@ type Auth struct {
 	Metadata map[string]string
 }
 
-// MCPDecision records the outcome of evaluating an mcp { } policy block
+// MCPDecision records the outcome of evaluating an MCP rule-set
 // against a request. Populated on every branch (allow and deny) so the
 // audit layer can render the decision unconditionally. The JSON tags
 // double as the wire shape exposed in audit records under
@@ -161,7 +161,7 @@ type MCPDecision struct {
 	// which set's deny surfaces on a multi-set deny.
 	BatchIndex *int `json:"batch_index,omitempty"`
 
-	// Condition carries the CEL condition decision when an mcp{} condition
+	// Condition carries the CEL condition decision when an MCP policy condition
 	// was evaluated for this call. Populated when RuleType is "condition" or
 	// "condition_error"; nil when no condition applied.
 	Condition *ConditionResult `json:"condition,omitempty"`

--- a/logical/mcp_list_filter.go
+++ b/logical/mcp_list_filter.go
@@ -7,7 +7,7 @@ package logical
 // items the caller is actually allowed to use, so discovery matches
 // enforcement: what an agent sees in tools/list is what it can call.
 //
-// The policy layer builds it (over the matched mcp{} rule-sets) and hangs it
+// The policy layer builds it (over the matched MCP rule-sets) and hangs it
 // on Request.MCPListFilter when it allows a list request whose family the
 // policy governs. A gateway that finds it non-nil buffers the upstream list
 // response and drops every item whose name Keep rejects; a nil filter means

--- a/provider/mcp/provider_test.go
+++ b/provider/mcp/provider_test.go
@@ -102,7 +102,7 @@ func TestExtractBearerToken_UnsupportedType(t *testing.T) {
 }
 
 // The enforcement gate decides whether a request is subject to body-authoritative
-// mcp { } rules. It has to decline anything whose body is not a JSON-RPC call —
+// MCP rules. It has to decline anything whose body is not a JSON-RPC call —
 // SSE reconnects and session closes carry no method to authorise — while
 // admitting every shape a real client's POST takes.
 


### PR DESCRIPTION
Stacked on #624 — review that first.

Warden resolves two principals on a gateway request: the agent, which authorizes, and the user it acts for, which is identity-only. Only the agent was visible to policy conditions, so a rule could not require that the two belong together. This adds a `user` namespace beside `agent`, sharing the same builder:

```
user.present && user.metadata.acting_agent == agent.principal
```

## Where the consent value comes from

A binding is decided cryptographically at the IdP and enforced here per request; where the IdP decided nothing, the gateway decides and enforces in one step.

When the IdP decides, it attests the pairing with the RFC 8693 `act` claim — "agent A acting for user B" — which on a *user* token names the agent. A role maps it with a JSON Pointer:

```hcl
metadata_claims { "/act/sub" = "acting_agent" }
```

**Why a mapped metadata key rather than indexing `user.actors`:** an indexed select contributes no audit path (`celAnalyzeRefs` skips the index operand), so `user.actors[0].subject == agent.principal` would record the agent it compared against but not the actor that caused the mismatch — the half an operator needs. A missing `act` claim is also a clean `no_such_key` deny, since `extractMetadata` skips absent claims rather than erroring.

## What is deliberately absent

`user.policies`. The user never authorizes, so `"admin" in user.policies` would read like an authorization check that it is not. Suppression lives in the builder rather than in the caller's field-set, so a future field-set path cannot reintroduce it by forgetting.

Two exposed fields are mount-level constants and are documented as such: `user.role` is the auth-mount role fixed by `user_auth_role` — **not** the person's organizational role — and `user.namespace` always equals `request.namespace`. Gate on `user.metadata.<k>`. Both are pinned by tests so the caveat is enforced rather than resting on a doc paragraph.

## A limitation worth knowing

A condition must evaluate to bool while a dyn-map field types as `dyn`, so a bare `user.present` is rejected at write time. It works as a guard, which is how it is meant to be written. Pre-existing for every dyn-map boolean (`request.transparent` behaves the same), not introduced here.

## Testing

Two field-set seams decide whether a user condition evaluates at all, and both fail silently when wrong — a pruned-away field is a runtime `no_such_key` deny, not a compile error. Tests drive the full compile → analyze → prune → eval path for the path-level and MCP evaluators, covering both the **seed** and **union** arms of each: a single user rule-set is what an operator writes first, and two policies naming one path is what exercises the union. Both verified by mutation.

The second commit removes the last traces of the deleted `mcp { }` block — ~30 stale comments across `core`, `logical` and `provider`, plus unreachable canonicalisation in `parsePaths` that the removal guard makes unreachable.

Full unit suite and `go vet` clean.