### PR TITLE
feat(policy): challenge instead of forbidding when a policy needs a user

### DIFF
--- a/core/policy_cel.go
+++ b/core/policy_cel.go
@@ -124,11 +124,20 @@ type celRequestInput struct {
 // and `user` namespaces. Decoupled from *logical.TokenEntry so the activation
 // builder stays unit-testable; the wiring layer adapts the token entry into this.
 type celPrincipalInput struct {
-	// Present is false when no principal occupied this leg. It exists so an
-	// operator can write `user.present && …`: a user credential is optional on
-	// a protected-resource mount, and without this field its absence would be a
-	// missing-key deny that reads as a bug rather than a policy decision. On the
-	// agent leg it is always true wherever a condition evaluates, since
+	// Present is false when no principal occupied this leg.
+	//
+	// It is how a condition requires *a* user without depending on any
+	// particular claim — `user.present && agent.principal == "x"` has nothing
+	// else to carry the requirement. The alternative, `user.principal != ""`,
+	// leans on zero-value semantics to mean absence, which is exactly the
+	// implicitness this field removes.
+	//
+	// It also keeps absence a clean deny rather than a no_such_key error, which
+	// matters for how the audit record reads — though both now reach the same
+	// 401 and user challenge, since ConditionResult.UserAbsent is set from the
+	// whole condition list rather than from which branch produced the denial.
+	//
+	// On the agent leg it is always true wherever a condition evaluates, since
 	// CheckToken has a token entry by then.
 	Present       bool
 	Principal     string
@@ -919,10 +928,11 @@ func evaluatePathConditions(conds []*compiledCondition, req *logical.Request, te
 		agtF = unionFieldSets(agtF, c.AgtFields)
 		usrF = unionFieldSets(usrF, c.UsrFields)
 	}
+	usr := celUserInputFromRequest(req, now)
 	act := newCELActivation(
 		celRequestInputFromRequest(req, nsPath), reqF,
 		celPrincipalInputFromEntry(te, now), agtF,
-		celUserInputFromRequest(req, now), usrF,
+		usr, usrF,
 		now, nil)
 
 	var deciding *logical.ConditionResult
@@ -943,8 +953,35 @@ func evaluatePathConditions(conds []*compiledCondition, req *logical.Request, te
 			deciding = &logical.ConditionResult{Decision: "deny", Expression: c.Source, Inputs: resolveConditionInputs(c.RefPaths, c.RefSegs, act)}
 		}
 	}
+	// Set here, at the single deny return, rather than where `deciding` is
+	// built. There are two construction sites — the error branch above and the
+	// false branch — and an unguarded `user.metadata.x == …` takes the ERROR one
+	// when no user is present (metadata binds to emptyStringMap, so the access is
+	// a no_such_key), while the guarded `user.present && …` takes the false one.
+	// Setting the flag in either branch alone would hand one of the two most
+	// common policy shapes a bare 403 while the other got a challenge.
+	//
+	// Sanitize only rewrites strings, so the flag survives it either way.
+	deciding.UserAbsent = !usr.Present && conditionsReferenceUser(conds)
 	deciding.Sanitize()
 	return false, deciding
+}
+
+// conditionsReferenceUser reports whether any condition reads the `user`
+// namespace. Because the gate ORs, a deny means every condition failed — so a
+// user credential can only change the outcome if at least one of them looks at
+// the user at all.
+//
+// This is a compile-time reference check, not a satisfiability one: it answers
+// "might a user matter here", never "would a user pass". See
+// ConditionResult.UserAbsent.
+func conditionsReferenceUser(conds []*compiledCondition) bool {
+	for _, c := range conds {
+		if c.UsrFields.all || len(c.UsrFields.fields) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveConditionInputs snapshots the values of the expression's referenced

--- a/core/policy_cel_path_test.go
+++ b/core/policy_cel_path_test.go
@@ -422,6 +422,113 @@ func userReq(path string, userMeta map[string]string) *logical.Request {
 	return req
 }
 
+// TestCBP_UserAbsent covers the flag that turns a policy denial into a user
+// challenge. Its whole job is to answer "might acquiring a user change this?",
+// so the cases that must NOT set it matter as much as the ones that must.
+func TestCBP_UserAbsent(t *testing.T) {
+	ctx := testContext()
+	agentTE := &logical.TokenEntry{
+		PrincipalID: "agent-gateway",
+		Metadata:    map[string]string{"team": "platform"},
+	}
+
+	denyWith := func(t *testing.T, condition string, req *logical.Request) *logical.ConditionResult {
+		t.Helper()
+		policy := testParsePolicy(t, `
+			path "vault-gw/gateway" {
+				capabilities = ["create"]
+				condition = "`+condition+`"
+			}
+		`)
+		cbp, err := NewCBP(ctx, []*Policy{policy})
+		require.NoError(t, err)
+		res := cbp.AllowOperation(ctx, req, agentTE, false)
+		require.False(t, res.Allowed)
+		require.NotNil(t, res.Condition)
+		return res.Condition
+	}
+
+	noUser := func() *logical.Request {
+		return &logical.Request{Operation: logical.CreateOperation, Path: "vault-gw/gateway"}
+	}
+
+	// The guarded shape: user.present short-circuits, so this is a clean false.
+	t.Run("guarded condition, user absent", func(t *testing.T) {
+		c := denyWith(t, "user.present && user.metadata.acting_agent == agent.principal", noUser())
+		assert.True(t, c.UserAbsent)
+		assert.Empty(t, c.ErrorKind, "the guard makes absence a decision, not an error")
+	})
+
+	// The unguarded shape takes the ERROR branch instead — user.metadata binds
+	// to an empty map, so the access is a no_such_key. An implementation that
+	// set the flag only where `deciding` is built on the false branch would give
+	// this shape a bare 403 while the guarded one got a challenge.
+	t.Run("unguarded condition, user absent", func(t *testing.T) {
+		c := denyWith(t, "user.metadata.acting_agent == agent.principal", noUser())
+		assert.True(t, c.UserAbsent, "the error branch must set the flag too")
+		assert.Equal(t, "no_such_key", c.ErrorKind)
+	})
+
+	// A user IS present and simply does not match. Acquiring one cannot help —
+	// they already have one.
+	t.Run("user present but mismatched", func(t *testing.T) {
+		req := noUser()
+		req.User = &logical.UserPrincipal{
+			TokenEntry: &logical.TokenEntry{Metadata: map[string]string{"acting_agent": "agent-other"}},
+		}
+		c := denyWith(t, "user.present && user.metadata.acting_agent == agent.principal", req)
+		assert.False(t, c.UserAbsent)
+	})
+
+	// No condition reads the user, so a user is irrelevant to the outcome.
+	t.Run("condition does not reference the user", func(t *testing.T) {
+		c := denyWith(t, "agent.principal == 'someone-else'", noUser())
+		assert.False(t, c.UserAbsent)
+	})
+
+	// Deny means every OR'd condition failed, so a user-referencing one anywhere
+	// in the list is enough — even when an unrelated condition is the one
+	// recorded as deciding.
+	t.Run("mixed list, only one references the user", func(t *testing.T) {
+		a := testParsePolicy(t, `path "vault-gw/gateway" { capabilities = ["create"] condition = "agent.principal == 'nobody'" }`)
+		// `== true` because a condition must evaluate to bool and a dyn-map field
+		// types as dyn; a bare `user.present` is rejected at write time.
+		b := testParsePolicy(t, `path "vault-gw/gateway" { capabilities = ["create"] condition = "user.present == true" }`)
+		cbp, err := NewCBP(ctx, []*Policy{a, b})
+		require.NoError(t, err)
+		res := cbp.AllowOperation(ctx, noUser(), agentTE, false)
+		require.False(t, res.Allowed)
+		require.NotNil(t, res.Condition)
+		assert.True(t, res.Condition.UserAbsent)
+	})
+
+	// A capability denial returns before the condition gate, so there is no
+	// ConditionResult at all and nothing can be converted to a challenge.
+	t.Run("capability deny produces no condition result", func(t *testing.T) {
+		policy := testParsePolicy(t, `path "vault-gw/gateway" { capabilities = ["read"] condition = "user.present == true" }`)
+		cbp, err := NewCBP(ctx, []*Policy{policy})
+		require.NoError(t, err)
+		res := cbp.AllowOperation(ctx, noUser(), agentTE, false) // create, not read
+		assert.False(t, res.Allowed)
+		assert.Nil(t, res.Condition)
+	})
+
+	// The flag is a syntactic over-approximation: this condition can never pass
+	// however good the user token is. It still draws the flag, so the client
+	// makes one wasted round trip — but the retry arrives WITH a user, which
+	// clears the flag and terminates at a 403. Pins that it cannot loop.
+	t.Run("unsatisfiable user condition terminates", func(t *testing.T) {
+		const cond = "user.present && agent.principal == 'alice'"
+		first := denyWith(t, cond, noUser())
+		assert.True(t, first.UserAbsent, "over-approximates: a user might have helped")
+
+		withUser := noUser()
+		withUser.User = &logical.UserPrincipal{TokenEntry: &logical.TokenEntry{}}
+		second := denyWith(t, cond, withUser)
+		assert.False(t, second.UserAbsent, "retry must not draw a second challenge")
+	})
+}
+
 // TestCBP_UserCondition_ConsentBinding drives the agent-user binding end to end
 // through the pruned activation: allow when the IdP's act.sub (mapped to the
 // acting_agent metadata key) names this agent, deny when it names another.

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -824,6 +824,13 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 	// Help requests are never streaming - they should return help text, not proxy upstream.
 	isStreaming := c.isStreamingRequest(ctx, req.Path) && req.Operation != logical.HelpOperation
 
+	// Whether this mount is a protected resource — i.e. whether a user
+	// credential can be presented at all. Resolved inside the streaming branch
+	// below, but declared here so the policy-denial path can read it: a deny
+	// that a user might remedy is answered with a challenge only when there is
+	// somewhere to send the client.
+	var userLegMount bool
+
 	if !isStreaming {
 		if err := c.parseRequestBody(req); err != nil {
 			return logical.ErrorResponse(err), nil, nil
@@ -938,6 +945,7 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 		// rule collapses to the pre-0.20 behaviour and userCred stays empty.
 		userAuthPath, userAuthRole := c.resolveUserAuthConfig(ctx, matchingBackend)
 		userLeg := userAuthPath != ""
+		userLegMount = userLeg
 
 		// Reject the one genuinely ambiguous credential combination rather than
 		// resolving it silently. X-Warden-Token is the operator credential and
@@ -1108,6 +1116,24 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 				resp = nil
 			} else {
 				resp = logical.ErrorResponse(ctErr)
+			}
+
+			// A policy denied because no user rode a request that could have
+			// carried one. 403 is the wrong answer: nothing in a real client
+			// stack acts on it, so the caller concludes it is forbidden when one
+			// OAuth round trip away it might succeed. Answer 401 and name where
+			// to authenticate, exactly as the credential layer already does when
+			// a spec requires a user (see exchangeInputError).
+			//
+			// Swapping resp here rather than at the return is what keeps the
+			// audit honest: handleCancelableRequest audits whatever this returns,
+			// so the logged status is the 401 the client actually received. The
+			// request entry still records the policy denial and its
+			// ConditionResult, and user_absent on that record is what explains
+			// why a denial went out as an invitation to authenticate.
+			if challenge := c.userChallengeForDeny(ctx, req, auth, userLegMount); challenge != nil {
+				resp = challenge
+				retErr = nil
 			}
 
 			// No response audit here. handleCancelableRequest audits the response

--- a/core/request_handler.go
+++ b/core/request_handler.go
@@ -663,7 +663,7 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request, isI
 			retErr = multierror.Append(retErr, errType)
 		}
 
-		// Build the error response for audit logging
+		// Build the error response
 		var resp *logical.Response
 		if ctErr == ErrInternalError {
 			resp = nil
@@ -671,15 +671,23 @@ func (c *Core) handleLoginRequest(ctx context.Context, req *logical.Request, isI
 			resp = logical.ErrorResponse(logical.ErrInternal(ctErr.Error()))
 		}
 
-		// Audit the failed response - ensures complete request/response pair in audit log
-		respAuditEntry := c.buildResponseAuditEntry(ctx, req, resp, auth, nil, ctErr)
-		if _, auditErr := c.auditManager.LogResponse(ctx, respAuditEntry); auditErr != nil {
-			c.logger.Error("failed to audit login failure response",
-				logger.String("path", req.Path),
-				logger.Err(auditErr),
-			)
-		}
-
+		// No response audit here, for the same reason as the token-check denial
+		// below: handleCancelableRequest audits the response of every request it
+		// handles, so auditing here too would record this one twice.
+		//
+		// The other caller — the transparent-auth internal login — audits no
+		// response at all, so this branch would have been that sub-request's only
+		// response entry. Removing it matches how a *successful* internal login
+		// already behaves (a request entry, no response entry), so the asymmetry
+		// predates this and is not introduced by dropping the call.
+		//
+		// This branch is unreachable today in any case: CheckToken is called here
+		// with unauth=true, which swallows every token/CBP fetch error and skips
+		// the policy gate entirely, and its remaining exits need a backend that
+		// either declares an ExistenceCheck (none does) or lists one path as both
+		// Root and Unauthenticated (none does). It is kept rather than deleted so
+		// that if a future backend makes it live, it fails as one audit entry
+		// rather than silently as two.
 		if ctErr == ErrInternalError {
 			return nil, auth, retErr
 		}
@@ -1102,15 +1110,20 @@ func (c *Core) handleNonLoginRequest(ctx context.Context, req *logical.Request) 
 				resp = logical.ErrorResponse(ctErr)
 			}
 
-			// Audit the failed response
-			respAuditEntry := c.buildResponseAuditEntry(ctx, req, resp, auth, te, ctErr)
-			if _, auditErr := c.auditManager.LogResponse(ctx, respAuditEntry); auditErr != nil {
-				c.logger.Error("failed to audit token check failure response",
-					logger.String("path", req.Path),
-					logger.Err(auditErr),
-				)
-			}
-
+			// No response audit here. handleCancelableRequest audits the response
+			// of every request once this returns, so auditing again would record
+			// a denial twice — and anything counting audit events (denial rate
+			// limits, alerting, compliance tallies) would see two rejections
+			// where one occurred.
+			//
+			// The caller's entry carries the same response, auth and token entry
+			// (it re-reads req.TokenEntry(), which was set before any denial can
+			// occur). For a permission denial its error IS this ctErr. For the
+			// default class above — neither internal nor permission-denied —
+			// retErr is a generic invalid-request instead, so that entry's Error
+			// field is less specific than this one was; the exact ctErr is still
+			// recorded on the request entry below and in the audited response
+			// body, so nothing leaves the audit record.
 			if errwrap.Contains(retErr, ErrInternalError.Error()) {
 				return nil, auth, retErr
 			}

--- a/core/user_challenge.go
+++ b/core/user_challenge.go
@@ -200,3 +200,50 @@ func (c *Core) attachUserRequiredChallenge(ctx context.Context, req *logical.Req
 	}
 	c.attachUserChallenge(ctx, req, resp, false)
 }
+
+// userChallengeForDeny converts a policy denial into a 401 carrying the user
+// challenge, when the denial was caused by the absence of a user principal on a
+// request that could have carried one. Returns nil to leave the denial as the
+// 403 it already is.
+//
+// Why 401 rather than 403. RFC 9110 §15.5.4 permits a client to retry a 403
+// "with new or different credentials", and §11.6.1 permits the challenge on a
+// non-401 response — so 403 + WWW-Authenticate would be legal. It does not work
+// in practice: deployed OAuth, RFC 9728 and MCP client stacks begin discovery on
+// 401 only, so a challenge on a 403 is correct on the wire and ignored by every
+// client that would act on it. The credential layer already answers this same
+// situation with 401 (see exchangeInputError), and without this the wire
+// behaviour would depend on whether the operator expressed the requirement in a
+// credential spec or in a policy condition.
+//
+// The gate is narrow, because a 401 is a lie wherever a user cannot be acquired
+// and presented:
+//
+//   - req.Streamed — captureUserContext runs only on gateway requests, so
+//     elsewhere no user could ever have ridden along and the caller can do
+//     nothing about it. Same reasoning as accessPathMintError, which returns 500
+//     on the access path for that structural impossibility; a policy denial
+//     stays a 403 instead because a policy is a reusable document and a user.*
+//     condition may legitimately span paths it was not written for.
+//   - userLegMount — with no user_auth_path there is no authorization server to
+//     name, so the challenge would point nowhere and the condition is
+//     unsatisfiable forever.
+//
+// Both nil checks are load-bearing: auth is nil when the agent's own token
+// failed, and auth.Condition is nil on a capability denial, which returns before
+// the condition gate ever runs.
+func (c *Core) userChallengeForDeny(ctx context.Context, req *logical.Request, auth *logical.Auth, userLegMount bool) *logical.Response {
+	if !req.Streamed || !userLegMount {
+		return nil
+	}
+	if auth == nil || auth.Condition == nil || !auth.Condition.UserAbsent {
+		return nil
+	}
+
+	resp := logical.ErrorResponse(logical.ErrUnauthorized(
+		"a policy for this path requires a user principal and none was presented"))
+	// invalidToken=false: nothing was presented, and RFC 6750 §3.1 says a
+	// request lacking any authentication information gets no error code.
+	c.attachUserChallenge(ctx, req, resp, false)
+	return resp
+}

--- a/core/user_challenge_test.go
+++ b/core/user_challenge_test.go
@@ -137,6 +137,68 @@ func TestAccessPathMintError(t *testing.T) {
 	})
 }
 
+// TestUserChallengeForDeny pins the conversion of a policy denial into a user
+// challenge, and — more importantly — every case where it must NOT fire.
+//
+// A 401 is an invitation to authenticate. Sending one where a user could never
+// be presented tells a client to do something that cannot work, which is the
+// same fault accessPathMintError exists to avoid.
+func TestUserChallengeForDeny(t *testing.T) {
+	ctx := namespace.ContextWithNamespace(context.Background(), namespace.RootNamespace)
+	core := challengeTestCore(t, true)
+
+	req := func(streamed bool) *logical.Request {
+		return &logical.Request{
+			Path:        "github/gateway/user",
+			MountPoint:  "github/",
+			Streamed:    streamed,
+			HTTPRequest: httptest.NewRequest(http.MethodGet, "/v1/github/gateway/user", nil),
+		}
+	}
+	denyAuth := func(userAbsent bool) *logical.Auth {
+		return &logical.Auth{Condition: &logical.ConditionResult{
+			Decision: "deny", Expression: "user.present", UserAbsent: userAbsent,
+		}}
+	}
+
+	t.Run("converts a user-absent deny into a bare challenge", func(t *testing.T) {
+		resp := core.userChallengeForDeny(ctx, req(true), denyAuth(true), true)
+		require.NotNil(t, resp, "a streaming request on a user-leg mount must be challenged")
+		// StatusCode is what writeLogicalResponse puts on the wire; asserting
+		// only the error code would pass even if the response carried no status.
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+		got := resp.Headers.Get("WWW-Authenticate")
+		assert.Contains(t, got, "resource_metadata=",
+			"a challenge that names nowhere to go is no better than the 403")
+		assert.NotContains(t, got, "invalid_token",
+			"nothing was presented, so naming a credential invalid would be a lie")
+	})
+
+	t.Run("no conversion when the deny was not about a missing user", func(t *testing.T) {
+		assert.Nil(t, core.userChallengeForDeny(ctx, req(true), denyAuth(false), true))
+	})
+
+	// captureUserContext runs only on gateway requests, so elsewhere no user
+	// could have ridden along and no retry can change the outcome.
+	t.Run("no conversion on a non-streaming request", func(t *testing.T) {
+		assert.Nil(t, core.userChallengeForDeny(ctx, req(false), denyAuth(true), true))
+	})
+
+	// Without user_auth_path there is no authorization server to name.
+	t.Run("no conversion on a mount with no user leg", func(t *testing.T) {
+		assert.Nil(t, core.userChallengeForDeny(ctx, req(true), denyAuth(true), false))
+	})
+
+	// Both nil shapes are reachable: auth is nil when the agent's own token
+	// failed, and Condition is nil on a capability deny, which returns before
+	// the condition gate runs. Either would panic on a bare field access.
+	t.Run("survives the nil shapes the deny path actually produces", func(t *testing.T) {
+		assert.Nil(t, core.userChallengeForDeny(ctx, req(true), nil, true))
+		assert.Nil(t, core.userChallengeForDeny(ctx, req(true), &logical.Auth{}, true))
+	})
+}
+
 // TestChallengeURLIsActuallyServed is the anti-drift check: the URL a challenge
 // names must be one the metadata endpoint resolves. The two are derived
 // independently, and a mismatch fails silently — the client follows the link,

--- a/e2e/userleg/binding_test.go
+++ b/e2e/userleg/binding_test.go
@@ -5,6 +5,7 @@ package userleg
 import (
 	"strings"
 	"testing"
+	"time"
 
 	h "github.com/stephnangue/warden/e2e/helpers"
 )
@@ -66,6 +67,11 @@ func TestBinding_MatchingAgentAllowed(t *testing.T) {
 // Both cert roles carry the same policy and the same capabilities, so a denial
 // here can only come from the condition. Had they differed in authorization this
 // would pass for the wrong reason — and keep passing with the binding removed.
+//
+// It stays 403 while TestBinding_MissingUserChallenged is a 401, and together
+// they pin the whole progression: challenged while the client has no user,
+// forbidden once it has one that does not match. A 401 here would loop a client
+// that has already done everything asked of it.
 func TestBinding_MismatchedAgentDenied(t *testing.T) {
 	bindingEnv(t)
 
@@ -81,24 +87,92 @@ func TestBinding_MismatchedAgentDenied(t *testing.T) {
 	}
 }
 
-// TestBinding_MissingUserDenied covers `user.present`. A user credential is
-// optional on a protected-resource mount, so its absence has to be a decision
-// the condition makes — not an error, and not a silent allow.
+// TestBinding_MissingUserChallenged covers `user.present`, and is where the
+// binding's bootstrap lives.
+//
+// A user credential is optional on a protected-resource mount: some paths need
+// one, others do not, and the client cannot know which. So a request arriving
+// without one is well-formed — the client did nothing wrong. Answering 403 would
+// end the exchange there, because no client stack begins discovery on a 403.
+// The 401 names where to acquire a user, which is the only way the client can
+// ever learn that this path wants one.
 //
 // Uses the same certificate that succeeds in TestBinding_MatchingAgentAllowed,
 // so the only difference is the missing Authorization header.
-func TestBinding_MissingUserDenied(t *testing.T) {
+func TestBinding_MissingUserChallenged(t *testing.T) {
 	actingAgent := bindingEnv(t)
 
 	cert, _ := h.GenerateClientCert(t, agentCAPEM, agentCAKey, actingAgent)
-	status, body := h.UserLegRequestAs(t, leaderPort, h.UserLegBoundRole, cert, nil)
+	status, _, hdrs := h.DoRequestWithResponseHeaders(t, "GET",
+		h.NodeURL(leaderPort)+"/v1/"+h.UserLegMount+"/gateway/v1/secret/data/e2e/app-config",
+		map[string]string{
+			"X-Warden-Role":     h.UserLegBoundRole,
+			"X-SSL-Client-Cert": h.URLEncodePEM(cert),
+		}, "")
 
-	if status == 200 {
-		t.Fatalf("a bound path must not be reachable without a user credential, got 200: %s", string(body))
+	if status != 401 {
+		t.Fatalf("a bound path with no user must challenge, not merely forbid; got %d", status)
 	}
-	if status != 403 {
-		t.Errorf("absence of a user is a policy denial, not an error; got %d: %s", status, string(body))
+
+	challenge := challengeOf(t, hdrs)
+	if !strings.Contains(challenge, "resource_metadata=") {
+		t.Fatalf("the challenge must name where to authenticate: %q", challenge)
 	}
+	if strings.Contains(challenge, "invalid_token") {
+		t.Errorf("no credential was presented, so none can be invalid: %q", challenge)
+	}
+
+	// The link has to resolve, or the bootstrap dies one step later.
+	url := extractResourceMetadata(t, challenge)
+	if fetchStatus, _ := h.DoRequest(t, "GET", url, nil, ""); fetchStatus != 200 {
+		t.Fatalf("challenge named %s, which returned %d", url, fetchStatus)
+	}
+
+	assertChallengeAudited(t, leaderPort)
+}
+
+// assertChallengeAudited pins that the audit log agrees with the wire.
+//
+// A denial is audited twice — once inside the deny branch and once by the
+// caller — and the first entry takes its status from the response object as it
+// stands at that moment. Build the challenge after that entry instead of before
+// and the log records 403 while the client received 401, with nothing in either
+// place revealing the disagreement. Every wire-level assertion above still
+// passes in that state, so this is the only thing standing between that bug and
+// production.
+//
+// Both entries must also carry user_absent, since that is what explains how a
+// "permission denied" decision produced a 401 rather than a 403.
+func assertChallengeAudited(t *testing.T, port int) {
+	t.Helper()
+	nodeNum := h.NodeNumberForPort(port)
+
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		var seen int
+		for _, e := range h.ReadAuditEntries(t, nodeNum, h.UserLegMount) {
+			if e.Type != "response" || e.Auth == nil || e.Auth.PolicyResults == nil {
+				continue
+			}
+			cond := e.Auth.PolicyResults.Condition
+			if cond == nil || !cond.UserAbsent {
+				continue
+			}
+			seen++
+			if e.Response == nil || e.Response.StatusCode != 401 {
+				got := 0
+				if e.Response != nil {
+					got = e.Response.StatusCode
+				}
+				t.Fatalf("audited status %d disagrees with the 401 sent to the client", got)
+			}
+		}
+		if seen > 0 {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Error("no audited response recorded the user-absent denial")
 }
 
 // TestBinding_UnmappedClaimDenies is the fail-closed property that makes the

--- a/logical/auth.go
+++ b/logical/auth.go
@@ -205,6 +205,20 @@ type ConditionResult struct {
 	// clean allow/deny.
 	ErrorKind string `json:"error_kind,omitempty"`
 
+	// UserAbsent marks a deny that occurred with no user principal on the
+	// request while at least one merged condition reads user.* — so acquiring a
+	// user credential MIGHT change the outcome. It is a syntactic
+	// over-approximation, not a satisfiability result: a condition can reference
+	// user.* and still be unsatisfiable no matter what user is presented.
+	//
+	// The handler uses it to answer with a 401 and the user challenge instead of
+	// a bare 403, so a client can discover where to acquire a user identity. That
+	// conversion is gated on the request being able to carry one at all; this
+	// flag is recorded on every matching deny, including paths where no user
+	// could ever be presented, so read it as "a user was absent here", not as
+	// "a user would have helped".
+	UserAbsent bool `json:"user_absent,omitempty"`
+
 	// Inputs maps the expression's referenced variables to their CTL-stripped
 	// values so a denial is self-explanatory. Sensitive keys are
 	// redacted/salted by the audit format layer.


### PR DESCRIPTION
Stacked on #626 — review that first. Two independent commits; see the note at the bottom about the first one.

## The problem

A condition requiring a user principal denied with a bare 403 when none was presented. On a mount with `user_auth_path` the user leg is **optional by design** — some paths need one, others do not, and the client cannot know which — so a request arriving without one is well-formed. The 403 ended the exchange there: no OAuth, RFC 9728 or MCP client stack begins discovery on a 403, so a caller one round trip away from succeeding concluded it was forbidden.

Answer 401 with the user challenge instead, naming where to acquire an identity.

**The consistency argument is the real one.** The credential layer already answers this same situation with 401 when a spec requires a user (`exchangeInputError`, and its comment says why). Until now the wire behaviour depended on which layer the operator expressed the requirement in: `assertion_user_claims` guided a client to the authorization server, the equivalent CEL condition dead-ended it.

**Not a spec mandate, and the code says so.** RFC 9110 §15.5.4 lets a client retry a 403 "with new or different credentials", and §11.6.1 permits `WWW-Authenticate` on a non-401 — so 403 + challenge would be legal. It is rejected because no deployed client acts on it.

## Detection is an over-approximation, deliberately

`ConditionResult.UserAbsent` is set when no user was present **and** any merged condition reads `user.*` — "a user *might* change this", never "would". `UsrFields` is a compile-time reference set, not a satisfiability result. A condition referencing `user.*` that can never pass draws one wasted round trip, then a terminal 403 once the retry carries a user. It cannot loop, and a test pins that.

The flag is set at the **single deny return**, not where the deciding result is built. There are two construction sites, and an unguarded `user.metadata.x == …` takes the *error* branch with `no_such_key` while the guarded `user.present && …` takes the *false* branch — setting it in either alone would hand one of the two common policy shapes a bare 403. Mutation-verified.

## Where a 401 would be a lie

Gated to requests that could carry a user at all — gateway requests on a mount with `user_auth_path`. Elsewhere no user could ever have ridden along, so a challenge would invite a retry that cannot succeed; the same reasoning `accessPathMintError` already applies. Both nil checks on the auth are load-bearing: `auth` is nil when the agent's own token failed, and `Condition` is nil on a capability denial.

## Testing

The e2e asserts the **audited** status matches the wire, because every wire-level assertion still passes if the two disagree. Verified by building the challenge after the audit entry: the log records 403 while the client receives 401, and only the new assertion catches it.

`TestBinding_MissingUserDenied` becomes `TestBinding_MissingUserChallenged`. Its old comment — "absence of a user is a policy denial, not an error" — encoded the philosophy this reverses. Paired with `TestBinding_MismatchedAgentDenied` it now pins the whole progression: challenged while the client has no user, forbidden once it has one that does not match.

## The first commit is independent

`fix(audit): stop recording every denied request twice` is a **pre-existing** bug, unrelated to this feature: `handleNonLoginRequest` audited the response inside its denial branch and then returned, while `handleCancelableRequest` audits every response once that returns. Correlating by request id on a live cluster showed allowed requests producing 2 entries and denials producing 3. Anything counting audit events — denial rate limits, alerting, compliance tallies — saw two rejections where one occurred.

It cherry-picks onto `main` cleanly if you would rather land it without waiting on this stack.

Full unit suite, `e2e/userleg` and `e2e/audit` green.