### PR TITLE
test(e2e): prove agent-user binding end to end

### DIFF
--- a/e2e/helpers/userleg_helpers.go
+++ b/e2e/helpers/userleg_helpers.go
@@ -5,6 +5,7 @@ package helpers
 import (
 	"crypto/ecdsa"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -268,4 +269,139 @@ func UserLegRequest(t *testing.T, port int, agentCertPEM string, headers map[str
 	}
 	u := fmt.Sprintf("%s/v1/%s/gateway/v1/secret/data/e2e/app-config", NodeURL(port), UserLegMount)
 	return DoRequest(t, "GET", u, all, "")
+}
+
+// =============================================================================
+// Agent-user binding
+// =============================================================================
+//
+// A binding is decided cryptographically at the IdP and enforced at the gateway,
+// per request. Where the IdP has decided nothing, the gateway decides and
+// enforces in one step. Both land on the same machinery — a CEL condition
+// comparing a value carried on the USER's token against the agent's own identity
+// — and differ only in where the compared value came from.
+//
+// When the IdP decided: it attests the pairing with RFC 8693 `act.sub` ("agent A
+// acting for user B"), mapped with a JSON Pointer,
+// metadata_claims { "/act/sub" = "acting_agent" }, and the gateway verifies the
+// agent presenting the request is the one attested.
+//
+// This harness runs the other case. Hydra's client_credentials grant emits no
+// `act` claim, so there is no IdP decision to enforce and the rule is decided
+// here: the user's own `sub` must match the agent's principal. The claim
+// mapping, the condition layer and the per-request evaluation are the same; only
+// the provenance of the compared value differs — so what stays unexercised is
+// the JSON Pointer into a nested `act` claim, which is unit-covered instead.
+const (
+	// UserLegBindingPolicy carries the binding condition. It deliberately does
+	// NOT also grant the unconditioned `-access` policy: conditions merge with
+	// OR across policies covering one path, so attaching both would let the
+	// unconditioned grant allow everything and the binding would prove nothing.
+	UserLegBindingPolicy = "e2e-userleg-binding"
+
+	// UserLegBoundRole is a cert role whose allowed CN is the value the user's
+	// mapped claim carries, so a certificate minted with that CN satisfies the
+	// binding.
+	UserLegBoundRole = "e2e-userleg-bound"
+
+	// UserLegUnboundRole is a cert role for the stock `agent-*` certificates.
+	// It carries the same binding policy, so a request through it is denied by
+	// the CONDITION rather than by authorization — which is what makes the deny
+	// case evidence of the binding working.
+	UserLegUnboundRole = "e2e-userleg-unbound"
+
+	// UserLegActingAgentKey is the metadata key the mapped claim lands on.
+	UserLegActingAgentKey = "acting_agent"
+)
+
+// SetupUserLegBinding installs the binding policy, the two cert roles, and the
+// claim mapping on the user role. actingAgent is the value the user's mapped
+// claim will carry; the caller reads it off the actual user token rather than
+// assuming it, so the fixture cannot drift from what the IdP issues.
+func SetupUserLegBinding(t *testing.T, port int, actingAgent string) {
+	t.Helper()
+
+	policy := fmt.Sprintf(
+		`path \"%s/gateway*\" {\n  capabilities = [\"read\",\"create\",\"update\",\"delete\",\"list\"]\n  condition = \"user.present && user.metadata.%s == agent.principal\"\n}`,
+		UserLegMount, UserLegActingAgentKey)
+	mustAPI(t, port, "POST", "sys/policies/cbp/"+UserLegBindingPolicy,
+		fmt.Sprintf(`{"policy":"%s"}`, policy), "create binding policy")
+
+	// Map the claim onto the user role. Additive: other tests read the user's
+	// identity, not its metadata, so they are unaffected.
+	//
+	// Role writes are create-only — a POST over an existing role is a 409, not
+	// an update — so every mutation here deletes first. Setup must be
+	// re-runnable: these tests share one role and each installs the fixture.
+	SetUserLegClaimMapping(t, port, true)
+
+	for role, cns := range map[string]string{
+		UserLegBoundRole:   fmt.Sprintf("%q", actingAgent),
+		UserLegUnboundRole: `"agent-*"`,
+	} {
+		APIRequest(t, "DELETE", "auth/cert/role/"+role, port, "")
+		mustAPI(t, port, "POST", "auth/cert/role/"+role,
+			fmt.Sprintf(`{"allowed_common_names":[%s],"token_policies":["%s"],"cred_spec_name":"vault-token-reader","token_ttl":3600}`,
+				cns, UserLegBindingPolicy),
+			"create cert role "+role)
+	}
+}
+
+// SetUserLegClaimMapping rewrites the user role with or without the
+// acting-agent claim mapping, so a test can remove the mapping and watch the
+// binding fail closed.
+func SetUserLegClaimMapping(t *testing.T, port int, mapped bool) {
+	t.Helper()
+	body := `{"user_claim":"sub","token_ttl":3600}`
+	if mapped {
+		body = fmt.Sprintf(`{"user_claim":"sub","metadata_claims":{"sub":%q},"token_ttl":3600}`,
+			UserLegActingAgentKey)
+	}
+	APIRequest(t, "DELETE", "auth/user-jwt/role/"+UserLegAuthRole, port, "")
+	mustAPI(t, port, "POST", "auth/user-jwt/role/"+UserLegAuthRole, body, "write user role")
+}
+
+// TeardownUserLegBinding removes what SetupUserLegBinding created and restores
+// the user role to its unmapped shape.
+func TeardownUserLegBinding(t *testing.T, port int) {
+	t.Helper()
+	APIRequest(t, "DELETE", "auth/cert/role/"+UserLegBoundRole, port, "")
+	APIRequest(t, "DELETE", "auth/cert/role/"+UserLegUnboundRole, port, "")
+	APIRequest(t, "DELETE", "sys/policies/cbp/"+UserLegBindingPolicy, port, "")
+	SetUserLegClaimMapping(t, port, false)
+}
+
+// UserLegRequestAs is UserLegRequest against a caller-chosen cert role, so a
+// test can drive the same mount through roles with different bound CNs.
+func UserLegRequestAs(t *testing.T, port int, role, agentCertPEM string, headers map[string]string) (int, []byte) {
+	t.Helper()
+	all := map[string]string{"X-Warden-Role": role}
+	if agentCertPEM != "" {
+		all["X-SSL-Client-Cert"] = URLEncodePEM(agentCertPEM)
+	}
+	for k, v := range headers {
+		all[k] = v
+	}
+	u := fmt.Sprintf("%s/v1/%s/gateway/v1/secret/data/e2e/app-config", NodeURL(port), UserLegMount)
+	return DoRequest(t, "GET", u, all, "")
+}
+
+// JWTSubject returns the `sub` claim of a compact JWS, so a test can bind a
+// fixture to the identity the IdP actually issued instead of hardcoding it.
+func JWTSubject(t *testing.T, token string) string {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		t.Fatalf("not a compact JWS: %d segments", len(parts))
+	}
+	var claims struct {
+		Sub string `json:"sub"`
+	}
+	if err := json.Unmarshal(DecodeJWTSegment(t, parts[1]), &claims); err != nil {
+		t.Fatalf("decode JWT claims: %v", err)
+	}
+	if claims.Sub == "" {
+		t.Fatal("user token carries no sub claim; the binding fixture has nothing to bind to")
+	}
+	return claims.Sub
 }

--- a/e2e/userleg/binding_test.go
+++ b/e2e/userleg/binding_test.go
@@ -1,0 +1,160 @@
+//go:build e2e
+
+package userleg
+
+import (
+	"strings"
+	"testing"
+
+	h "github.com/stephnangue/warden/e2e/helpers"
+)
+
+// =============================================================================
+// Agent-user binding
+// =============================================================================
+//
+// The user leg proves who the human is. A binding additionally ties that human
+// to the agent acting for them, so an agent cannot pair itself with any user
+// token it happens to obtain.
+//
+// The decision can be made at the IdP — attested cryptographically on the user's
+// token — and enforced here per request; or, where the IdP has decided nothing,
+// decided and enforced here in one step. Either way the gateway compares a value
+// carried on the user's token against the agent actually presenting the request.
+// These tests run the second case; SetupUserLegBinding explains why and what it
+// leaves to unit coverage.
+//
+// This is the only place the whole chain runs: a claim on a real IdP-issued
+// token, through the role's metadata_claims, into a CEL condition evaluated
+// against the live agent. The unit tests fabricate req.User by hand and start at
+// the CEL layer, so they cannot catch a break in captureUserContext, in the
+// claim mapping, or in the order the two principals are resolved.
+
+// bindingEnv installs the binding fixture and returns the identity the user's
+// mapped claim carries, read off the token the IdP actually issued.
+func bindingEnv(t *testing.T) string {
+	t.Helper()
+	ensureEnv(t)
+	actingAgent := h.JWTSubject(t, h.UserJWT(t))
+	h.SetupUserLegBinding(t, leaderPort, actingAgent)
+	t.Cleanup(func() { h.TeardownUserLegBinding(t, leaderPort) })
+	return actingAgent
+}
+
+// TestBinding_MatchingAgentAllowed is the case the binding exists to permit: the
+// agent the user's token names is the agent presenting the request.
+//
+// The certificate CN is derived from the token rather than hardcoded. A literal
+// would make this pass or fail on whether it still matches what the IdP issues,
+// which is not what is under test.
+func TestBinding_MatchingAgentAllowed(t *testing.T) {
+	actingAgent := bindingEnv(t)
+
+	cert, _ := h.GenerateClientCert(t, agentCAPEM, agentCAKey, actingAgent)
+	status, body := h.UserLegRequestAs(t, leaderPort, h.UserLegBoundRole, cert,
+		map[string]string{"Authorization": "Bearer " + h.UserJWT(t)})
+
+	if status != 200 {
+		t.Fatalf("agent %q matches the user's claim and must be allowed, got %d: %s",
+			actingAgent, status, string(body))
+	}
+}
+
+// TestBinding_MismatchedAgentDenied is the case it exists to refuse: same user
+// token, different agent.
+//
+// Both cert roles carry the same policy and the same capabilities, so a denial
+// here can only come from the condition. Had they differed in authorization this
+// would pass for the wrong reason — and keep passing with the binding removed.
+func TestBinding_MismatchedAgentDenied(t *testing.T) {
+	bindingEnv(t)
+
+	// CN "agent-userleg": a legitimate agent, just not this user's.
+	status, body := h.UserLegRequestAs(t, leaderPort, h.UserLegUnboundRole, agentCert(t),
+		map[string]string{"Authorization": "Bearer " + h.UserJWT(t)})
+
+	if status == 200 {
+		t.Fatalf("a user token naming another agent must not be accepted, got 200: %s", string(body))
+	}
+	if status != 403 {
+		t.Errorf("expected a policy denial (403), got %d: %s", status, string(body))
+	}
+}
+
+// TestBinding_MissingUserDenied covers `user.present`. A user credential is
+// optional on a protected-resource mount, so its absence has to be a decision
+// the condition makes — not an error, and not a silent allow.
+//
+// Uses the same certificate that succeeds in TestBinding_MatchingAgentAllowed,
+// so the only difference is the missing Authorization header.
+func TestBinding_MissingUserDenied(t *testing.T) {
+	actingAgent := bindingEnv(t)
+
+	cert, _ := h.GenerateClientCert(t, agentCAPEM, agentCAKey, actingAgent)
+	status, body := h.UserLegRequestAs(t, leaderPort, h.UserLegBoundRole, cert, nil)
+
+	if status == 200 {
+		t.Fatalf("a bound path must not be reachable without a user credential, got 200: %s", string(body))
+	}
+	if status != 403 {
+		t.Errorf("absence of a user is a policy denial, not an error; got %d: %s", status, string(body))
+	}
+}
+
+// TestBinding_UnmappedClaimDenies is the fail-closed property that makes the
+// binding safe to rely on. Removing the claim mapping — the misconfiguration an
+// operator is most likely to make — must deny, because the condition then reads
+// a metadata key that no longer exists.
+func TestBinding_UnmappedClaimDenies(t *testing.T) {
+	actingAgent := bindingEnv(t)
+
+	// Drop metadata_claims, leaving everything else in place.
+	h.SetUserLegClaimMapping(t, leaderPort, false)
+
+	cert, _ := h.GenerateClientCert(t, agentCAPEM, agentCAKey, actingAgent)
+	status, body := h.UserLegRequestAs(t, leaderPort, h.UserLegBoundRole, cert,
+		map[string]string{"Authorization": "Bearer " + h.UserJWT(t)})
+
+	if status == 200 {
+		t.Fatalf("an unmapped claim must fail closed, not pass: %s", string(body))
+	}
+}
+
+// TestBinding_AuditRecordsBothSides is why the binding compares a mapped
+// metadata key rather than indexing user.actors: an indexed select contributes
+// no audit path, so a denial would record the agent it compared against but not
+// the value that failed to match — the half an operator needs to debug it.
+func TestBinding_AuditRecordsBothSides(t *testing.T) {
+	bindingEnv(t)
+
+	status, _ := h.UserLegRequestAs(t, leaderPort, h.UserLegUnboundRole, agentCert(t),
+		map[string]string{"Authorization": "Bearer " + h.UserJWT(t)})
+	if status == 200 {
+		t.Fatal("expected the mismatch to be denied")
+	}
+
+	wantKeys := []string{"user.metadata." + h.UserLegActingAgentKey, "agent.principal"}
+	nodeNum := h.NodeNumberForPort(leaderPort)
+
+	var found bool
+	for _, e := range h.ReadAuditEntries(t, nodeNum, h.UserLegMount) {
+		if e.Auth == nil || e.Auth.PolicyResults == nil || e.Auth.PolicyResults.Condition == nil {
+			continue
+		}
+		cond := e.Auth.PolicyResults.Condition
+		if cond.Decision != "deny" || cond.Inputs == nil ||
+			!strings.Contains(cond.Expression, h.UserLegActingAgentKey) {
+			continue
+		}
+		found = true
+		for _, k := range wantKeys {
+			if _, ok := cond.Inputs[k]; !ok {
+				t.Errorf("denial audit is missing input %q; recorded: %v", k, cond.Inputs)
+			}
+		}
+		break
+	}
+	if !found {
+		t.Error("no audited condition result carried the binding denial — the deciding inputs are unrecoverable")
+	}
+}


### PR DESCRIPTION
Stacked on #625 — review that first.

The unit tests fabricate `req.User` by hand and start at the CEL layer, so nothing covered the chain the feature actually runs on: a claim on a real IdP-issued token, through the role's `metadata_claims`, into a condition evaluated against the agent presenting the request. A break in `captureUserContext`, in the claim mapping, or in the order the two principals resolve would have gone unnoticed.

## Cases

Five, against the live cluster: the named agent is allowed; a different agent carrying the same user token is denied; a request with no user credential is denied; dropping the claim mapping fails closed; and a denial records both compared values in the audit entry.

**Both cert roles carry the same policy and the same capabilities**, so a denial can only come from the condition. Had they differed in authorization the deny tests would have passed for the wrong reason and kept passing with the binding removed — verified by removing the condition and watching all four fail while the allow case still passed.

The agent certificate's CN is derived from the user token at runtime rather than hardcoded, so the fixture cannot drift from what the IdP issues.

## What this does not cover

Hydra's `client_credentials` grant emits no RFC 8693 `act` claim, so there is no IdP attestation to enforce and the fixture maps the user's own `sub` — the gateway decides the rule itself. Everything downstream of the claim is identical: the mapping, `user.metadata.<k>`, the condition, the per-request evaluation. What stays unexercised is the JSON Pointer into a nested `act` claim, which is unit-covered in `auth/method/jwt` instead. `SetupUserLegBinding` says so at the point someone would need to know.

Closing it would mean adding a token-hook webhook to `e2e/docker-compose.yml` to inject `act` — disproportionate against a gap one config key wide.

## Fixture notes

Role writes are create-only — a POST over an existing role is a 409, not an update — so the fixture deletes before writing and setup is re-runnable across tests that share a role.

Full `e2e/userleg` package green.