### PR TITLE
chore(helm): bump the chart to 0.3.6 for v0.20.0

### DIFF
--- a/deploy/helm/warden/Chart.yaml
+++ b/deploy/helm/warden/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: warden
 description: Identity-aware egress proxy for AI agents — Helm chart for Kubernetes deployments.
 type: application
-version: 0.3.5
-appVersion: "0.19.0"
+version: 0.3.6
+appVersion: "0.20.0"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/stephnangue/warden
 sources:


### PR DESCRIPTION
Prerequisite for tagging v0.20.0.

The release workflow refuses to republish an existing chart version:

```
if helm pull "oci://ghcr.io/stephnangue/charts/warden" --version "$CHART_VERSION" ...; then
  echo "ERROR: chart version $CHART_VERSION is already published."
```

`Chart.yaml` still reads `version: 0.3.5`, which shipped with v0.19.0 (`warden-0.3.5.tgz` is attached to that release). Tagging without this bump would let GoReleaser publish the GitHub release, binaries and image, then fail at the Helm step — a release that looks complete but has no chart, and a red workflow.

The chart moves every release:

| tag | chart |
|---|---|
| v0.17.0 | 0.3.3 |
| v0.18.0 | 0.3.4 |
| v0.19.0 | 0.3.5 |
| v0.20.0 | **0.3.6** |

`appVersion` follows the tag for tidiness only — the workflow overrides it at package time with `--app-version "$VERSION"`, so the chart always pins the image matching the tag.

Verified with `helm lint` (passes). Note `helm template` with no values fails on this branch — but identically on `main`, because the chart fails closed until `tls`, `storage` and `seal` are configured. That is by design and unrelated to this change.